### PR TITLE
[FEAT] WelcomeView

### DIFF
--- a/docs/bva/WelcomeView.md
+++ b/docs/bva/WelcomeView.md
@@ -46,7 +46,7 @@ Scope: **Constructor** (field initialization) and **`getPlayer1Name()`** / **`ge
   - **State of the system**: `WelcomeView` constructed; `player1NameField` text set to `"Alice"` via package-private setter
   - **Expected output**: `getPlayer1Name()` returns `"Alice"`
 
-- **WV-TC4: GetPlayer2Name_WhenFieldHasText_ReturnsEnteredName** ( :x: )
+- **WV-TC4: GetPlayer2Name_WhenFieldHasText_ReturnsEnteredName** ( :white_check_mark: )
   - **Method(s) under test**: `getPlayer2Name()`
   - **State of the system**: `WelcomeView` constructed; `player2NameField` text set to `"Bob"` via package-private setter
   - **Expected output**: `getPlayer2Name()` returns `"Bob"`

--- a/docs/bva/WelcomeView.md
+++ b/docs/bva/WelcomeView.md
@@ -71,7 +71,7 @@ Scope: **Constructor** (field initialization) and **`getPlayer1Name()`** / **`ge
 
 ### Step 4: Test cases
 
-- **WV-TC5: IsChess960Selected_OnFreshWelcomeView_ReturnsFalse** ( :x: )
+- **WV-TC5: IsChess960Selected_OnFreshWelcomeView_ReturnsFalse** ( :white_check_mark: )
   - **Method(s) under test**: `WelcomeView()`, `isChess960Selected()`
   - **State of the system**: freshly constructed `WelcomeView`
   - **Expected output**: `isChess960Selected()` returns `false`

--- a/docs/bva/WelcomeView.md
+++ b/docs/bva/WelcomeView.md
@@ -47,6 +47,39 @@ Scope: **Constructor** (field initialization) and **`getPlayer1Name()`** / **`ge
   - **Expected output**: `getPlayer1Name()` returns `"Alice"`
 
 - **WV-TC4: GetPlayer2Name_WhenFieldHasText_ReturnsEnteredName** ( :white_check_mark: )
+
+---
+
+## Method / behavior: `isChess960Selected()`
+
+### Step 1: Input and output equivalence classes
+
+| Concern | Equivalence classes |
+| ------- | ------------------- |
+| `chess960CheckBox` state | Unchecked (default) → `false`; checked → `true` |
+
+### Step 2: BVA catalog data types
+
+| Variable / output | Catalog type | Notes |
+| ----------------- | ------------ | ----- |
+| `isChess960Selected()` result | Boolean | `false` (unchecked) vs `true` (checked) — two-state boundary |
+
+### Step 3: Concrete boundary values
+
+- `false`: JCheckBox default — user has not selected Chess960.
+- `true`: user has checked the box.
+
+### Step 4: Test cases
+
+- **WV-TC5: IsChess960Selected_OnFreshWelcomeView_ReturnsFalse** ( :x: )
+  - **Method(s) under test**: `WelcomeView()`, `isChess960Selected()`
+  - **State of the system**: freshly constructed `WelcomeView`
+  - **Expected output**: `isChess960Selected()` returns `false`
+
+- **WV-TC6: IsChess960Selected_WhenCheckBoxIsChecked_ReturnsTrue** ( :x: )
+  - **Method(s) under test**: `isChess960Selected()`
+  - **State of the system**: `WelcomeView` constructed; `chess960CheckBox` checked via package-private setter
+  - **Expected output**: `isChess960Selected()` returns `true`
   - **Method(s) under test**: `getPlayer2Name()`
   - **State of the system**: `WelcomeView` constructed; `player2NameField` text set to `"Bob"` via package-private setter
   - **Expected output**: `getPlayer2Name()` returns `"Bob"`

--- a/docs/bva/WelcomeView.md
+++ b/docs/bva/WelcomeView.md
@@ -2,9 +2,11 @@
 
 Package: `ui.WelcomeView`
 
-Scope: **Constructor** (field initialization) and **`getPlayer1Name()`** / **`getPlayer2Name()`** (getter delegation to JTextField). `createWelcomeScreenUI` is **untestable** (Swing UI assembly side-effect) and is excluded from this BVA.
+Scope: **Constructor** (field initialization), **`getPlayer1Name()`** / **`getPlayer2Name()`** (getter delegation to JTextField), **`isChess960Selected()`** (radio button state), and **`setStartGameAction(Runnable)`** (action wiring). `createWelcomeScreenUI` is **untestable** (Swing UI assembly side-effect) and is excluded from this BVA.
 
 **Headless guard:** `WelcomeView` extends `JFrame`, which cannot be instantiated in a headless JVM. All TCs use a `@BeforeAll assumeTrue(!GraphicsEnvironment.isHeadless())` guard so they skip cleanly on headless CI and run on machines with a display.
+
+**Radio button note:** Game mode is selected via `standardRadioButton` / `chess960RadioButton` in a `ButtonGroup`. Standard is selected by default. `isChess960Selected()` delegates to `chess960RadioButton.isSelected()`. Tests use a package-private `setChess960Selected(boolean)` setter to flip state without navigating the component tree.
 
 ---
 
@@ -47,6 +49,9 @@ Scope: **Constructor** (field initialization) and **`getPlayer1Name()`** / **`ge
   - **Expected output**: `getPlayer1Name()` returns `"Alice"`
 
 - **WV-TC4: GetPlayer2Name_WhenFieldHasText_ReturnsEnteredName** ( :white_check_mark: )
+  - **Method(s) under test**: `getPlayer2Name()`
+  - **State of the system**: `WelcomeView` constructed; `player2NameField` text set to `"Bob"` via package-private setter
+  - **Expected output**: `getPlayer2Name()` returns `"Bob"`
 
 ---
 
@@ -56,18 +61,18 @@ Scope: **Constructor** (field initialization) and **`getPlayer1Name()`** / **`ge
 
 | Concern | Equivalence classes |
 | ------- | ------------------- |
-| `chess960CheckBox` state | Unchecked (default) → `false`; checked → `true` |
+| `chess960RadioButton` state | Unselected (default, `standardRadioButton` selected) → `false`; selected → `true` |
 
 ### Step 2: BVA catalog data types
 
 | Variable / output | Catalog type | Notes |
 | ----------------- | ------------ | ----- |
-| `isChess960Selected()` result | Boolean | `false` (unchecked) vs `true` (checked) — two-state boundary |
+| `isChess960Selected()` result | Boolean | `false` (standard selected by default) vs `true` (Chess960 selected) — two-state boundary |
 
 ### Step 3: Concrete boundary values
 
-- `false`: JCheckBox default — user has not selected Chess960.
-- `true`: user has checked the box.
+- `false`: `standardRadioButton` selected by default on construction.
+- `true`: `chess960RadioButton` selected.
 
 ### Step 4: Test cases
 
@@ -76,10 +81,35 @@ Scope: **Constructor** (field initialization) and **`getPlayer1Name()`** / **`ge
   - **State of the system**: freshly constructed `WelcomeView`
   - **Expected output**: `isChess960Selected()` returns `false`
 
-- **WV-TC6: IsChess960Selected_WhenCheckBoxIsChecked_ReturnsTrue** ( :white_check_mark: )
+- **WV-TC6: IsChess960Selected_WhenChess960RadioIsSelected_ReturnsTrue** ( :white_check_mark: )
   - **Method(s) under test**: `isChess960Selected()`
-  - **State of the system**: `WelcomeView` constructed; `chess960CheckBox` checked via package-private setter
+  - **State of the system**: `WelcomeView` constructed; `chess960RadioButton` selected via package-private setter
   - **Expected output**: `isChess960Selected()` returns `true`
-  - **Method(s) under test**: `getPlayer2Name()`
-  - **State of the system**: `WelcomeView` constructed; `player2NameField` text set to `"Bob"` via package-private setter
-  - **Expected output**: `getPlayer2Name()` returns `"Bob"`
+
+---
+
+## Method / behavior: `setStartGameAction(Runnable action)`
+
+### Step 1: Input and output equivalence classes
+
+| Concern | Equivalence classes |
+| ------- | ------------------- |
+| Action registration | Runnable registered → invoked when Start Game is clicked |
+
+### Step 2: BVA catalog data types
+
+| Variable / output | Catalog type | Notes |
+| ----------------- | ------------ | ----- |
+| Invocation count | Integer | 0 (not clicked) vs 1 (clicked once) |
+
+### Step 3: Concrete boundary values
+
+- 0: action not yet invoked (button not clicked).
+- 1: button clicked once → action invoked exactly once.
+
+### Step 4: Test cases
+
+- **WV-TC7: SetStartGameAction_WhenStartGameClicked_ActionIsInvoked** ( :x: )
+  - **Method(s) under test**: `setStartGameAction(Runnable)`
+  - **State of the system**: `WelcomeView` constructed; a counting `Runnable` registered; Start Game triggered via package-private `clickStartGame()`
+  - **Expected output**: Runnable invoked exactly once

--- a/docs/bva/WelcomeView.md
+++ b/docs/bva/WelcomeView.md
@@ -36,7 +36,7 @@ Scope: **Constructor** (field initialization) and **`getPlayer1Name()`** / **`ge
   - **State of the system**: freshly constructed `WelcomeView`
   - **Expected output**: `getPlayer1Name()` returns `""`
 
-- **WV-TC2: Constructor_OnFreshWelcomeView_Player2NameIsEmpty** ( :x: )
+- **WV-TC2: Constructor_OnFreshWelcomeView_Player2NameIsEmpty** ( :white_check_mark: )
   - **Method(s) under test**: `WelcomeView()`, `getPlayer2Name()`
   - **State of the system**: freshly constructed `WelcomeView`
   - **Expected output**: `getPlayer2Name()` returns `""`

--- a/docs/bva/WelcomeView.md
+++ b/docs/bva/WelcomeView.md
@@ -41,7 +41,7 @@ Scope: **Constructor** (field initialization) and **`getPlayer1Name()`** / **`ge
   - **State of the system**: freshly constructed `WelcomeView`
   - **Expected output**: `getPlayer2Name()` returns `""`
 
-- **WV-TC3: GetPlayer1Name_WhenFieldHasText_ReturnsEnteredName** ( :x: )
+- **WV-TC3: GetPlayer1Name_WhenFieldHasText_ReturnsEnteredName** ( :white_check_mark: )
   - **Method(s) under test**: `getPlayer1Name()`
   - **State of the system**: `WelcomeView` constructed; `player1NameField` text set to `"Alice"` via package-private setter
   - **Expected output**: `getPlayer1Name()` returns `"Alice"`

--- a/docs/bva/WelcomeView.md
+++ b/docs/bva/WelcomeView.md
@@ -76,7 +76,7 @@ Scope: **Constructor** (field initialization) and **`getPlayer1Name()`** / **`ge
   - **State of the system**: freshly constructed `WelcomeView`
   - **Expected output**: `isChess960Selected()` returns `false`
 
-- **WV-TC6: IsChess960Selected_WhenCheckBoxIsChecked_ReturnsTrue** ( :x: )
+- **WV-TC6: IsChess960Selected_WhenCheckBoxIsChecked_ReturnsTrue** ( :white_check_mark: )
   - **Method(s) under test**: `isChess960Selected()`
   - **State of the system**: `WelcomeView` constructed; `chess960CheckBox` checked via package-private setter
   - **Expected output**: `isChess960Selected()` returns `true`

--- a/docs/bva/WelcomeView.md
+++ b/docs/bva/WelcomeView.md
@@ -109,7 +109,7 @@ Scope: **Constructor** (field initialization), **`getPlayer1Name()`** / **`getPl
 
 ### Step 4: Test cases
 
-- **WV-TC7: SetStartGameAction_WhenStartGameClicked_ActionIsInvoked** ( :x: )
+- **WV-TC7: SetStartGameAction_WhenStartGameClicked_ActionIsInvoked** ( :white_check_mark: )
   - **Method(s) under test**: `setStartGameAction(Runnable)`
   - **State of the system**: `WelcomeView` constructed; a counting `Runnable` registered; Start Game triggered via package-private `clickStartGame()`
   - **Expected output**: Runnable invoked exactly once

--- a/docs/bva/WelcomeView.md
+++ b/docs/bva/WelcomeView.md
@@ -4,6 +4,8 @@ Package: `ui.WelcomeView`
 
 Scope: **Constructor** (field initialization) and **`getPlayer1Name()`** / **`getPlayer2Name()`** (getter delegation to JTextField). `createWelcomeScreenUI` is **untestable** (Swing UI assembly side-effect) and is excluded from this BVA.
 
+**Headless guard:** `WelcomeView` extends `JFrame`, which cannot be instantiated in a headless JVM. All TCs use a `@BeforeAll assumeTrue(!GraphicsEnvironment.isHeadless())` guard so they skip cleanly on headless CI and run on machines with a display.
+
 ---
 
 ## Method / behavior: `WelcomeView()`
@@ -29,7 +31,7 @@ Scope: **Constructor** (field initialization) and **`getPlayer1Name()`** / **`ge
 
 ### Step 4: Test cases
 
-- **WV-TC1: Constructor_OnFreshWelcomeView_Player1NameIsEmpty** ( :x: )
+- **WV-TC1: Constructor_OnFreshWelcomeView_Player1NameIsEmpty** ( :white_check_mark: )
   - **Method(s) under test**: `WelcomeView()`, `getPlayer1Name()`
   - **State of the system**: freshly constructed `WelcomeView`
   - **Expected output**: `getPlayer1Name()` returns `""`

--- a/docs/bva/WelcomeView.md
+++ b/docs/bva/WelcomeView.md
@@ -1,0 +1,50 @@
+# BVA Analysis for WelcomeView
+
+Package: `ui.WelcomeView`
+
+Scope: **Constructor** (field initialization) and **`getPlayer1Name()`** / **`getPlayer2Name()`** (getter delegation to JTextField). `createWelcomeScreenUI` is **untestable** (Swing UI assembly side-effect) and is excluded from this BVA.
+
+---
+
+## Method / behavior: `WelcomeView()`
+
+### Step 1: Input and output equivalence classes
+
+| Concern | Equivalence classes |
+| ------- | ------------------- |
+| Post-construction `player1NameField` | Initialized; `getPlayer1Name()` returns `""` (JTextField default) |
+| Post-construction `player2NameField` | Initialized; `getPlayer2Name()` returns `""` (JTextField default) |
+
+### Step 2: BVA catalog data types
+
+| Variable / output | Catalog type | Notes |
+| ----------------- | ------------ | ----- |
+| `getPlayer1Name()` result | String | Empty string (no text entered) vs non-empty (text typed) |
+| `getPlayer2Name()` result | String | Same as above |
+
+### Step 3: Concrete boundary values
+
+- Empty string `""`: JTextField default — both fields start here.
+- Non-empty string (e.g. `"Alice"`): text has been entered into the field.
+
+### Step 4: Test cases
+
+- **WV-TC1: Constructor_OnFreshWelcomeView_Player1NameIsEmpty** ( :x: )
+  - **Method(s) under test**: `WelcomeView()`, `getPlayer1Name()`
+  - **State of the system**: freshly constructed `WelcomeView`
+  - **Expected output**: `getPlayer1Name()` returns `""`
+
+- **WV-TC2: Constructor_OnFreshWelcomeView_Player2NameIsEmpty** ( :x: )
+  - **Method(s) under test**: `WelcomeView()`, `getPlayer2Name()`
+  - **State of the system**: freshly constructed `WelcomeView`
+  - **Expected output**: `getPlayer2Name()` returns `""`
+
+- **WV-TC3: GetPlayer1Name_WhenFieldHasText_ReturnsEnteredName** ( :x: )
+  - **Method(s) under test**: `getPlayer1Name()`
+  - **State of the system**: `WelcomeView` constructed; `player1NameField` text set to `"Alice"` via package-private setter
+  - **Expected output**: `getPlayer1Name()` returns `"Alice"`
+
+- **WV-TC4: GetPlayer2Name_WhenFieldHasText_ReturnsEnteredName** ( :x: )
+  - **Method(s) under test**: `getPlayer2Name()`
+  - **State of the system**: `WelcomeView` constructed; `player2NameField` text set to `"Bob"` via package-private setter
+  - **Expected output**: `getPlayer2Name()` returns `"Bob"`

--- a/docs/bva/WelcomeView.md
+++ b/docs/bva/WelcomeView.md
@@ -113,3 +113,8 @@ Scope: **Constructor** (field initialization), **`getPlayer1Name()`** / **`getPl
   - **Method(s) under test**: `setStartGameAction(Runnable)`
   - **State of the system**: `WelcomeView` constructed; a counting `Runnable` registered; Start Game triggered via package-private `clickStartGame()`
   - **Expected output**: Runnable invoked exactly once
+
+- **WV-TC8: ClickStartGame_WhenNoActionRegistered_DoesNotThrow** ( :white_check_mark: )
+  - **Method(s) under test**: `clickStartGame()`
+  - **State of the system**: `WelcomeView` constructed; no action registered; `clickStartGame()` called
+  - **Expected output**: no exception thrown

--- a/docs/design/chess-full-design.puml
+++ b/docs/design/chess-full-design.puml
@@ -10,12 +10,14 @@ package ui{
     +class WelcomeView{
         -player1NameField: JTextField
         -player2NameField: JTextField
-        -chess960CheckBox: JCheckBox
+        -standardRadioButton: JRadioButton
+        -chess960RadioButton: JRadioButton
 
         +WelcomeView()
         +getPlayer1Name(): String
         +getPlayer2Name(): String
         +isChess960Selected(): boolean
+        +setStartGameAction(action: Runnable): void
         -createWelcomeScreenUI(): void
     }
 

--- a/docs/design/chess-full-design.puml
+++ b/docs/design/chess-full-design.puml
@@ -10,10 +10,12 @@ package ui{
     +class WelcomeView{
         -player1NameField: JTextField
         -player2NameField: JTextField
+        -chess960CheckBox: JCheckBox
 
         +WelcomeView()
         +getPlayer1Name(): String
         +getPlayer2Name(): String
+        +isChess960Selected(): boolean
         -createWelcomeScreenUI(): void
     }
 
@@ -33,7 +35,7 @@ package ui{
         -player1Name: String
         -player2Name: String
 
-        +MainView(player1Name: String, player2Name: String)
+        +MainView(player1Name: String, player2Name: String, chess960: boolean)
         -configureMainView(): void
         -addGameStatsView(): void
         -addBoardView(): void
@@ -74,7 +76,7 @@ package ui{
 
         -lastSelectedLoc: Location
 
-        +BoardController()
+        +BoardController(initializer: BoardInitializer)
         +setBoardView(boardView: BoardView): void
 
         +handleSquareClick(loc: Location): void
@@ -318,6 +320,7 @@ BoardMouseListener -u-|> MouseAdapter
 
 BoardController --> BoardView
 BoardController --> Board
+BoardController ..> BoardInitializer
 BoardController ..> Location
 BoardController ..> Piece
 

--- a/docs/design/chess-full-design.puml
+++ b/docs/design/chess-full-design.puml
@@ -12,6 +12,8 @@ package ui{
         -player2NameField: JTextField
 
         +WelcomeView()
+        +getPlayer1Name(): String
+        +getPlayer2Name(): String
         -createWelcomeScreenUI(): void
     }
 

--- a/src/main/java/ui/README.md
+++ b/src/main/java/ui/README.md
@@ -1,0 +1,2 @@
+Placeholder for WelcomeView. This file marks the feature-welcome-view branch.
+The WelcomeView class and associated tests will be added in subsequent commits following the TDD workflow.

--- a/src/main/java/ui/WelcomeView.java
+++ b/src/main/java/ui/WelcomeView.java
@@ -1,0 +1,31 @@
+package ui;
+
+import javax.swing.JFrame;
+import javax.swing.JTextField;
+
+public class WelcomeView extends JFrame {
+
+    private JTextField player1NameField;
+    private JTextField player2NameField;
+
+    public WelcomeView() {
+    }
+
+    public String getPlayer1Name() {
+        return "";
+    }
+
+    public String getPlayer2Name() {
+        return "";
+    }
+
+    void setPlayer1Name(String name) {
+    }
+
+    void setPlayer2Name(String name) {
+    }
+
+    private void createWelcomeScreenUI() {
+        // untestable: Swing UI assembly
+    }
+}

--- a/src/main/java/ui/WelcomeView.java
+++ b/src/main/java/ui/WelcomeView.java
@@ -1,5 +1,6 @@
 package ui;
 
+import javax.swing.JCheckBox;
 import javax.swing.JFrame;
 import javax.swing.JTextField;
 
@@ -7,10 +8,12 @@ public class WelcomeView extends JFrame {
 
     private JTextField player1NameField;
     private JTextField player2NameField;
+    private JCheckBox chess960CheckBox;
 
     public WelcomeView() {
         player1NameField = new JTextField();
         player2NameField = new JTextField();
+        createWelcomeScreenUI();
     }
 
     public String getPlayer1Name() {
@@ -29,7 +32,30 @@ public class WelcomeView extends JFrame {
         player2NameField.setText(name);
     }
 
+    public boolean isChess960Selected() {
+        return false;
+    }
+
+    void setChess960Selected(boolean selected) {
+    }
+
     private void createWelcomeScreenUI() {
         // untestable: Swing UI assembly
+        javax.swing.JPanel panel = new javax.swing.JPanel(new java.awt.GridLayout(3, 2, 10, 10));
+        panel.setBorder(javax.swing.BorderFactory.createEmptyBorder(20, 20, 20, 20));
+        panel.add(new javax.swing.JLabel("Player 1 Name:"));
+        panel.add(player1NameField);
+        panel.add(new javax.swing.JLabel("Player 2 Name:"));
+        panel.add(player2NameField);
+
+        javax.swing.JButton startButton = new javax.swing.JButton("Start Game");
+        panel.add(new javax.swing.JLabel());
+        panel.add(startButton);
+
+        setTitle("Chess");
+        setDefaultCloseOperation(javax.swing.JFrame.EXIT_ON_CLOSE);
+        getContentPane().add(panel);
+        pack();
+        setLocationRelativeTo(null);
     }
 }

--- a/src/main/java/ui/WelcomeView.java
+++ b/src/main/java/ui/WelcomeView.java
@@ -18,7 +18,7 @@ public class WelcomeView extends JFrame {
     }
 
     public String getPlayer2Name() {
-        return "";
+        return player2NameField.getText();
     }
 
     void setPlayer1Name(String name) {
@@ -26,6 +26,7 @@ public class WelcomeView extends JFrame {
     }
 
     void setPlayer2Name(String name) {
+        player2NameField.setText(name);
     }
 
     private void createWelcomeScreenUI() {

--- a/src/main/java/ui/WelcomeView.java
+++ b/src/main/java/ui/WelcomeView.java
@@ -10,7 +10,7 @@ public class WelcomeView extends JFrame {
     private JTextField player2NameField;
     private JRadioButton standardRadioButton;
     private JRadioButton chess960RadioButton;
-    private Runnable startGameAction;
+    private Runnable startGameAction = () -> {};
 
     public WelcomeView() {
         player1NameField   = new JTextField();
@@ -51,9 +51,7 @@ public class WelcomeView extends JFrame {
     }
 
     void clickStartGame() {
-        if (startGameAction != null) {
-            startGameAction.run();
-        }
+        startGameAction.run();
     }
 
     private void createWelcomeScreenUI() {

--- a/src/main/java/ui/WelcomeView.java
+++ b/src/main/java/ui/WelcomeView.java
@@ -9,10 +9,12 @@ public class WelcomeView extends JFrame {
     private JTextField player2NameField;
 
     public WelcomeView() {
+        player1NameField = new JTextField();
+        player2NameField = new JTextField();
     }
 
     public String getPlayer1Name() {
-        return "";
+        return player1NameField.getText();
     }
 
     public String getPlayer2Name() {
@@ -20,6 +22,7 @@ public class WelcomeView extends JFrame {
     }
 
     void setPlayer1Name(String name) {
+        player1NameField.setText(name);
     }
 
     void setPlayer2Name(String name) {

--- a/src/main/java/ui/WelcomeView.java
+++ b/src/main/java/ui/WelcomeView.java
@@ -43,12 +43,14 @@ public class WelcomeView extends JFrame {
 
     private void createWelcomeScreenUI() {
         // untestable: Swing UI assembly
-        javax.swing.JPanel panel = new javax.swing.JPanel(new java.awt.GridLayout(3, 2, 10, 10));
+        javax.swing.JPanel panel = new javax.swing.JPanel(new java.awt.GridLayout(4, 2, 10, 10));
         panel.setBorder(javax.swing.BorderFactory.createEmptyBorder(20, 20, 20, 20));
         panel.add(new javax.swing.JLabel("Player 1 Name:"));
         panel.add(player1NameField);
         panel.add(new javax.swing.JLabel("Player 2 Name:"));
         panel.add(player2NameField);
+        panel.add(new javax.swing.JLabel("Play Chess960:"));
+        panel.add(chess960CheckBox);
 
         javax.swing.JButton startButton = new javax.swing.JButton("Start Game");
         panel.add(new javax.swing.JLabel());

--- a/src/main/java/ui/WelcomeView.java
+++ b/src/main/java/ui/WelcomeView.java
@@ -1,19 +1,23 @@
 package ui;
 
-import javax.swing.JCheckBox;
 import javax.swing.JFrame;
+import javax.swing.JRadioButton;
 import javax.swing.JTextField;
 
 public class WelcomeView extends JFrame {
 
     private JTextField player1NameField;
     private JTextField player2NameField;
-    private JCheckBox chess960CheckBox;
+    private JRadioButton standardRadioButton;
+    private JRadioButton chess960RadioButton;
+    private Runnable startGameAction;
 
     public WelcomeView() {
-        player1NameField = new JTextField();
-        player2NameField = new JTextField();
-        chess960CheckBox = new JCheckBox();
+        player1NameField   = new JTextField();
+        player2NameField   = new JTextField();
+        standardRadioButton = new JRadioButton();
+        chess960RadioButton = new JRadioButton();
+        standardRadioButton.setSelected(true);
         createWelcomeScreenUI();
     }
 
@@ -34,32 +38,112 @@ public class WelcomeView extends JFrame {
     }
 
     public boolean isChess960Selected() {
-        return chess960CheckBox.isSelected();
+        return chess960RadioButton.isSelected();
     }
 
     void setChess960Selected(boolean selected) {
-        chess960CheckBox.setSelected(selected);
+        chess960RadioButton.setSelected(selected);
+        standardRadioButton.setSelected(!selected);
+    }
+
+    public void setStartGameAction(Runnable action) {
+        this.startGameAction = action;
+    }
+
+    void clickStartGame() {
+        if (startGameAction != null) {
+            startGameAction.run();
+        }
     }
 
     private void createWelcomeScreenUI() {
         // untestable: Swing UI assembly
-        javax.swing.JPanel panel = new javax.swing.JPanel(new java.awt.GridLayout(4, 2, 10, 10));
-        panel.setBorder(javax.swing.BorderFactory.createEmptyBorder(20, 20, 20, 20));
-        panel.add(new javax.swing.JLabel("Player 1 Name:"));
-        panel.add(player1NameField);
-        panel.add(new javax.swing.JLabel("Player 2 Name:"));
-        panel.add(player2NameField);
-        panel.add(new javax.swing.JLabel("Play Chess960:"));
-        panel.add(chess960CheckBox);
+        java.awt.Color background  = new java.awt.Color(30, 20, 12);
+        java.awt.Color accentColor = new java.awt.Color(181, 136, 99);
+        java.awt.Color textColor   = new java.awt.Color(240, 217, 181);
+        java.awt.Color fieldBg     = new java.awt.Color(255, 248, 240);
+
+        java.awt.Font titleFont  = new java.awt.Font("Serif",     java.awt.Font.BOLD,  52);
+        java.awt.Font labelFont  = new java.awt.Font("SansSerif", java.awt.Font.PLAIN, 18);
+        java.awt.Font fieldFont  = new java.awt.Font("SansSerif", java.awt.Font.PLAIN, 16);
+        java.awt.Font radioFont  = new java.awt.Font("SansSerif", java.awt.Font.PLAIN, 18);
+        java.awt.Font buttonFont = new java.awt.Font("SansSerif", java.awt.Font.BOLD,  16);
+
+        javax.swing.JPanel panel = new javax.swing.JPanel();
+        panel.setLayout(new javax.swing.BoxLayout(panel, javax.swing.BoxLayout.Y_AXIS));
+        panel.setBackground(background);
+        panel.setBorder(javax.swing.BorderFactory.createEmptyBorder(55, 90, 55, 90));
+
+        javax.swing.JLabel title = new javax.swing.JLabel("♟  Chess  ♟");
+        title.setFont(titleFont);
+        title.setForeground(textColor);
+        title.setAlignmentX(java.awt.Component.CENTER_ALIGNMENT);
+        panel.add(title);
+        panel.add(javax.swing.Box.createVerticalStrut(45));
+
+        for (int i = 0; i < 2; i++) {
+            javax.swing.JTextField field = (i == 0) ? player1NameField : player2NameField;
+            String labelText = (i == 0) ? "Player 1" : "Player 2";
+
+            javax.swing.JLabel lbl = new javax.swing.JLabel(labelText);
+            lbl.setFont(labelFont);
+            lbl.setForeground(textColor);
+            lbl.setAlignmentX(java.awt.Component.CENTER_ALIGNMENT);
+            panel.add(lbl);
+            panel.add(javax.swing.Box.createVerticalStrut(5));
+
+            field.setFont(fieldFont);
+            field.setBackground(fieldBg);
+            field.setMaximumSize(new java.awt.Dimension(Integer.MAX_VALUE, 36));
+            field.setBorder(javax.swing.BorderFactory.createCompoundBorder(
+                javax.swing.BorderFactory.createLineBorder(accentColor, 1),
+                javax.swing.BorderFactory.createEmptyBorder(4, 8, 4, 8)));
+            panel.add(field);
+            panel.add(javax.swing.Box.createVerticalStrut(18));
+        }
+
+        javax.swing.ButtonGroup modeGroup = new javax.swing.ButtonGroup();
+        modeGroup.add(standardRadioButton);
+        modeGroup.add(chess960RadioButton);
+
+        javax.swing.JPanel radioPanel = new javax.swing.JPanel(new java.awt.FlowLayout(java.awt.FlowLayout.CENTER, 20, 0));
+        radioPanel.setBackground(background);
+        radioPanel.setAlignmentX(java.awt.Component.CENTER_ALIGNMENT);
+
+        for (JRadioButton btn : new JRadioButton[]{standardRadioButton, chess960RadioButton}) {
+            btn.setFont(radioFont);
+            btn.setForeground(textColor);
+            btn.setBackground(background);
+            btn.setFocusPainted(false);
+            radioPanel.add(btn);
+        }
+        standardRadioButton.setText("Standard");
+        chess960RadioButton.setText("Chess960");
+
+        panel.add(radioPanel);
+        panel.add(javax.swing.Box.createVerticalStrut(36));
 
         javax.swing.JButton startButton = new javax.swing.JButton("Start Game");
-        panel.add(new javax.swing.JLabel());
+        startButton.setFont(buttonFont);
+        startButton.setBackground(accentColor);
+        startButton.setForeground(textColor);
+        startButton.setFocusPainted(false);
+        startButton.setOpaque(true);
+        startButton.setBorderPainted(false);
+        startButton.setMaximumSize(new java.awt.Dimension(180, 42));
+        startButton.setAlignmentX(java.awt.Component.CENTER_ALIGNMENT);
+        startButton.addActionListener(e -> {
+            if (startGameAction != null) {
+                startGameAction.run();
+            }
+        });
         panel.add(startButton);
 
         setTitle("Chess");
         setDefaultCloseOperation(javax.swing.JFrame.EXIT_ON_CLOSE);
+        getContentPane().setBackground(background);
         getContentPane().add(panel);
-        pack();
+        setSize(600, 600);
         setLocationRelativeTo(null);
     }
 }

--- a/src/main/java/ui/WelcomeView.java
+++ b/src/main/java/ui/WelcomeView.java
@@ -132,11 +132,7 @@ public class WelcomeView extends JFrame {
         startButton.setBorderPainted(false);
         startButton.setMaximumSize(new java.awt.Dimension(180, 42));
         startButton.setAlignmentX(java.awt.Component.CENTER_ALIGNMENT);
-        startButton.addActionListener(e -> {
-            if (startGameAction != null) {
-                startGameAction.run();
-            }
-        });
+        startButton.addActionListener(e -> clickStartGame());
         panel.add(startButton);
 
         setTitle("Chess");

--- a/src/main/java/ui/WelcomeView.java
+++ b/src/main/java/ui/WelcomeView.java
@@ -13,6 +13,7 @@ public class WelcomeView extends JFrame {
     public WelcomeView() {
         player1NameField = new JTextField();
         player2NameField = new JTextField();
+        chess960CheckBox = new JCheckBox();
         createWelcomeScreenUI();
     }
 
@@ -33,10 +34,11 @@ public class WelcomeView extends JFrame {
     }
 
     public boolean isChess960Selected() {
-        return false;
+        return chess960CheckBox.isSelected();
     }
 
     void setChess960Selected(boolean selected) {
+        chess960CheckBox.setSelected(selected);
     }
 
     private void createWelcomeScreenUI() {

--- a/src/test/java/ui/WelcomeViewTest.java
+++ b/src/test/java/ui/WelcomeViewTest.java
@@ -65,7 +65,7 @@ class WelcomeViewTest {
     }
 
     @Test
-    void IsChess960Selected_WhenCheckBoxIsChecked_ReturnsTrue() {
+    void IsChess960Selected_WhenChess960RadioIsSelected_ReturnsTrue() {
         WelcomeView view = new WelcomeView();
         view.setChess960Selected(true);
 

--- a/src/test/java/ui/WelcomeViewTest.java
+++ b/src/test/java/ui/WelcomeViewTest.java
@@ -84,4 +84,10 @@ class WelcomeViewTest {
         int actual = callCount[0];
         assertEquals(expected, actual);
     }
+
+    @Test
+    void ClickStartGame_WhenNoActionRegistered_DoesNotThrow() {
+        WelcomeView view = new WelcomeView();
+        view.clickStartGame();
+    }
 }

--- a/src/test/java/ui/WelcomeViewTest.java
+++ b/src/test/java/ui/WelcomeViewTest.java
@@ -1,0 +1,4 @@
+package ui;
+
+class WelcomeViewTest {
+}

--- a/src/test/java/ui/WelcomeViewTest.java
+++ b/src/test/java/ui/WelcomeViewTest.java
@@ -25,4 +25,13 @@ class WelcomeViewTest {
         String actual = view.getPlayer1Name();
         assertEquals(expected, actual);
     }
+
+    @Test
+    void Constructor_OnFreshWelcomeView_Player2NameIsEmpty() {
+        WelcomeView view = new WelcomeView();
+
+        String expected = "";
+        String actual = view.getPlayer2Name();
+        assertEquals(expected, actual);
+    }
 }

--- a/src/test/java/ui/WelcomeViewTest.java
+++ b/src/test/java/ui/WelcomeViewTest.java
@@ -63,4 +63,14 @@ class WelcomeViewTest {
         boolean actual = view.isChess960Selected();
         assertEquals(expected, actual);
     }
+
+    @Test
+    void IsChess960Selected_WhenCheckBoxIsChecked_ReturnsTrue() {
+        WelcomeView view = new WelcomeView();
+        view.setChess960Selected(true);
+
+        boolean expected = true;
+        boolean actual = view.isChess960Selected();
+        assertEquals(expected, actual);
+    }
 }

--- a/src/test/java/ui/WelcomeViewTest.java
+++ b/src/test/java/ui/WelcomeViewTest.java
@@ -1,4 +1,28 @@
 package ui;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.awt.GraphicsEnvironment;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
 class WelcomeViewTest {
+
+    @BeforeAll
+    static void requireDisplay() {
+        System.setProperty("java.awt.headless", "false");
+        assumeTrue(
+            !GraphicsEnvironment.getLocalGraphicsEnvironment().isHeadless(),
+            "Skipping WelcomeView tests: no display available");
+    }
+
+    @Test
+    void Constructor_OnFreshWelcomeView_Player1NameIsEmpty() {
+        WelcomeView view = new WelcomeView();
+
+        String expected = "";
+        String actual = view.getPlayer1Name();
+        assertEquals(expected, actual);
+    }
 }

--- a/src/test/java/ui/WelcomeViewTest.java
+++ b/src/test/java/ui/WelcomeViewTest.java
@@ -34,4 +34,14 @@ class WelcomeViewTest {
         String actual = view.getPlayer2Name();
         assertEquals(expected, actual);
     }
+
+    @Test
+    void GetPlayer1Name_WhenFieldHasText_ReturnsEnteredName() {
+        WelcomeView view = new WelcomeView();
+        view.setPlayer1Name("Alice");
+
+        String expected = "Alice";
+        String actual = view.getPlayer1Name();
+        assertEquals(expected, actual);
+    }
 }

--- a/src/test/java/ui/WelcomeViewTest.java
+++ b/src/test/java/ui/WelcomeViewTest.java
@@ -54,4 +54,13 @@ class WelcomeViewTest {
         String actual = view.getPlayer2Name();
         assertEquals(expected, actual);
     }
+
+    @Test
+    void IsChess960Selected_OnFreshWelcomeView_ReturnsFalse() {
+        WelcomeView view = new WelcomeView();
+
+        boolean expected = false;
+        boolean actual = view.isChess960Selected();
+        assertEquals(expected, actual);
+    }
 }

--- a/src/test/java/ui/WelcomeViewTest.java
+++ b/src/test/java/ui/WelcomeViewTest.java
@@ -73,4 +73,16 @@ class WelcomeViewTest {
         boolean actual = view.isChess960Selected();
         assertEquals(expected, actual);
     }
+
+    @Test
+    void SetStartGameAction_WhenStartGameClicked_ActionIsInvoked() {
+        WelcomeView view = new WelcomeView();
+        int[] callCount = {0};
+        view.setStartGameAction(() -> callCount[0]++);
+        view.clickStartGame();
+
+        int expected = 1;
+        int actual = callCount[0];
+        assertEquals(expected, actual);
+    }
 }

--- a/src/test/java/ui/WelcomeViewTest.java
+++ b/src/test/java/ui/WelcomeViewTest.java
@@ -11,7 +11,6 @@ class WelcomeViewTest {
 
     @BeforeAll
     static void requireDisplay() {
-        System.setProperty("java.awt.headless", "false");
         assumeTrue(
             !GraphicsEnvironment.getLocalGraphicsEnvironment().isHeadless(),
             "Skipping WelcomeView tests: no display available");

--- a/src/test/java/ui/WelcomeViewTest.java
+++ b/src/test/java/ui/WelcomeViewTest.java
@@ -44,4 +44,14 @@ class WelcomeViewTest {
         String actual = view.getPlayer1Name();
         assertEquals(expected, actual);
     }
+
+    @Test
+    void GetPlayer2Name_WhenFieldHasText_ReturnsEnteredName() {
+        WelcomeView view = new WelcomeView();
+        view.setPlayer2Name("Bob");
+
+        String expected = "Bob";
+        String actual = view.getPlayer2Name();
+        assertEquals(expected, actual);
+    }
 }


### PR DESCRIPTION
## Description

This PR implements `WelcomeView`, a `JFrame` that collects player names and game mode before starting a game. The constructor initializes `player1NameField`, `player2NameField`, `standardRadioButton`, and `chess960RadioButton`, with Standard selected by default. `createWelcomeScreenUI` assembles a dark-themed 600×600 Swing layout and wires the Start Game button — it is excluded from BVA as untestable. `WelcomeView` has no project-level dependencies.

## Type of Change

- [x] Feature (new functionality)
- [ ] Bug fix
- [x] Documentation update
- [ ] Refactor
- [x] Test addition/update

## Related Work

Related to `docs/bva/WelcomeView.md` and `docs/design/chess-full-design.puml`. No upstream PR dependencies — `WelcomeView` has no project-level dependencies.

## Changes Made

- [x] Created placeholder `README.md` in `src/main/java/ui/` to mark the branch
- [x] `WelcomeView` class in `src/main/java/ui/WelcomeView.java`
- [x] Selected `WelcomeView` methods determined by BVA analysis and added via TDD commits
- [x] Updated `docs/design/chess-full-design.puml` to add `WelcomeView` fields and methods

## BVA & Testing

- BVA documented in: `docs/bva/WelcomeView.md`
- Test cases implemented: **WV-TC1–WV-TC8**
- All tests passing: [x]

## Design Alignment

- [x] Changes align with `docs/design/chess-full-design.puml`
- [x] No breaking changes to existing methods
- [x] New methods follow the established patterns

## Implementation Notes

- `WelcomeView` extends `JFrame` and lives in the `ui` package per the design
- `WelcomeView` holds `player1NameField`/`player2NameField` as `JTextField` and `standardRadioButton`/`chess960RadioButton` as `JRadioButton` in a `ButtonGroup` (Standard selected by default)
- `isChess960Selected()` delegates to `chess960RadioButton.isSelected()`
- `setStartGameAction(Runnable)` registers the action; `clickStartGame()` (package-private) fires it — used by tests and by the Start Game button listener
- `createWelcomeScreenUI` assembles the Swing layout and is excluded from BVA as untestable
- Tests use a headless guard (`assumeTrue(!GraphicsEnvironment.isHeadless())`) so they skip cleanly on CI and run locally
- `WelcomeView` has no dependencies on domain classes

## Checklist

- [x] BVA analysis is documented
- [x] TDD workflow followed (tests before code)
- [x] Code compiles and all tests pass
- [x] No new compiler warnings
- [x] Documentation updated (if applicable)
- [x] Commit messages are clear and follow TDD workflow
