### PR TITLE
[FEAT] Remaining Piece Classes

### DIFF
--- a/docs/bva/Bishop.md
+++ b/docs/bva/Bishop.md
@@ -66,7 +66,7 @@
   - **State of the system**: an existing black bishop
   - **Expected output**: returned piece type is `BISHOP`
 
-- **TC6: MakeCopy_OnBlackBishop_CopyColorIsBlack** ( :x: )
+- **TC6: MakeCopy_OnBlackBishop_CopyColorIsBlack** ( :white_check_mark: )
   - **Method(s) under test**: `makeCopy()`
   - **State of the system**: an existing black bishop
   - **Expected output**: returned piece color is `BLACK`

--- a/docs/bva/Bishop.md
+++ b/docs/bva/Bishop.md
@@ -36,7 +36,7 @@
   - **State of the system**: no existing bishop object; input color is `WHITE`
   - **Expected output**: `getColor()` returns `WHITE`
 
-- **TC3: Constructor_OnWhiteBishop_CanJumpIsFalse** ( :x: )
+- **TC3: Constructor_OnWhiteBishop_CanJumpIsFalse** ( :white_check_mark: )
   - **Method(s) under test**: `Bishop(PieceColor color)`
   - **State of the system**: no existing bishop object; input color is `WHITE`
   - **Expected output**: `canJump()` returns `false`

--- a/docs/bva/Bishop.md
+++ b/docs/bva/Bishop.md
@@ -1,0 +1,84 @@
+# BVA Analysis for Bishop
+
+## Design Review Notes
+
+- The design document defines `Bishop` as a subclass of `Piece` with three public methods: `Bishop(PieceColor color)`, `makeCopy()`, and `isValidMoveShape(Location from, Location to)`.
+- The board design notes separate obstacle handling from move-shape validation and model jump capability at the `Piece` level. That means the bishop BVA should focus on constructor state, copy behavior, and move shape only.
+- The current checkout does not contain the domain implementation, and `docs/requirements/game-rules.md` is still a placeholder. The analysis below therefore uses the UML plus the standard chess rule that a bishop moves diagonally: the absolute row displacement must equal the absolute column displacement, and the displacement must be non-zero.
+
+## Specification
+
+- **`public Bishop(PieceColor color)`**: creates a bishop with the provided color. The created piece has type `BISHOP`, reports the same color through `getColor()`, and reports that it cannot jump through `canJump()`.
+- **`public Piece makeCopy()`**: returns a new `Piece` object representing the same kind of piece as the original bishop. The returned piece is a distinct object, still has type `BISHOP`, has the same color as the original, and cannot jump.
+- **`public boolean isValidMoveShape(Location from, Location to)`**: returns `true` exactly when the absolute row displacement equals the absolute column displacement and the displacement is non-zero. Returns `false` for all other displacements. This method checks shape only, not board occupancy or obstacles.
+
+---
+
+## Method: `Bishop(PieceColor color)`
+
+### Step 1-3: Analysis
+
+| Parameter | Catalog clue | Values considered |
+|-----------|--------------|-------------------|
+| Input: `color` | Cases | `WHITE`, `BLACK` |
+| Output: piece type | Cases | `BISHOP` |
+| Output: piece jump capability | Boolean | `false` |
+
+### Step 4: Test Cases (Catalog-aligned Each-Choice Strategy)
+
+- **TC1: Constructor_OnWhiteBishop_TypeIsBishop** ( :white_check_mark: )
+  - **Method(s) under test**: `Bishop(PieceColor color)`
+  - **State of the system**: no existing bishop object; input color is `WHITE`
+  - **Expected output**: created piece type is `BISHOP`
+
+- **TC2: Constructor_OnWhiteBishop_ColorIsWhite** ( :x: )
+  - **Method(s) under test**: `Bishop(PieceColor color)`
+  - **State of the system**: no existing bishop object; input color is `WHITE`
+  - **Expected output**: `getColor()` returns `WHITE`
+
+- **TC3: Constructor_OnWhiteBishop_CanJumpIsFalse** ( :x: )
+  - **Method(s) under test**: `Bishop(PieceColor color)`
+  - **State of the system**: no existing bishop object; input color is `WHITE`
+  - **Expected output**: `canJump()` returns `false`
+
+---
+
+## Method: `makeCopy()`
+
+### Step 1-3: Analysis
+
+| Parameter | Catalog clue | Values considered |
+|-----------|--------------|-------------------|
+| Input: original piece color | Cases | `WHITE`, `BLACK` |
+| Output: returned piece type | Cases | `BISHOP` |
+| Output: returned piece jump capability | Boolean | `false` |
+| Output: original and copy references | Pairs of references | same object is not allowed; copy must be a different object |
+
+### Step 4: Test Cases (Catalog-aligned Each-Choice Strategy)
+
+- **TC4: MakeCopy_OnWhiteBishop_CopyTypeIsBishop** ( :x: )
+  - **Method(s) under test**: `makeCopy()`
+  - **State of the system**: an existing white bishop
+  - **Expected output**: returned piece type is `BISHOP`
+
+- **TC5: MakeCopy_OnBlackBishop_CopyTypeIsBishop** ( :x: )
+  - **Method(s) under test**: `makeCopy()`
+  - **State of the system**: an existing black bishop
+  - **Expected output**: returned piece type is `BISHOP`
+
+- **TC6: MakeCopy_OnBlackBishop_CopyColorIsBlack** ( :x: )
+  - **Method(s) under test**: `makeCopy()`
+  - **State of the system**: an existing black bishop
+  - **Expected output**: returned piece color is `BLACK`
+
+- **TC7: MakeCopy_OnBlackBishop_CopyCanJumpIsFalse** ( :x: )
+  - **Method(s) under test**: `makeCopy()`
+  - **State of the system**: an existing black bishop
+  - **Expected output**: returned piece cannot jump
+
+- **TC8: MakeCopy_OnBlackBishop_CopyIsDifferentObject** ( :x: )
+  - **Method(s) under test**: `makeCopy()`
+  - **State of the system**: an existing black bishop
+  - **Expected output**: returned piece is a different object from the original
+
+---

--- a/docs/bva/Bishop.md
+++ b/docs/bva/Bishop.md
@@ -61,7 +61,7 @@
   - **State of the system**: an existing white bishop
   - **Expected output**: returned piece type is `BISHOP`
 
-- **TC5: MakeCopy_OnBlackBishop_CopyTypeIsBishop** ( :x: )
+- **TC5: MakeCopy_OnBlackBishop_CopyTypeIsBishop** ( :white_check_mark: )
   - **Method(s) under test**: `makeCopy()`
   - **State of the system**: an existing black bishop
   - **Expected output**: returned piece type is `BISHOP`

--- a/docs/bva/Bishop.md
+++ b/docs/bva/Bishop.md
@@ -76,7 +76,7 @@
   - **State of the system**: an existing black bishop
   - **Expected output**: returned piece cannot jump
 
-- **TC8: MakeCopy_OnBlackBishop_CopyIsDifferentObject** ( :x: )
+- **TC8: MakeCopy_OnBlackBishop_CopyIsDifferentObject** ( :white_check_mark: )
   - **Method(s) under test**: `makeCopy()`
   - **State of the system**: an existing black bishop
   - **Expected output**: returned piece is a different object from the original

--- a/docs/bva/Bishop.md
+++ b/docs/bva/Bishop.md
@@ -71,7 +71,7 @@
   - **State of the system**: an existing black bishop
   - **Expected output**: returned piece color is `BLACK`
 
-- **TC7: MakeCopy_OnBlackBishop_CopyCanJumpIsFalse** ( :x: )
+- **TC7: MakeCopy_OnBlackBishop_CopyCanJumpIsFalse** ( :white_check_mark: )
   - **Method(s) under test**: `makeCopy()`
   - **State of the system**: an existing black bishop
   - **Expected output**: returned piece cannot jump

--- a/docs/bva/Bishop.md
+++ b/docs/bva/Bishop.md
@@ -56,7 +56,7 @@
 
 ### Step 4: Test Cases (Catalog-aligned Each-Choice Strategy)
 
-- **TC4: MakeCopy_OnWhiteBishop_CopyTypeIsBishop** ( :x: )
+- **TC4: MakeCopy_OnWhiteBishop_CopyTypeIsBishop** ( :white_check_mark: )
   - **Method(s) under test**: `makeCopy()`
   - **State of the system**: an existing white bishop
   - **Expected output**: returned piece type is `BISHOP`

--- a/docs/bva/Bishop.md
+++ b/docs/bva/Bishop.md
@@ -31,7 +31,7 @@
   - **State of the system**: no existing bishop object; input color is `WHITE`
   - **Expected output**: created piece type is `BISHOP`
 
-- **TC2: Constructor_OnWhiteBishop_ColorIsWhite** ( :x: )
+- **TC2: Constructor_OnWhiteBishop_ColorIsWhite** ( :white_check_mark: )
   - **Method(s) under test**: `Bishop(PieceColor color)`
   - **State of the system**: no existing bishop object; input color is `WHITE`
   - **Expected output**: `getColor()` returns `WHITE`

--- a/docs/bva/Pawn.md
+++ b/docs/bva/Pawn.md
@@ -61,7 +61,7 @@
   - **State of the system**: an existing white pawn
   - **Expected output**: returned piece type is `PAWN`
 
-- **TC5: MakeCopy_OnBlackPawn_CopyTypeIsPawn** ( :x: )
+- **TC5: MakeCopy_OnBlackPawn_CopyTypeIsPawn** ( :white_check_mark: )
   - **Method(s) under test**: `makeCopy()`
   - **State of the system**: an existing black pawn
   - **Expected output**: returned piece type is `PAWN`

--- a/docs/bva/Pawn.md
+++ b/docs/bva/Pawn.md
@@ -36,7 +36,7 @@
   - **State of the system**: no existing pawn object; input color is `WHITE`
   - **Expected output**: `getColor()` returns `WHITE`
 
-- **TC3: Constructor_OnWhitePawn_CanJumpIsFalse** ( :x: )
+- **TC3: Constructor_OnWhitePawn_CanJumpIsFalse** ( :white_check_mark: )
   - **Method(s) under test**: `Pawn(PieceColor color)`
   - **State of the system**: no existing pawn object; input color is `WHITE`
   - **Expected output**: `canJump()` returns `false`

--- a/docs/bva/Pawn.md
+++ b/docs/bva/Pawn.md
@@ -71,7 +71,7 @@
   - **State of the system**: an existing black pawn
   - **Expected output**: returned piece color is `BLACK`
 
-- **TC7: MakeCopy_OnBlackPawn_CopyCanJumpIsFalse** ( :x: )
+- **TC7: MakeCopy_OnBlackPawn_CopyCanJumpIsFalse** ( :white_check_mark: )
   - **Method(s) under test**: `makeCopy()`
   - **State of the system**: an existing black pawn
   - **Expected output**: returned piece cannot jump

--- a/docs/bva/Pawn.md
+++ b/docs/bva/Pawn.md
@@ -56,7 +56,7 @@
 
 ### Step 4: Test Cases (Catalog-aligned Each-Choice Strategy)
 
-- **TC4: MakeCopy_OnWhitePawn_CopyTypeIsPawn** ( :x: )
+- **TC4: MakeCopy_OnWhitePawn_CopyTypeIsPawn** ( :white_check_mark: )
   - **Method(s) under test**: `makeCopy()`
   - **State of the system**: an existing white pawn
   - **Expected output**: returned piece type is `PAWN`

--- a/docs/bva/Pawn.md
+++ b/docs/bva/Pawn.md
@@ -76,7 +76,7 @@
   - **State of the system**: an existing black pawn
   - **Expected output**: returned piece cannot jump
 
-- **TC8: MakeCopy_OnBlackPawn_CopyIsDifferentObject** ( :x: )
+- **TC8: MakeCopy_OnBlackPawn_CopyIsDifferentObject** ( :white_check_mark: )
   - **Method(s) under test**: `makeCopy()`
   - **State of the system**: an existing black pawn
   - **Expected output**: returned piece is a different object from the original

--- a/docs/bva/Pawn.md
+++ b/docs/bva/Pawn.md
@@ -31,7 +31,7 @@
   - **State of the system**: no existing pawn object; input color is `WHITE`
   - **Expected output**: created piece type is `PAWN`
 
-- **TC2: Constructor_OnWhitePawn_ColorIsWhite** ( :x: )
+- **TC2: Constructor_OnWhitePawn_ColorIsWhite** ( :white_check_mark: )
   - **Method(s) under test**: `Pawn(PieceColor color)`
   - **State of the system**: no existing pawn object; input color is `WHITE`
   - **Expected output**: `getColor()` returns `WHITE`

--- a/docs/bva/Pawn.md
+++ b/docs/bva/Pawn.md
@@ -26,7 +26,7 @@
 
 ### Step 4: Test Cases (Catalog-aligned Each-Choice Strategy)
 
-- **TC1: Constructor_OnWhitePawn_TypeIsPawn** ( :x: )
+- **TC1: Constructor_OnWhitePawn_TypeIsPawn** ( :white_check_mark: )
   - **Method(s) under test**: `Pawn(PieceColor color)`
   - **State of the system**: no existing pawn object; input color is `WHITE`
   - **Expected output**: created piece type is `PAWN`

--- a/docs/bva/Pawn.md
+++ b/docs/bva/Pawn.md
@@ -66,7 +66,7 @@
   - **State of the system**: an existing black pawn
   - **Expected output**: returned piece type is `PAWN`
 
-- **TC6: MakeCopy_OnBlackPawn_CopyColorIsBlack** ( :x: )
+- **TC6: MakeCopy_OnBlackPawn_CopyColorIsBlack** ( :white_check_mark: )
   - **Method(s) under test**: `makeCopy()`
   - **State of the system**: an existing black pawn
   - **Expected output**: returned piece color is `BLACK`

--- a/docs/bva/Pawn.md
+++ b/docs/bva/Pawn.md
@@ -1,0 +1,84 @@
+# BVA Analysis for Pawn
+
+## Design Review Notes
+
+- The design document defines `Pawn` as a subclass of `Piece` with three public methods: `Pawn(PieceColor color)`, `makeCopy()`, and `isValidMoveShape(Location from, Location to)`.
+- The board design notes separate obstacle handling from move-shape validation and model jump capability at the `Piece` level. That means the pawn BVA should focus on constructor state, copy behavior, and move shape only.
+- The current checkout does not contain the domain implementation, and `docs/requirements/game-rules.md` is still a placeholder. The analysis below therefore uses the UML plus the standard chess rule that a pawn moves one square forward and cannot jump over pieces.
+
+## Specification
+
+- **`public Pawn(PieceColor color)`**: creates a pawn with the provided color. The created piece has type `PAWN`, reports the same color through `getColor()`, and reports that it cannot jump through `canJump()`.
+- **`public Piece makeCopy()`**: returns a new `Piece` object representing the same kind of piece as the original pawn. The returned piece is a distinct object, still has type `PAWN`, has the same color as the original, and cannot jump.
+- **`public boolean isValidMoveShape(Location from, Location to)`**: returns `true` exactly when the displacement matches a valid pawn move shape. Returns `false` for all other displacements. This method checks shape only, not board occupancy or obstacles.
+
+---
+
+## Method: `Pawn(PieceColor color)`
+
+### Step 1-3: Analysis
+
+| Parameter | Catalog clue | Values considered |
+|-----------|--------------|-------------------|
+| Input: `color` | Cases | `WHITE`, `BLACK` |
+| Output: piece type | Cases | `PAWN` |
+| Output: piece jump capability | Boolean | `false` |
+
+### Step 4: Test Cases (Catalog-aligned Each-Choice Strategy)
+
+- **TC1: Constructor_OnWhitePawn_TypeIsPawn** ( :x: )
+  - **Method(s) under test**: `Pawn(PieceColor color)`
+  - **State of the system**: no existing pawn object; input color is `WHITE`
+  - **Expected output**: created piece type is `PAWN`
+
+- **TC2: Constructor_OnWhitePawn_ColorIsWhite** ( :x: )
+  - **Method(s) under test**: `Pawn(PieceColor color)`
+  - **State of the system**: no existing pawn object; input color is `WHITE`
+  - **Expected output**: `getColor()` returns `WHITE`
+
+- **TC3: Constructor_OnWhitePawn_CanJumpIsFalse** ( :x: )
+  - **Method(s) under test**: `Pawn(PieceColor color)`
+  - **State of the system**: no existing pawn object; input color is `WHITE`
+  - **Expected output**: `canJump()` returns `false`
+
+---
+
+## Method: `makeCopy()`
+
+### Step 1-3: Analysis
+
+| Parameter | Catalog clue | Values considered |
+|-----------|--------------|-------------------|
+| Input: original piece color | Cases | `WHITE`, `BLACK` |
+| Output: returned piece type | Cases | `PAWN` |
+| Output: returned piece jump capability | Boolean | `false` |
+| Output: original and copy references | Pairs of references | same object is not allowed; copy must be a different object |
+
+### Step 4: Test Cases (Catalog-aligned Each-Choice Strategy)
+
+- **TC4: MakeCopy_OnWhitePawn_CopyTypeIsPawn** ( :x: )
+  - **Method(s) under test**: `makeCopy()`
+  - **State of the system**: an existing white pawn
+  - **Expected output**: returned piece type is `PAWN`
+
+- **TC5: MakeCopy_OnBlackPawn_CopyTypeIsPawn** ( :x: )
+  - **Method(s) under test**: `makeCopy()`
+  - **State of the system**: an existing black pawn
+  - **Expected output**: returned piece type is `PAWN`
+
+- **TC6: MakeCopy_OnBlackPawn_CopyColorIsBlack** ( :x: )
+  - **Method(s) under test**: `makeCopy()`
+  - **State of the system**: an existing black pawn
+  - **Expected output**: returned piece color is `BLACK`
+
+- **TC7: MakeCopy_OnBlackPawn_CopyCanJumpIsFalse** ( :x: )
+  - **Method(s) under test**: `makeCopy()`
+  - **State of the system**: an existing black pawn
+  - **Expected output**: returned piece cannot jump
+
+- **TC8: MakeCopy_OnBlackPawn_CopyIsDifferentObject** ( :x: )
+  - **Method(s) under test**: `makeCopy()`
+  - **State of the system**: an existing black pawn
+  - **Expected output**: returned piece is a different object from the original
+
+---

--- a/docs/bva/Queen.md
+++ b/docs/bva/Queen.md
@@ -36,7 +36,7 @@
   - **State of the system**: no existing queen object; input color is `WHITE`
   - **Expected output**: `getColor()` returns `WHITE`
 
-- **TC3: Constructor_OnWhiteQueen_CanJumpIsFalse** ( :x: )
+- **TC3: Constructor_OnWhiteQueen_CanJumpIsFalse** ( :white_check_mark: )
   - **Method(s) under test**: `Queen(PieceColor color)`
   - **State of the system**: no existing queen object; input color is `WHITE`
   - **Expected output**: `canJump()` returns `false`

--- a/docs/bva/Queen.md
+++ b/docs/bva/Queen.md
@@ -76,7 +76,7 @@
   - **State of the system**: an existing black queen
   - **Expected output**: returned piece cannot jump
 
-- **TC8: MakeCopy_OnBlackQueen_CopyIsDifferentObject** ( :x: )
+- **TC8: MakeCopy_OnBlackQueen_CopyIsDifferentObject** ( :white_check_mark: )
   - **Method(s) under test**: `makeCopy()`
   - **State of the system**: an existing black queen
   - **Expected output**: returned piece is a different object from the original

--- a/docs/bva/Queen.md
+++ b/docs/bva/Queen.md
@@ -1,0 +1,84 @@
+# BVA Analysis for Queen
+
+## Design Review Notes
+
+- The design document defines `Queen` as a subclass of `Piece` with three public methods: `Queen(PieceColor color)`, `makeCopy()`, and `isValidMoveShape(Location from, Location to)`.
+- The board design notes separate obstacle handling from move-shape validation and model jump capability at the `Piece` level. That means the queen BVA should focus on constructor state, copy behavior, and move shape only.
+- The current checkout does not contain the domain implementation, and `docs/requirements/game-rules.md` is still a placeholder. The analysis below therefore uses the UML plus the standard chess rule that a queen moves any number of squares in any direction (row, column, or diagonal) and cannot jump over pieces.
+
+## Specification
+
+- **`public Queen(PieceColor color)`**: creates a queen with the provided color. The created piece has type `QUEEN`, reports the same color through `getColor()`, and reports that it cannot jump through `canJump()`.
+- **`public Piece makeCopy()`**: returns a new `Piece` object representing the same kind of piece as the original queen. The returned piece is a distinct object, still has type `QUEEN`, has the same color as the original, and cannot jump.
+- **`public boolean isValidMoveShape(Location from, Location to)`**: returns `true` exactly when the displacement matches a valid queen move shape (any non-zero row-only, column-only, or equal-magnitude diagonal displacement). Returns `false` for all other displacements. This method checks shape only, not board occupancy or obstacles.
+
+---
+
+## Method: `Queen(PieceColor color)`
+
+### Step 1-3: Analysis
+
+| Parameter | Catalog clue | Values considered |
+|-----------|--------------|-------------------|
+| Input: `color` | Cases | `WHITE`, `BLACK` |
+| Output: piece type | Cases | `QUEEN` |
+| Output: piece jump capability | Boolean | `false` |
+
+### Step 4: Test Cases (Catalog-aligned Each-Choice Strategy)
+
+- **TC1: Constructor_OnWhiteQueen_TypeIsQueen** ( :x: )
+  - **Method(s) under test**: `Queen(PieceColor color)`
+  - **State of the system**: no existing queen object; input color is `WHITE`
+  - **Expected output**: created piece type is `QUEEN`
+
+- **TC2: Constructor_OnWhiteQueen_ColorIsWhite** ( :x: )
+  - **Method(s) under test**: `Queen(PieceColor color)`
+  - **State of the system**: no existing queen object; input color is `WHITE`
+  - **Expected output**: `getColor()` returns `WHITE`
+
+- **TC3: Constructor_OnWhiteQueen_CanJumpIsFalse** ( :x: )
+  - **Method(s) under test**: `Queen(PieceColor color)`
+  - **State of the system**: no existing queen object; input color is `WHITE`
+  - **Expected output**: `canJump()` returns `false`
+
+---
+
+## Method: `makeCopy()`
+
+### Step 1-3: Analysis
+
+| Parameter | Catalog clue | Values considered |
+|-----------|--------------|-------------------|
+| Input: original piece color | Cases | `WHITE`, `BLACK` |
+| Output: returned piece type | Cases | `QUEEN` |
+| Output: returned piece jump capability | Boolean | `false` |
+| Output: original and copy references | Pairs of references | same object is not allowed; copy must be a different object |
+
+### Step 4: Test Cases (Catalog-aligned Each-Choice Strategy)
+
+- **TC4: MakeCopy_OnWhiteQueen_CopyTypeIsQueen** ( :x: )
+  - **Method(s) under test**: `makeCopy()`
+  - **State of the system**: an existing white queen
+  - **Expected output**: returned piece type is `QUEEN`
+
+- **TC5: MakeCopy_OnBlackQueen_CopyTypeIsQueen** ( :x: )
+  - **Method(s) under test**: `makeCopy()`
+  - **State of the system**: an existing black queen
+  - **Expected output**: returned piece type is `QUEEN`
+
+- **TC6: MakeCopy_OnBlackQueen_CopyColorIsBlack** ( :x: )
+  - **Method(s) under test**: `makeCopy()`
+  - **State of the system**: an existing black queen
+  - **Expected output**: returned piece color is `BLACK`
+
+- **TC7: MakeCopy_OnBlackQueen_CopyCanJumpIsFalse** ( :x: )
+  - **Method(s) under test**: `makeCopy()`
+  - **State of the system**: an existing black queen
+  - **Expected output**: returned piece cannot jump
+
+- **TC8: MakeCopy_OnBlackQueen_CopyIsDifferentObject** ( :x: )
+  - **Method(s) under test**: `makeCopy()`
+  - **State of the system**: an existing black queen
+  - **Expected output**: returned piece is a different object from the original
+
+---

--- a/docs/bva/Queen.md
+++ b/docs/bva/Queen.md
@@ -31,7 +31,7 @@
   - **State of the system**: no existing queen object; input color is `WHITE`
   - **Expected output**: created piece type is `QUEEN`
 
-- **TC2: Constructor_OnWhiteQueen_ColorIsWhite** ( :x: )
+- **TC2: Constructor_OnWhiteQueen_ColorIsWhite** ( :white_check_mark: )
   - **Method(s) under test**: `Queen(PieceColor color)`
   - **State of the system**: no existing queen object; input color is `WHITE`
   - **Expected output**: `getColor()` returns `WHITE`

--- a/docs/bva/Queen.md
+++ b/docs/bva/Queen.md
@@ -61,7 +61,7 @@
   - **State of the system**: an existing white queen
   - **Expected output**: returned piece type is `QUEEN`
 
-- **TC5: MakeCopy_OnBlackQueen_CopyTypeIsQueen** ( :x: )
+- **TC5: MakeCopy_OnBlackQueen_CopyTypeIsQueen** ( :white_check_mark: )
   - **Method(s) under test**: `makeCopy()`
   - **State of the system**: an existing black queen
   - **Expected output**: returned piece type is `QUEEN`

--- a/docs/bva/Queen.md
+++ b/docs/bva/Queen.md
@@ -66,7 +66,7 @@
   - **State of the system**: an existing black queen
   - **Expected output**: returned piece type is `QUEEN`
 
-- **TC6: MakeCopy_OnBlackQueen_CopyColorIsBlack** ( :x: )
+- **TC6: MakeCopy_OnBlackQueen_CopyColorIsBlack** ( :white_check_mark: )
   - **Method(s) under test**: `makeCopy()`
   - **State of the system**: an existing black queen
   - **Expected output**: returned piece color is `BLACK`

--- a/docs/bva/Queen.md
+++ b/docs/bva/Queen.md
@@ -71,7 +71,7 @@
   - **State of the system**: an existing black queen
   - **Expected output**: returned piece color is `BLACK`
 
-- **TC7: MakeCopy_OnBlackQueen_CopyCanJumpIsFalse** ( :x: )
+- **TC7: MakeCopy_OnBlackQueen_CopyCanJumpIsFalse** ( :white_check_mark: )
   - **Method(s) under test**: `makeCopy()`
   - **State of the system**: an existing black queen
   - **Expected output**: returned piece cannot jump

--- a/docs/bva/Queen.md
+++ b/docs/bva/Queen.md
@@ -56,7 +56,7 @@
 
 ### Step 4: Test Cases (Catalog-aligned Each-Choice Strategy)
 
-- **TC4: MakeCopy_OnWhiteQueen_CopyTypeIsQueen** ( :x: )
+- **TC4: MakeCopy_OnWhiteQueen_CopyTypeIsQueen** ( :white_check_mark: )
   - **Method(s) under test**: `makeCopy()`
   - **State of the system**: an existing white queen
   - **Expected output**: returned piece type is `QUEEN`

--- a/docs/bva/Queen.md
+++ b/docs/bva/Queen.md
@@ -26,7 +26,7 @@
 
 ### Step 4: Test Cases (Catalog-aligned Each-Choice Strategy)
 
-- **TC1: Constructor_OnWhiteQueen_TypeIsQueen** ( :x: )
+- **TC1: Constructor_OnWhiteQueen_TypeIsQueen** ( :white_check_mark: )
   - **Method(s) under test**: `Queen(PieceColor color)`
   - **State of the system**: no existing queen object; input color is `WHITE`
   - **Expected output**: created piece type is `QUEEN`

--- a/docs/bva/Rook.md
+++ b/docs/bva/Rook.md
@@ -31,7 +31,7 @@
   - **State of the system**: no existing rook object; input color is `WHITE`
   - **Expected output**: created piece type is `ROOK`
 
-- **TC2: Constructor_OnWhiteRook_ColorIsWhite** ( :x: )
+- **TC2: Constructor_OnWhiteRook_ColorIsWhite** ( :white_check_mark: )
   - **Method(s) under test**: `Rook(PieceColor color)`
   - **State of the system**: no existing rook object; input color is `WHITE`
   - **Expected output**: `getColor()` returns `WHITE`

--- a/docs/bva/Rook.md
+++ b/docs/bva/Rook.md
@@ -26,7 +26,7 @@
 
 ### Step 4: Test Cases (Catalog-aligned Each-Choice Strategy)
 
-- **TC1: Constructor_OnWhiteRook_TypeIsRook** ( :x: )
+- **TC1: Constructor_OnWhiteRook_TypeIsRook** ( :white_check_mark: )
   - **Method(s) under test**: `Rook(PieceColor color)`
   - **State of the system**: no existing rook object; input color is `WHITE`
   - **Expected output**: created piece type is `ROOK`

--- a/docs/bva/Rook.md
+++ b/docs/bva/Rook.md
@@ -66,7 +66,7 @@
   - **State of the system**: an existing black rook
   - **Expected output**: returned piece type is `ROOK`
 
-- **TC6: MakeCopy_OnBlackRook_CopyColorIsBlack** ( :x: )
+- **TC6: MakeCopy_OnBlackRook_CopyColorIsBlack** ( :white_check_mark: )
   - **Method(s) under test**: `makeCopy()`
   - **State of the system**: an existing black rook
   - **Expected output**: returned piece color is `BLACK`

--- a/docs/bva/Rook.md
+++ b/docs/bva/Rook.md
@@ -56,7 +56,7 @@
 
 ### Step 4: Test Cases (Catalog-aligned Each-Choice Strategy)
 
-- **TC4: MakeCopy_OnWhiteRook_CopyTypeIsRook** ( :x: )
+- **TC4: MakeCopy_OnWhiteRook_CopyTypeIsRook** ( :white_check_mark: )
   - **Method(s) under test**: `makeCopy()`
   - **State of the system**: an existing white rook
   - **Expected output**: returned piece type is `ROOK`

--- a/docs/bva/Rook.md
+++ b/docs/bva/Rook.md
@@ -36,7 +36,7 @@
   - **State of the system**: no existing rook object; input color is `WHITE`
   - **Expected output**: `getColor()` returns `WHITE`
 
-- **TC3: Constructor_OnWhiteRook_CanJumpIsFalse** ( :x: )
+- **TC3: Constructor_OnWhiteRook_CanJumpIsFalse** ( :white_check_mark: )
   - **Method(s) under test**: `Rook(PieceColor color)`
   - **State of the system**: no existing rook object; input color is `WHITE`
   - **Expected output**: `canJump()` returns `false`

--- a/docs/bva/Rook.md
+++ b/docs/bva/Rook.md
@@ -71,7 +71,7 @@
   - **State of the system**: an existing black rook
   - **Expected output**: returned piece color is `BLACK`
 
-- **TC7: MakeCopy_OnBlackRook_CopyCanJumpIsFalse** ( :x: )
+- **TC7: MakeCopy_OnBlackRook_CopyCanJumpIsFalse** ( :white_check_mark: )
   - **Method(s) under test**: `makeCopy()`
   - **State of the system**: an existing black rook
   - **Expected output**: returned piece cannot jump

--- a/docs/bva/Rook.md
+++ b/docs/bva/Rook.md
@@ -1,0 +1,84 @@
+# BVA Analysis for Rook
+
+## Design Review Notes
+
+- The design document defines `Rook` as a subclass of `Piece` with three public methods: `Rook(PieceColor color)`, `makeCopy()`, and `isValidMoveShape(Location from, Location to)`.
+- The board design notes separate obstacle handling from move-shape validation and model jump capability at the `Piece` level. That means the rook BVA should focus on constructor state, copy behavior, and move shape only.
+- The current checkout does not contain the domain implementation, and `docs/requirements/game-rules.md` is still a placeholder. The analysis below therefore uses the UML plus the standard chess rule that a rook moves any number of squares in a straight line (same row or same column) and cannot jump over pieces.
+
+## Specification
+
+- **`public Rook(PieceColor color)`**: creates a rook with the provided color. The created piece has type `ROOK`, reports the same color through `getColor()`, and reports that it cannot jump through `canJump()`.
+- **`public Piece makeCopy()`**: returns a new `Piece` object representing the same kind of piece as the original rook. The returned piece is a distinct object, still has type `ROOK`, has the same color as the original, and cannot jump.
+- **`public boolean isValidMoveShape(Location from, Location to)`**: returns `true` exactly when the displacement is purely horizontal or purely vertical and non-zero. Returns `false` for all other displacements. This method checks shape only, not board occupancy or obstacles.
+
+---
+
+## Method: `Rook(PieceColor color)`
+
+### Step 1-3: Analysis
+
+| Parameter | Catalog clue | Values considered |
+|-----------|--------------|-------------------|
+| Input: `color` | Cases | `WHITE`, `BLACK` |
+| Output: piece type | Cases | `ROOK` |
+| Output: piece jump capability | Boolean | `false` |
+
+### Step 4: Test Cases (Catalog-aligned Each-Choice Strategy)
+
+- **TC1: Constructor_OnWhiteRook_TypeIsRook** ( :x: )
+  - **Method(s) under test**: `Rook(PieceColor color)`
+  - **State of the system**: no existing rook object; input color is `WHITE`
+  - **Expected output**: created piece type is `ROOK`
+
+- **TC2: Constructor_OnWhiteRook_ColorIsWhite** ( :x: )
+  - **Method(s) under test**: `Rook(PieceColor color)`
+  - **State of the system**: no existing rook object; input color is `WHITE`
+  - **Expected output**: `getColor()` returns `WHITE`
+
+- **TC3: Constructor_OnWhiteRook_CanJumpIsFalse** ( :x: )
+  - **Method(s) under test**: `Rook(PieceColor color)`
+  - **State of the system**: no existing rook object; input color is `WHITE`
+  - **Expected output**: `canJump()` returns `false`
+
+---
+
+## Method: `makeCopy()`
+
+### Step 1-3: Analysis
+
+| Parameter | Catalog clue | Values considered |
+|-----------|--------------|-------------------|
+| Input: original piece color | Cases | `WHITE`, `BLACK` |
+| Output: returned piece type | Cases | `ROOK` |
+| Output: returned piece jump capability | Boolean | `false` |
+| Output: original and copy references | Pairs of references | same object is not allowed; copy must be a different object |
+
+### Step 4: Test Cases (Catalog-aligned Each-Choice Strategy)
+
+- **TC4: MakeCopy_OnWhiteRook_CopyTypeIsRook** ( :x: )
+  - **Method(s) under test**: `makeCopy()`
+  - **State of the system**: an existing white rook
+  - **Expected output**: returned piece type is `ROOK`
+
+- **TC5: MakeCopy_OnBlackRook_CopyTypeIsRook** ( :x: )
+  - **Method(s) under test**: `makeCopy()`
+  - **State of the system**: an existing black rook
+  - **Expected output**: returned piece type is `ROOK`
+
+- **TC6: MakeCopy_OnBlackRook_CopyColorIsBlack** ( :x: )
+  - **Method(s) under test**: `makeCopy()`
+  - **State of the system**: an existing black rook
+  - **Expected output**: returned piece color is `BLACK`
+
+- **TC7: MakeCopy_OnBlackRook_CopyCanJumpIsFalse** ( :x: )
+  - **Method(s) under test**: `makeCopy()`
+  - **State of the system**: an existing black rook
+  - **Expected output**: returned piece cannot jump
+
+- **TC8: MakeCopy_OnBlackRook_CopyIsDifferentObject** ( :x: )
+  - **Method(s) under test**: `makeCopy()`
+  - **State of the system**: an existing black rook
+  - **Expected output**: returned piece is a different object from the original
+
+---

--- a/docs/bva/Rook.md
+++ b/docs/bva/Rook.md
@@ -61,7 +61,7 @@
   - **State of the system**: an existing white rook
   - **Expected output**: returned piece type is `ROOK`
 
-- **TC5: MakeCopy_OnBlackRook_CopyTypeIsRook** ( :x: )
+- **TC5: MakeCopy_OnBlackRook_CopyTypeIsRook** ( :white_check_mark: )
   - **Method(s) under test**: `makeCopy()`
   - **State of the system**: an existing black rook
   - **Expected output**: returned piece type is `ROOK`

--- a/docs/bva/Rook.md
+++ b/docs/bva/Rook.md
@@ -76,7 +76,7 @@
   - **State of the system**: an existing black rook
   - **Expected output**: returned piece cannot jump
 
-- **TC8: MakeCopy_OnBlackRook_CopyIsDifferentObject** ( :x: )
+- **TC8: MakeCopy_OnBlackRook_CopyIsDifferentObject** ( :white_check_mark: )
   - **Method(s) under test**: `makeCopy()`
   - **State of the system**: an existing black rook
   - **Expected output**: returned piece is a different object from the original

--- a/src/main/java/domain/piece/Bishop.java
+++ b/src/main/java/domain/piece/Bishop.java
@@ -8,6 +8,6 @@ public class Bishop extends Piece {
 
     @Override
     public Piece makeCopy() {
-        return null;
+        return new Bishop(getColor());
     }
 }

--- a/src/main/java/domain/piece/Bishop.java
+++ b/src/main/java/domain/piece/Bishop.java
@@ -1,0 +1,5 @@
+package domain.piece;
+
+public class Bishop extends Piece {
+
+}

--- a/src/main/java/domain/piece/Bishop.java
+++ b/src/main/java/domain/piece/Bishop.java
@@ -2,4 +2,12 @@ package domain.piece;
 
 public class Bishop extends Piece {
 
+    public Bishop(PieceColor color) {
+        super(PieceType.BISHOP, color);
+    }
+
+    @Override
+    public Piece makeCopy() {
+        return null;
+    }
 }

--- a/src/main/java/domain/piece/Pawn.java
+++ b/src/main/java/domain/piece/Pawn.java
@@ -1,0 +1,13 @@
+package domain.piece;
+
+public class Pawn extends Piece {
+
+    public Pawn(PieceColor color) {
+        super(PieceType.PAWN, color);
+    }
+
+    @Override
+    public Piece makeCopy() {
+        return null;
+    }
+}

--- a/src/main/java/domain/piece/Pawn.java
+++ b/src/main/java/domain/piece/Pawn.java
@@ -8,6 +8,6 @@ public class Pawn extends Piece {
 
     @Override
     public Piece makeCopy() {
-        return null;
+        return new Pawn(getColor());
     }
 }

--- a/src/main/java/domain/piece/Queen.java
+++ b/src/main/java/domain/piece/Queen.java
@@ -1,0 +1,13 @@
+package domain.piece;
+
+public class Queen extends Piece {
+
+    public Queen(PieceColor color) {
+        super(PieceType.QUEEN, color);
+    }
+
+    @Override
+    public Piece makeCopy() {
+        return null;
+    }
+}

--- a/src/main/java/domain/piece/Queen.java
+++ b/src/main/java/domain/piece/Queen.java
@@ -8,6 +8,6 @@ public class Queen extends Piece {
 
     @Override
     public Piece makeCopy() {
-        return null;
+        return new Queen(getColor());
     }
 }

--- a/src/main/java/domain/piece/Rook.java
+++ b/src/main/java/domain/piece/Rook.java
@@ -8,6 +8,6 @@ public class Rook extends Piece {
 
     @Override
     public Piece makeCopy() {
-        return null;
+        return new Rook(getColor());
     }
 }

--- a/src/main/java/domain/piece/Rook.java
+++ b/src/main/java/domain/piece/Rook.java
@@ -1,0 +1,13 @@
+package domain.piece;
+
+public class Rook extends Piece {
+
+    public Rook(PieceColor color) {
+        super(PieceType.ROOK, color);
+    }
+
+    @Override
+    public Piece makeCopy() {
+        return null;
+    }
+}

--- a/src/test/java/domain/piece/BishopTest.java
+++ b/src/test/java/domain/piece/BishopTest.java
@@ -1,0 +1,17 @@
+package domain.piece;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class BishopTest {
+
+    @Test
+    void Constructor_OnWhiteBishop_TypeIsBishop() {
+        Bishop bishop = new Bishop(PieceColor.WHITE);
+
+        PieceType expected = PieceType.BISHOP;
+        PieceType actual = bishop.getType();
+        assertEquals(expected, actual);
+    }
+}

--- a/src/test/java/domain/piece/BishopTest.java
+++ b/src/test/java/domain/piece/BishopTest.java
@@ -58,4 +58,11 @@ class BishopTest {
         PieceColor actual = bishop.makeCopy().getColor();
         assertEquals(expected, actual);
     }
+
+    @Test
+    void MakeCopy_OnBlackBishop_CopyCanJumpIsFalse() {
+        Bishop bishop = new Bishop(PieceColor.BLACK);
+
+        assertFalse(bishop.makeCopy().canJump());
+    }
 }

--- a/src/test/java/domain/piece/BishopTest.java
+++ b/src/test/java/domain/piece/BishopTest.java
@@ -31,4 +31,13 @@ class BishopTest {
 
         assertFalse(bishop.canJump());
     }
+
+    @Test
+    void MakeCopy_OnWhiteBishop_CopyTypeIsBishop() {
+        Bishop bishop = new Bishop(PieceColor.WHITE);
+
+        PieceType expected = PieceType.BISHOP;
+        PieceType actual = bishop.makeCopy().getType();
+        assertEquals(expected, actual);
+    }
 }

--- a/src/test/java/domain/piece/BishopTest.java
+++ b/src/test/java/domain/piece/BishopTest.java
@@ -14,4 +14,13 @@ class BishopTest {
         PieceType actual = bishop.getType();
         assertEquals(expected, actual);
     }
+
+    @Test
+    void Constructor_OnWhiteBishop_ColorIsWhite() {
+        Bishop bishop = new Bishop(PieceColor.WHITE);
+
+        PieceColor expected = PieceColor.WHITE;
+        PieceColor actual = bishop.getColor();
+        assertEquals(expected, actual);
+    }
 }

--- a/src/test/java/domain/piece/BishopTest.java
+++ b/src/test/java/domain/piece/BishopTest.java
@@ -2,6 +2,7 @@ package domain.piece;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 import org.junit.jupiter.api.Test;
 
@@ -64,5 +65,12 @@ class BishopTest {
         Bishop bishop = new Bishop(PieceColor.BLACK);
 
         assertFalse(bishop.makeCopy().canJump());
+    }
+
+    @Test
+    void MakeCopy_OnBlackBishop_CopyIsDifferentObject() {
+        Bishop bishop = new Bishop(PieceColor.BLACK);
+
+        assertNotSame(bishop, bishop.makeCopy());
     }
 }

--- a/src/test/java/domain/piece/BishopTest.java
+++ b/src/test/java/domain/piece/BishopTest.java
@@ -40,4 +40,13 @@ class BishopTest {
         PieceType actual = bishop.makeCopy().getType();
         assertEquals(expected, actual);
     }
+
+    @Test
+    void MakeCopy_OnBlackBishop_CopyTypeIsBishop() {
+        Bishop bishop = new Bishop(PieceColor.BLACK);
+
+        PieceType expected = PieceType.BISHOP;
+        PieceType actual = bishop.makeCopy().getType();
+        assertEquals(expected, actual);
+    }
 }

--- a/src/test/java/domain/piece/BishopTest.java
+++ b/src/test/java/domain/piece/BishopTest.java
@@ -1,6 +1,7 @@
 package domain.piece;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.junit.jupiter.api.Test;
 
@@ -22,5 +23,12 @@ class BishopTest {
         PieceColor expected = PieceColor.WHITE;
         PieceColor actual = bishop.getColor();
         assertEquals(expected, actual);
+    }
+
+    @Test
+    void Constructor_OnWhiteBishop_CanJumpIsFalse() {
+        Bishop bishop = new Bishop(PieceColor.WHITE);
+
+        assertFalse(bishop.canJump());
     }
 }

--- a/src/test/java/domain/piece/BishopTest.java
+++ b/src/test/java/domain/piece/BishopTest.java
@@ -49,4 +49,13 @@ class BishopTest {
         PieceType actual = bishop.makeCopy().getType();
         assertEquals(expected, actual);
     }
+
+    @Test
+    void MakeCopy_OnBlackBishop_CopyColorIsBlack() {
+        Bishop bishop = new Bishop(PieceColor.BLACK);
+
+        PieceColor expected = PieceColor.BLACK;
+        PieceColor actual = bishop.makeCopy().getColor();
+        assertEquals(expected, actual);
+    }
 }

--- a/src/test/java/domain/piece/PawnTest.java
+++ b/src/test/java/domain/piece/PawnTest.java
@@ -14,4 +14,13 @@ class PawnTest {
         PieceType actual = pawn.getType();
         assertEquals(expected, actual);
     }
+
+    @Test
+    void Constructor_OnWhitePawn_ColorIsWhite() {
+        Pawn pawn = new Pawn(PieceColor.WHITE);
+
+        PieceColor expected = PieceColor.WHITE;
+        PieceColor actual = pawn.getColor();
+        assertEquals(expected, actual);
+    }
 }

--- a/src/test/java/domain/piece/PawnTest.java
+++ b/src/test/java/domain/piece/PawnTest.java
@@ -40,4 +40,13 @@ class PawnTest {
         PieceType actual = pawn.makeCopy().getType();
         assertEquals(expected, actual);
     }
+
+    @Test
+    void MakeCopy_OnBlackPawn_CopyTypeIsPawn() {
+        Pawn pawn = new Pawn(PieceColor.BLACK);
+
+        PieceType expected = PieceType.PAWN;
+        PieceType actual = pawn.makeCopy().getType();
+        assertEquals(expected, actual);
+    }
 }

--- a/src/test/java/domain/piece/PawnTest.java
+++ b/src/test/java/domain/piece/PawnTest.java
@@ -49,4 +49,13 @@ class PawnTest {
         PieceType actual = pawn.makeCopy().getType();
         assertEquals(expected, actual);
     }
+
+    @Test
+    void MakeCopy_OnBlackPawn_CopyColorIsBlack() {
+        Pawn pawn = new Pawn(PieceColor.BLACK);
+
+        PieceColor expected = PieceColor.BLACK;
+        PieceColor actual = pawn.makeCopy().getColor();
+        assertEquals(expected, actual);
+    }
 }

--- a/src/test/java/domain/piece/PawnTest.java
+++ b/src/test/java/domain/piece/PawnTest.java
@@ -31,4 +31,13 @@ class PawnTest {
 
         assertFalse(pawn.canJump());
     }
+
+    @Test
+    void MakeCopy_OnWhitePawn_CopyTypeIsPawn() {
+        Pawn pawn = new Pawn(PieceColor.WHITE);
+
+        PieceType expected = PieceType.PAWN;
+        PieceType actual = pawn.makeCopy().getType();
+        assertEquals(expected, actual);
+    }
 }

--- a/src/test/java/domain/piece/PawnTest.java
+++ b/src/test/java/domain/piece/PawnTest.java
@@ -1,0 +1,17 @@
+package domain.piece;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class PawnTest {
+
+    @Test
+    void Constructor_OnWhitePawn_TypeIsPawn() {
+        Pawn pawn = new Pawn(PieceColor.WHITE);
+
+        PieceType expected = PieceType.PAWN;
+        PieceType actual = pawn.getType();
+        assertEquals(expected, actual);
+    }
+}

--- a/src/test/java/domain/piece/PawnTest.java
+++ b/src/test/java/domain/piece/PawnTest.java
@@ -2,6 +2,7 @@ package domain.piece;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 import org.junit.jupiter.api.Test;
 
@@ -64,5 +65,12 @@ class PawnTest {
         Pawn pawn = new Pawn(PieceColor.BLACK);
 
         assertFalse(pawn.makeCopy().canJump());
+    }
+
+    @Test
+    void MakeCopy_OnBlackPawn_CopyIsDifferentObject() {
+        Pawn pawn = new Pawn(PieceColor.BLACK);
+
+        assertNotSame(pawn, pawn.makeCopy());
     }
 }

--- a/src/test/java/domain/piece/PawnTest.java
+++ b/src/test/java/domain/piece/PawnTest.java
@@ -1,6 +1,7 @@
 package domain.piece;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.junit.jupiter.api.Test;
 
@@ -22,5 +23,12 @@ class PawnTest {
         PieceColor expected = PieceColor.WHITE;
         PieceColor actual = pawn.getColor();
         assertEquals(expected, actual);
+    }
+
+    @Test
+    void Constructor_OnWhitePawn_CanJumpIsFalse() {
+        Pawn pawn = new Pawn(PieceColor.WHITE);
+
+        assertFalse(pawn.canJump());
     }
 }

--- a/src/test/java/domain/piece/PawnTest.java
+++ b/src/test/java/domain/piece/PawnTest.java
@@ -58,4 +58,11 @@ class PawnTest {
         PieceColor actual = pawn.makeCopy().getColor();
         assertEquals(expected, actual);
     }
+
+    @Test
+    void MakeCopy_OnBlackPawn_CopyCanJumpIsFalse() {
+        Pawn pawn = new Pawn(PieceColor.BLACK);
+
+        assertFalse(pawn.makeCopy().canJump());
+    }
 }

--- a/src/test/java/domain/piece/QueenTest.java
+++ b/src/test/java/domain/piece/QueenTest.java
@@ -25,4 +25,11 @@ class QueenTest {
         PieceColor actual = queen.getColor();
         assertEquals(expected, actual);
     }
+
+    @Test
+    void Constructor_OnWhiteQueen_CanJumpIsFalse() {
+        Queen queen = new Queen(PieceColor.WHITE);
+
+        assertFalse(queen.canJump());
+    }
 }

--- a/src/test/java/domain/piece/QueenTest.java
+++ b/src/test/java/domain/piece/QueenTest.java
@@ -50,4 +50,13 @@ class QueenTest {
         PieceType actual = queen.makeCopy().getType();
         assertEquals(expected, actual);
     }
+
+    @Test
+    void MakeCopy_OnBlackQueen_CopyColorIsBlack() {
+        Queen queen = new Queen(PieceColor.BLACK);
+
+        PieceColor expected = PieceColor.BLACK;
+        PieceColor actual = queen.makeCopy().getColor();
+        assertEquals(expected, actual);
+    }
 }

--- a/src/test/java/domain/piece/QueenTest.java
+++ b/src/test/java/domain/piece/QueenTest.java
@@ -59,4 +59,11 @@ class QueenTest {
         PieceColor actual = queen.makeCopy().getColor();
         assertEquals(expected, actual);
     }
+
+    @Test
+    void MakeCopy_OnBlackQueen_CopyCanJumpIsFalse() {
+        Queen queen = new Queen(PieceColor.BLACK);
+
+        assertFalse(queen.makeCopy().canJump());
+    }
 }

--- a/src/test/java/domain/piece/QueenTest.java
+++ b/src/test/java/domain/piece/QueenTest.java
@@ -41,4 +41,13 @@ class QueenTest {
         PieceType actual = queen.makeCopy().getType();
         assertEquals(expected, actual);
     }
+
+    @Test
+    void MakeCopy_OnBlackQueen_CopyTypeIsQueen() {
+        Queen queen = new Queen(PieceColor.BLACK);
+
+        PieceType expected = PieceType.QUEEN;
+        PieceType actual = queen.makeCopy().getType();
+        assertEquals(expected, actual);
+    }
 }

--- a/src/test/java/domain/piece/QueenTest.java
+++ b/src/test/java/domain/piece/QueenTest.java
@@ -1,0 +1,19 @@
+package domain.piece;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+
+import org.junit.jupiter.api.Test;
+
+class QueenTest {
+
+    @Test
+    void Constructor_OnWhiteQueen_TypeIsQueen() {
+        Queen queen = new Queen(PieceColor.WHITE);
+
+        PieceType expected = PieceType.QUEEN;
+        PieceType actual = queen.getType();
+        assertEquals(expected, actual);
+    }
+}

--- a/src/test/java/domain/piece/QueenTest.java
+++ b/src/test/java/domain/piece/QueenTest.java
@@ -32,4 +32,13 @@ class QueenTest {
 
         assertFalse(queen.canJump());
     }
+
+    @Test
+    void MakeCopy_OnWhiteQueen_CopyTypeIsQueen() {
+        Queen queen = new Queen(PieceColor.WHITE);
+
+        PieceType expected = PieceType.QUEEN;
+        PieceType actual = queen.makeCopy().getType();
+        assertEquals(expected, actual);
+    }
 }

--- a/src/test/java/domain/piece/QueenTest.java
+++ b/src/test/java/domain/piece/QueenTest.java
@@ -66,4 +66,11 @@ class QueenTest {
 
         assertFalse(queen.makeCopy().canJump());
     }
+
+    @Test
+    void MakeCopy_OnBlackQueen_CopyIsDifferentObject() {
+        Queen queen = new Queen(PieceColor.BLACK);
+
+        assertNotSame(queen, queen.makeCopy());
+    }
 }

--- a/src/test/java/domain/piece/QueenTest.java
+++ b/src/test/java/domain/piece/QueenTest.java
@@ -16,4 +16,13 @@ class QueenTest {
         PieceType actual = queen.getType();
         assertEquals(expected, actual);
     }
+
+    @Test
+    void Constructor_OnWhiteQueen_ColorIsWhite() {
+        Queen queen = new Queen(PieceColor.WHITE);
+
+        PieceColor expected = PieceColor.WHITE;
+        PieceColor actual = queen.getColor();
+        assertEquals(expected, actual);
+    }
 }

--- a/src/test/java/domain/piece/RookTest.java
+++ b/src/test/java/domain/piece/RookTest.java
@@ -41,4 +41,13 @@ class RookTest {
         PieceType actual = rook.makeCopy().getType();
         assertEquals(expected, actual);
     }
+
+    @Test
+    void MakeCopy_OnBlackRook_CopyTypeIsRook() {
+        Rook rook = new Rook(PieceColor.BLACK);
+
+        PieceType expected = PieceType.ROOK;
+        PieceType actual = rook.makeCopy().getType();
+        assertEquals(expected, actual);
+    }
 }

--- a/src/test/java/domain/piece/RookTest.java
+++ b/src/test/java/domain/piece/RookTest.java
@@ -59,4 +59,11 @@ class RookTest {
         PieceColor actual = rook.makeCopy().getColor();
         assertEquals(expected, actual);
     }
+
+    @Test
+    void MakeCopy_OnBlackRook_CopyCanJumpIsFalse() {
+        Rook rook = new Rook(PieceColor.BLACK);
+
+        assertFalse(rook.makeCopy().canJump());
+    }
 }

--- a/src/test/java/domain/piece/RookTest.java
+++ b/src/test/java/domain/piece/RookTest.java
@@ -1,0 +1,19 @@
+package domain.piece;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+
+import org.junit.jupiter.api.Test;
+
+class RookTest {
+
+    @Test
+    void Constructor_OnWhiteRook_TypeIsRook() {
+        Rook rook = new Rook(PieceColor.WHITE);
+
+        PieceType expected = PieceType.ROOK;
+        PieceType actual = rook.getType();
+        assertEquals(expected, actual);
+    }
+}

--- a/src/test/java/domain/piece/RookTest.java
+++ b/src/test/java/domain/piece/RookTest.java
@@ -66,4 +66,11 @@ class RookTest {
 
         assertFalse(rook.makeCopy().canJump());
     }
+
+    @Test
+    void MakeCopy_OnBlackRook_CopyIsDifferentObject() {
+        Rook rook = new Rook(PieceColor.BLACK);
+
+        assertNotSame(rook, rook.makeCopy());
+    }
 }

--- a/src/test/java/domain/piece/RookTest.java
+++ b/src/test/java/domain/piece/RookTest.java
@@ -25,4 +25,11 @@ class RookTest {
         PieceColor actual = rook.getColor();
         assertEquals(expected, actual);
     }
+
+    @Test
+    void Constructor_OnWhiteRook_CanJumpIsFalse() {
+        Rook rook = new Rook(PieceColor.WHITE);
+
+        assertFalse(rook.canJump());
+    }
 }

--- a/src/test/java/domain/piece/RookTest.java
+++ b/src/test/java/domain/piece/RookTest.java
@@ -16,4 +16,13 @@ class RookTest {
         PieceType actual = rook.getType();
         assertEquals(expected, actual);
     }
+
+    @Test
+    void Constructor_OnWhiteRook_ColorIsWhite() {
+        Rook rook = new Rook(PieceColor.WHITE);
+
+        PieceColor expected = PieceColor.WHITE;
+        PieceColor actual = rook.getColor();
+        assertEquals(expected, actual);
+    }
 }

--- a/src/test/java/domain/piece/RookTest.java
+++ b/src/test/java/domain/piece/RookTest.java
@@ -50,4 +50,13 @@ class RookTest {
         PieceType actual = rook.makeCopy().getType();
         assertEquals(expected, actual);
     }
+
+    @Test
+    void MakeCopy_OnBlackRook_CopyColorIsBlack() {
+        Rook rook = new Rook(PieceColor.BLACK);
+
+        PieceColor expected = PieceColor.BLACK;
+        PieceColor actual = rook.makeCopy().getColor();
+        assertEquals(expected, actual);
+    }
 }

--- a/src/test/java/domain/piece/RookTest.java
+++ b/src/test/java/domain/piece/RookTest.java
@@ -32,4 +32,13 @@ class RookTest {
 
         assertFalse(rook.canJump());
     }
+
+    @Test
+    void MakeCopy_OnWhiteRook_CopyTypeIsRook() {
+        Rook rook = new Rook(PieceColor.WHITE);
+
+        PieceType expected = PieceType.ROOK;
+        PieceType actual = rook.makeCopy().getType();
+        assertEquals(expected, actual);
+    }
 }


### PR DESCRIPTION
# Remaining pieces feature

## Summary

This PR completes the Bishop, Pawn, Queen, and Rook class work for the chess project using a TDD workflow. It adds the BVA analysis for each class, implements the constructor and makeCopy() for all four pieces, and documents the test coverage in the branch history.

## Scope

- Add BVA documentation for Bishop, Pawn, Queen, and Rook in `docs/bva/`
- Cover the constructor and `makeCopy()` for each class in the analysis
- Implement the constructor and `makeCopy()` in `src/main/java/domain/piece/` for each class
- Add focused tests in `src/test/java/domain/piece/` for each class
- Keep `isValidMoveShape()` out of scope for this pass

## Current status

- BVA analysis completed for all four classes
- Class-specific tests implemented for all four classes
- Implementation completed for the covered methods for all four classes
- All targeted tests pass

## Notes

- The analysis follows the design in `docs/design/chess-full-design.puml`
- Standard chess move rules used for `isValidMoveShape()` descriptions since `docs/requirements/game-rules.md` is still a placeholder
- The implementation follows the existing `Piece` abstraction and constructor/copy behavior
- Commits were made in small TDD steps with one focused test and its implementation per commit

## Testing

```bash
./gradlew test --tests "domain.piece.BishopTest"
./gradlew test --tests "domain.piece.PawnTest"
./gradlew test --tests "domain.piece.QueenTest"
./gradlew test --tests "domain.piece.RookTest"
```

- 8 test cases implemented and passing per class (32 total)
- Full project tests pass cleanly

## Design Alignment

- Changes align with `docs/design/chess-full-design.puml`
- No breaking changes to existing methods
- New methods follow the established patterns

## Implementation Notes

- Bishop, Pawn, Queen, and Rook each extend `Piece`
- Each constructor sets the appropriate piece type (`BISHOP`, `PAWN`, `QUEEN`, `ROOK`)
- `makeCopy()` returns a new instance of the same piece with the same color as the original
- `canJump()` returns `false` automatically for all four classes via the `Piece` constructor logic

## Checklist

- [x] BVA analysis is documented
- [x] TDD workflow followed (tests before code)
- [x] Code compiles and targeted tests pass
- [x] No new compiler warnings
- [x] Documentation updated
- [x] Commit messages are clear and follow TDD workflow
