### PR TITLE
[FEAT] Setup Jacoco and Pitest

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,6 +47,15 @@ tasks.compileJava {
     options.release = 11
 }
 
+tasks.jacocoTestReport {
+    reports {
+        xml.required = false
+        csv.required = false
+        html.outputLocation = layout.buildDirectory.dir("reports/jacoco")
+    }
+}
+
 tasks.test {
     useJUnitPlatform()
+    finalizedBy(tasks.jacocoTestReport) // report is always generated after tests run
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ import org.gradle.api.plugins.quality.Checkstyle
 plugins {
     id("java")
     checkstyle
+    jacoco
 }
 
 group = "nu.csse.sqe"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("java")
     checkstyle
     jacoco
+    id("info.solidsoft.pitest") version "1.15.0"
 }
 
 group = "nu.csse.sqe"
@@ -58,4 +59,18 @@ tasks.jacocoTestReport {
 tasks.test {
     useJUnitPlatform()
     finalizedBy(tasks.jacocoTestReport) // report is always generated after tests run
+}
+
+pitest {
+    targetClasses = setOf("domain.*", "ui.*")
+    targetTests = setOf("domain.*", "ui.*")
+    junit5PluginVersion = "1.2.1"
+    threads = 4
+    outputFormats = setOf("HTML")
+    timestampedReports = false
+    testSourceSets.set(listOf(sourceSets.test.get()))
+    mainSourceSets.set(listOf(sourceSets.main.get()))
+    jvmArgs.set(listOf("-Xmx1024m"))
+    useClasspathFile.set(true)
+    exportLineCoverage = true
 }


### PR DESCRIPTION
## Description
  
  Add JaCoCo code coverage plugin to the Gradle build so that running `./gradlew test` automatically generates an HTML coverage report at `build/reports/jacoco/test/html/index.html`. Additionally, configure Pitest.
  
  ## Type of Change

  - [ ] Feature (new functionality)
  - [ ] Bug fix
  - [ ] Documentation update
  - [ ] Refactor
  - [x] Test addition/update

  ## Related Work
  
  N/A — build tooling change only

  ## Changes Made

  - [x] Add `jacoco` plugin to `build.gradle.kts`
  - [x] Wire `jacocoTestReport` to finalize after `test`
  - [x] Configure HTML report output

  ## BVA & Testing

  N/A 

  ## Design Alignment
  
  - [ ] Changes align with `docs/design/chess-full-design.puml` — N/A (build config only)
  - [x] No breaking changes to existing methods
  - [x] New methods follow the established patterns

  ## Implementation Notes

 N/A
  
  ## Checklist

  - [ ] BVA analysis is documented — N/A
  - [ ] TDD workflow followed — N/A
  - [x] Code compiles and all tests pass
  - [x] No new compiler warnings
  - [ ] Documentation updated (if applicable) — N/A
  - [x] Commit messages are clear and follow TDD workflow