### PR TITLE
[FEAT] Move Board Piece

### DIFF
--- a/docs/bva/Bishop.md
+++ b/docs/bva/Bishop.md
@@ -82,3 +82,26 @@
   - **Expected output**: returned piece is a different object from the original
 
 ---
+
+## Method: `isValidMoveShape(Location from, Location to)`
+
+### Step 1-3: Analysis
+
+| Parameter | Catalog clue | Values considered |
+|-----------|--------------|-------------------|
+| Input: absolute displacement | Cases | equal row/col non-zero, other invalid |
+| Output: return value | Boolean | `true`, `false` |
+
+### Step 4: Test Cases (Catalog-aligned Each-Choice Strategy)
+
+- **TC9: IsValidMoveShape_OnBishop_DiagonalMoveIsTrue** ( :x: )
+  - **Method(s) under test**: `isValidMoveShape(Location from, Location to)`
+  - **State of the system**: bishop; `from = Location(2, 7)`, `to = Location(5, 4)`
+  - **Expected output**: returns `true`
+
+- **TC10: IsValidMoveShape_OnBishop_HorizontalMoveIsFalse** ( :x: )
+  - **Method(s) under test**: `isValidMoveShape(Location from, Location to)`
+  - **State of the system**: bishop; `from = Location(2, 7)`, `to = Location(5, 7)`
+  - **Expected output**: returns `false`
+
+---

--- a/docs/bva/Bishop.md
+++ b/docs/bva/Bishop.md
@@ -99,7 +99,7 @@
   - **State of the system**: bishop; `from = Location(2, 7)`, `to = Location(5, 4)`
   - **Expected output**: returns `true`
 
-- **TC10: IsValidMoveShape_OnBishop_HorizontalMoveIsFalse** ( :x: )
+- **TC10: IsValidMoveShape_OnBishop_HorizontalMoveIsFalse** ( :white_check_mark: )
   - **Method(s) under test**: `isValidMoveShape(Location from, Location to)`
   - **State of the system**: bishop; `from = Location(2, 7)`, `to = Location(5, 7)`
   - **Expected output**: returns `false`

--- a/docs/bva/Bishop.md
+++ b/docs/bva/Bishop.md
@@ -94,7 +94,7 @@
 
 ### Step 4: Test Cases (Catalog-aligned Each-Choice Strategy)
 
-- **TC9: IsValidMoveShape_OnBishop_DiagonalMoveIsTrue** ( :x: )
+- **TC9: IsValidMoveShape_OnBishop_DiagonalMoveIsTrue** ( :white_check_mark: )
   - **Method(s) under test**: `isValidMoveShape(Location from, Location to)`
   - **State of the system**: bishop; `from = Location(2, 7)`, `to = Location(5, 4)`
   - **Expected output**: returns `true`

--- a/docs/bva/Board.md
+++ b/docs/bva/Board.md
@@ -591,12 +591,12 @@ Scope: **Make a Legal Move (phase 1)** — domain execution only. Validates in o
 
 ### Step 4: Test Cases (Each-Choice Strategy)
 
-- **TC50: MovePiece_LegalPawnForwardOneToEmptySquare_ReturnsTrue** ( :x: )
+- **TC50: MovePiece_LegalPawnForwardOneToEmptySquare_ReturnsTrue** ( :white_check_mark: )
   - **Method(s) under test**: `movePiece(Location, Location)`
   - **State of the system**: `Board(Piece[][])` with `Pawn(WHITE)` at `[6][4]`, all other cells `NonePiece`; `WHITE_TURN`; `from = Location(4, 6)`, `to = Location(4, 5)`
   - **Expected output**: return value is `true`
 
-- **TC51: MovePiece_LegalPawnForwardOneToEmptySquare_OriginBecomesNone** ( :x: )
+- **TC51: MovePiece_LegalPawnForwardOneToEmptySquare_OriginBecomesNone** ( :white_check_mark: )
   - **Method(s) under test**: `movePiece(Location, Location)`
   - **State of the system**: same as TC50
   - **Expected output**: `getPieceAt(6, 4).getType()` is `NONE` after the call

--- a/docs/bva/Board.md
+++ b/docs/bva/Board.md
@@ -12,17 +12,18 @@
 
 ### Step 2: Data Types (from BVA Catalog)
 
-| Equivalence class                              | Catalog data type | Parameters                                    |
-| ---------------------------------------------- | ----------------- | --------------------------------------------- |
-| Input: piece type returned by initializer      | Cases             | ROOK, KNIGHT, BISHOP, QUEEN, KING, PAWN, NONE |
-| Input: position half                           | Cases             | top (rows 0–3), bottom (rows 4–7)             |
-| Output: piece type at position                 | Cases             | ROOK, KNIGHT, BISHOP, QUEEN, KING, PAWN, NONE |
-| Output: piece color at an occupied position    | Cases             | BLACK, WHITE                                  |
-| Output: initial game state                     | Cases             | WHITE_TURN                                    |
+| Equivalence class                           | Catalog data type | Parameters                                    |
+| ------------------------------------------- | ----------------- | --------------------------------------------- |
+| Input: piece type returned by initializer   | Cases             | ROOK, KNIGHT, BISHOP, QUEEN, KING, PAWN, NONE |
+| Input: position half                        | Cases             | top (rows 0–3), bottom (rows 4–7)             |
+| Output: piece type at position              | Cases             | ROOK, KNIGHT, BISHOP, QUEEN, KING, PAWN, NONE |
+| Output: piece color at an occupied position | Cases             | BLACK, WHITE                                  |
+| Output: initial game state                  | Cases             | WHITE_TURN                                    |
 
 ### Step 3: Boundary Values (from BVA Catalog)
 
 **Piece types — Cases:**
+
 - ROOK
 - KNIGHT
 - BISHOP
@@ -32,14 +33,17 @@
 - NONE
 
 **Position half — Cases:**
+
 - top (rows 0–3)
 - bottom (rows 4–7)
 
 **Piece color — Cases:**
+
 - BLACK
 - WHITE
 
 **Game state — Cases:**
+
 - WHITE_TURN
 
 ### Step 4: Test Cases (Each-Choice Strategy)
@@ -123,19 +127,20 @@
 
 ### Step 2: Data Types (from BVA Catalog)
 
-| Equivalence class | Catalog data type | Parameters |
-| --- | --- | --- |
-| Input: piece type of the `Piece` at each position | Cases | ROOK, KNIGHT, BISHOP, QUEEN, KING, PAWN, NONE |
-| Input: piece color of the `Piece` at each position | Cases | BLACK, WHITE |
-| Input: row of each piece | Interval | [0, 7] |
-| Input: column of each piece | Interval | [0, 7] |
-| Output: piece type at position | Cases | ROOK, KNIGHT, BISHOP, QUEEN, KING, PAWN, NONE |
-| Output: piece color at position | Cases | BLACK, WHITE |
-| Output: initial game state | Cases | WHITE_TURN |
+| Equivalence class                                  | Catalog data type | Parameters                                    |
+| -------------------------------------------------- | ----------------- | --------------------------------------------- |
+| Input: piece type of the `Piece` at each position  | Cases             | ROOK, KNIGHT, BISHOP, QUEEN, KING, PAWN, NONE |
+| Input: piece color of the `Piece` at each position | Cases             | BLACK, WHITE                                  |
+| Input: row of each piece                           | Interval          | [0, 7]                                        |
+| Input: column of each piece                        | Interval          | [0, 7]                                        |
+| Output: piece type at position                     | Cases             | ROOK, KNIGHT, BISHOP, QUEEN, KING, PAWN, NONE |
+| Output: piece color at position                    | Cases             | BLACK, WHITE                                  |
+| Output: initial game state                         | Cases             | WHITE_TURN                                    |
 
 ### Step 3: Boundary Values (from BVA Catalog)
 
 **Piece types — Cases:**
+
 - ROOK
 - KNIGHT
 - BISHOP
@@ -145,16 +150,20 @@
 - NONE
 
 **Piece colors — Cases:**
+
 - BLACK
 - WHITE
 
 **Row — Interval [0, 7]:**
+
 - 0 (min), 7 (max)
 
 **Column — Interval [0, 7]:**
+
 - 0 (min), 7 (max)
 
 **Game state — Cases:**
+
 - WHITE_TURN
 
 ### Step 4: Test Cases (Each-Choice Strategy)
@@ -235,19 +244,21 @@
 
 ### Step 2: Data Types (from BVA Catalog)
 
-| Equivalence class              | Catalog data type | Parameters                                    |
-| ------------------------------ | ----------------- | --------------------------------------------- |
-| Input: piece type              | Cases             | ROOK, KNIGHT, BISHOP, QUEEN, KING, PAWN, NONE |
-| Input: piece color             | Cases             | BLACK, WHITE                                  |
-| Output: returned piece type    | Cases             | ROOK, KNIGHT, BISHOP, QUEEN, KING, PAWN, NONE |
-| Output: returned piece color   | Cases             | BLACK, WHITE                                  |
+| Equivalence class            | Catalog data type | Parameters                                    |
+| ---------------------------- | ----------------- | --------------------------------------------- |
+| Input: piece type            | Cases             | ROOK, KNIGHT, BISHOP, QUEEN, KING, PAWN, NONE |
+| Input: piece color           | Cases             | BLACK, WHITE                                  |
+| Output: returned piece type  | Cases             | ROOK, KNIGHT, BISHOP, QUEEN, KING, PAWN, NONE |
+| Output: returned piece color | Cases             | BLACK, WHITE                                  |
 
 ### Step 3: Boundary Values (from BVA Catalog)
 
 **Piece types — Cases:**
+
 - ROOK, KNIGHT, BISHOP, QUEEN, KING, PAWN, NONE
 
 **Piece colors — Cases:**
+
 - BLACK, WHITE
 
 ### Step 4: Test Cases (Each-Choice Strategy)
@@ -295,20 +306,22 @@
 
 ### Step 2: Data Types (from BVA Catalog)
 
-| Equivalence class                        | Catalog data type      | Parameters                                                       |
-| ---------------------------------------- | ---------------------- | ---------------------------------------------------------------- |
-| Output: returned outer array vs internal | Pairs of references    | two references should refer to different objects                 |
-| Output: returned row array vs internal   | Pairs of references    | two references should refer to different objects                 |
+| Equivalence class                        | Catalog data type      | Parameters                                                          |
+| ---------------------------------------- | ---------------------- | ------------------------------------------------------------------- |
+| Output: returned outer array vs internal | Pairs of references    | two references should refer to different objects                    |
+| Output: returned row array vs internal   | Pairs of references    | two references should refer to different objects                    |
 | Output: returned Piece vs internal       | Pairs of references    | two references should refer to different objects with same contents |
-| Output: snapshot content                 | Collections (contents) | snapshot matches current board state                             |
+| Output: snapshot content                 | Collections (contents) | snapshot matches current board state                                |
 
 ### Step 3: Boundary Values (from BVA Catalog)
 
 **Pairs of references:**
+
 - Two references refer to the same object (should NOT happen — this is what we test against)
 - Two reference arguments refer to different objects with the same contents (should happen)
 
 **Collections (contents):**
+
 - Collection contains the expected elements (content matches board state)
 
 ### Step 4: Test Cases (Each-Choice Strategy)
@@ -357,6 +370,7 @@ Note: `WHITE_WIN`, `BLACK_WIN`, and `DRAW` are reachable only through game-logic
 ### Step 3: Boundary Values (from BVA Catalog)
 
 **Game state — Cases:**
+
 - WHITE_TURN (first possibility)
 - BLACK_TURN (second possibility)
 
@@ -392,10 +406,12 @@ Note: `WHITE_WIN`, `BLACK_WIN`, and `DRAW` are reachable only through game-logic
 ### Step 3: Boundary Values (from BVA Catalog)
 
 **Input game state — Cases:**
+
 - WHITE_TURN (first possibility)
 - BLACK_TURN (second possibility)
 
 **Output game state — Cases:**
+
 - BLACK_TURN (first possibility)
 - WHITE_TURN (second possibility)
 
@@ -426,29 +442,34 @@ Note: `WHITE_WIN`, `BLACK_WIN`, and `DRAW` are reachable only through game-logic
 
 ### Step 2: Data Types (from BVA Catalog)
 
-| Equivalence class                          | Catalog data type   | Parameters                                    |
-| ------------------------------------------ | ------------------- | --------------------------------------------- |
-| Input: rank                                | Interval            | [0, 7]                                        |
-| Input: file                                | Interval            | [0, 7]                                        |
-| Output: piece type at (rank, file)         | Cases               | ROOK, KNIGHT, BISHOP, QUEEN, KING, PAWN, NONE |
-| Output: piece color at (rank, file)        | Cases               | BLACK, WHITE                                  |
-| Output: returned piece vs internal piece   | Pairs of references | two references should refer to different objects with same contents |
+| Equivalence class                        | Catalog data type   | Parameters                                                          |
+| ---------------------------------------- | ------------------- | ------------------------------------------------------------------- |
+| Input: rank                              | Interval            | [0, 7]                                                              |
+| Input: file                              | Interval            | [0, 7]                                                              |
+| Output: piece type at (rank, file)       | Cases               | ROOK, KNIGHT, BISHOP, QUEEN, KING, PAWN, NONE                       |
+| Output: piece color at (rank, file)      | Cases               | BLACK, WHITE                                                        |
+| Output: returned piece vs internal piece | Pairs of references | two references should refer to different objects with same contents |
 
 ### Step 3: Boundary Values (from BVA Catalog)
 
 **Rank — Interval [0, 7]:**
+
 - 0 (min), 7 (max)
 
 **File — Interval [0, 7]:**
+
 - 0 (min), 7 (max)
 
 **Piece type — Cases:**
+
 - ROOK, KNIGHT, BISHOP, QUEEN, KING, PAWN, NONE
 
 **Piece color — Cases:**
+
 - BLACK, WHITE
 
 **Pairs of references:**
+
 - Two references refer to different objects with the same contents (should happen)
 
 ### Step 4: Test Cases (Each-Choice Strategy)
@@ -509,5 +530,115 @@ Note: `WHITE_WIN`, `BLACK_WIN`, and `DRAW` are reachable only through game-logic
   - **Method(s) under test**: `getPieceAt(int rank, int file)`
   - **State of the system**: board constructed with `Rook(BLACK)` at `[0][0]`; `getPieceAt(0, 0)` called twice
   - **Expected output**: the two returned `Piece` references are not the same object, but have equal type and color
+
+---
+
+## Method: `movePiece(Location from, Location to)`
+
+Scope: **Make a Legal Move (one turn)** — domain execution only. Validates in order: destination not same color → move shape → path clear (non-jumpers) → not moving into check (deferred TCs until king-safety slice). Does **not** call `switchTurn()`; the controller switches turn after `true`. Uses `Board(Piece[][])` for injected layouts. Coordinates: `Location.getX()` is file, `Location.getY()` is rank; `getPieceAt(rank, file)` matches that convention.
+
+### Step 1: Equivalence Classes
+
+- **Input: `from` square** — occupied by moving piece; empty; out of bounds (invalid — not a BVA boundary per project null/out-of-range policy for public APIs if guarded)
+- **Input: `to` square** — empty; occupied by opponent; occupied by friendly; same square as `from`
+- **Input: moving piece type** — pawn, knight, rook, bishop, queen, king (shape and path rules differ)
+- **Input: board layout** — clear path; blocked sliding path; knight jump over piece
+- **Output: return value** — `true` (move applied); `false` (board unchanged)
+- **Output: origin after call** — `NonePiece` on success; unchanged on failure
+- **Output: destination after call** — moving piece on success; unchanged on failure
+- **Output: captured piece** — removed on legal capture; N/A on non-capture
+- **Output: `hasMoved()` on moved piece** — `true` after success
+
+### Step 2: Data Types (from BVA Catalog)
+
+| Equivalence class            | Catalog data type | Parameters                                      |
+| ---------------------------- | ----------------- | ----------------------------------------------- |
+| Input: destination occupancy | Cases             | empty (`NONE`), opponent piece, friendly piece  |
+| Input: move shape validity   | Cases             | valid shape, invalid shape                      |
+| Input: sliding path          | Cases             | clear, blocked                                  |
+| Input: piece jump capability | Boolean           | jumper (`KNIGHT`), non-jumper (sliders)         |
+| Output: return value         | Boolean           | `true`, `false`                                 |
+| Output: origin cell type     | Cases             | `NONE` after success; unchanged type on failure |
+
+### Step 3: Boundary Values (from BVA Catalog)
+
+**Destination occupancy — Cases:**
+
+- Empty square (forward non-capture)
+- Opponent piece (capture)
+- Friendly piece (illegal)
+
+**Move shape — Cases:**
+
+- Valid pawn one-step forward (rank delta 1, same file, from starting rank)
+- Valid knight L-shape `(2,1)` absolute displacement
+- Invalid pawn move (wrong direction or distance for shape-only check)
+
+**Sliding path — Cases:**
+
+- No intervening pieces (rook horizontal move)
+- One intervening piece between rook and destination (blocked)
+
+**Return value — Boolean:**
+
+- `true` (success boundary)
+- `false` (rejection boundary)
+
+### Step 4: Test Cases (Each-Choice Strategy)
+
+- **TC50: MovePiece_LegalPawnForwardOneToEmptySquare_ReturnsTrue** ( :x: )
+  - **Method(s) under test**: `movePiece(Location, Location)`
+  - **State of the system**: `Board(Piece[][])` with `Pawn(WHITE)` at rank 6 file 4, empty at rank 5 file 4; `WHITE_TURN`
+  - **Expected output**: return value is `true`
+
+- **TC51: MovePiece_LegalPawnForwardOneToEmptySquare_OriginBecomesNone** ( :x: )
+  - **Method(s) under test**: `movePiece(Location, Location)`
+  - **State of the system**: same as TC50; `from = Location(4, 6)`, `to = Location(4, 5)`
+  - **Expected output**: `getPieceAt(6, 4).getType()` is `NONE` after the call
+
+- **TC52: MovePiece_LegalPawnForwardOneToEmptySquare_DestinationHasPawn** ( :x: )
+  - **Method(s) under test**: `movePiece(Location, Location)`
+  - **State of the system**: same as TC50
+  - **Expected output**: `getPieceAt(5, 4).getType()` is `PAWN` and color is `WHITE`
+
+- **TC53: MovePiece_LegalPawnForwardOneToEmptySquare_MovedPawnHasMovedTrue** ( :x: )
+  - **Method(s) under test**: `movePiece(Location, Location)`
+  - **State of the system**: same as TC50
+  - **Expected output**: `getPieceAt(5, 4).hasMoved()` is `true`
+
+- **TC54: MovePiece_LegalKnightJumpOverPiece_ReturnsTrue** ( :x: )
+  - **Method(s) under test**: `movePiece(Location, Location)`
+  - **State of the system**: `Knight(WHITE)` at rank 7 file 6 with friendly pawn on rank 6 file 6; empty at rank 5 file 5 (valid L-shape)
+  - **Expected output**: return value is `true`
+
+- **TC55: MovePiece_DestinationOccupiedByFriendlyPiece_ReturnsFalse** ( :x: )
+  - **Method(s) under test**: `movePiece(Location, Location)`
+  - **State of the system**: `Rook(WHITE)` at rank 7 file 0; another `Rook(WHITE)` at rank 7 file 3; empty between them
+  - **Expected output**: return value is `false`
+
+- **TC56: MovePiece_DestinationOccupiedByFriendlyPiece_BoardUnchanged** ( :x: )
+  - **Method(s) under test**: `movePiece(Location, Location)`
+  - **State of the system**: same as TC55; snapshot taken before call
+  - **Expected output**: cell-wise type and color match pre-move snapshot
+
+- **TC57: MovePiece_InvalidMoveShape_ReturnsFalse** ( :x: )
+  - **Method(s) under test**: `movePiece(Location, Location)`
+  - **State of the system**: `Pawn(WHITE)` at rank 6 file 4; empty at rank 4 file 4 (two ranks forward without en passant/double-push rules in scope — illegal shape or blocked per implementation)
+  - **Expected output**: return value is `false`
+
+- **TC58: MovePiece_BlockedRookSlide_ReturnsFalse** ( :x: )
+  - **Method(s) under test**: `movePiece(Location, Location)`
+  - **State of the system**: `Rook(WHITE)` at rank 7 file 0; `Pawn(WHITE)` at rank 7 file 1; empty at rank 7 file 3
+  - **Expected output**: return value is `false`
+
+- **TC59: MovePiece_LegalCapture_RemovesOpponentFromDestination** ( :x: )
+  - **Method(s) under test**: `movePiece(Location, Location)`
+  - **State of the system**: `Pawn(WHITE)` at rank 4 file 4; `Pawn(BLACK)` at rank 3 file 5 (diagonal capture shape); `WHITE_TURN`
+  - **Expected output**: return value is `true`; `getPieceAt(3, 5)` is white pawn; `getPieceAt(4, 4)` is `NONE`
+
+- **TC60: MovePiece_AfterFailedMove_GameStateUnchanged** ( :x: )
+  - **Method(s) under test**: `movePiece(Location, Location)`, `getCurrentGameState()`
+  - **State of the system**: same as TC55 (friendly destination)
+  - **Expected output**: `getCurrentGameState()` still `WHITE_TURN` (movePiece does not switch turn)
 
 ---

--- a/docs/bva/Board.md
+++ b/docs/bva/Board.md
@@ -641,7 +641,7 @@ Scope: **Make a Legal Move (phase 1)** — domain execution only. Validates in o
   - **State of the system**: `Board(Piece[][])` with `Rook(WHITE)` at `[7][0]`, empty at `[7][3]`, all other cells `NonePiece`; `WHITE_TURN`; `from = Location(0, 7)`, `to = Location(3, 7)`
   - **Expected output**: return value is `true`
 
-- **TC60: MovePiece_LegalCapture_ReturnsTrue** ( :x: )
+- **TC60: MovePiece_LegalCapture_ReturnsTrue** ( :white_check_mark: )
   - **Method(s) under test**: `movePiece(Location, Location)`
   - **State of the system**: `Board(Piece[][])` with `Pawn(WHITE)` at `[4][4]`, `Pawn(BLACK)` at `[3][5]`, all other cells `NonePiece`; `WHITE_TURN`; `from = Location(4, 4)`, `to = Location(5, 3)`
   - **Expected output**: return value is `true`

--- a/docs/bva/Board.md
+++ b/docs/bva/Board.md
@@ -606,7 +606,7 @@ Scope: **Make a Legal Move (phase 1)** — domain execution only. Validates in o
   - **State of the system**: same as TC50
   - **Expected output**: `getPieceAt(5, 4).getType()` is `PAWN` and color is `WHITE`
 
-- **TC53: MovePiece_LegalPawnForwardOneToEmptySquare_MovedPawnHasMovedTrue** ( :x: )
+- **TC53: MovePiece_LegalPawnForwardOneToEmptySquare_MovedPawnHasMovedTrue** ( :white_check_mark: )
   - **Method(s) under test**: `movePiece(Location, Location)`
   - **State of the system**: same as TC50
   - **Expected output**: `getPieceAt(5, 4).hasMoved()` is `true`

--- a/docs/bva/Board.md
+++ b/docs/bva/Board.md
@@ -626,7 +626,7 @@ Scope: **Make a Legal Move (phase 1)** — domain execution only. Validates in o
   - **State of the system**: same as TC55; `getSnapshot()` taken before `movePiece`
   - **Expected output**: cell-wise type and color match pre-move snapshot
 
-- **TC57: MovePiece_InvalidMoveShape_ReturnsFalse** ( :x: )
+- **TC57: MovePiece_InvalidMoveShape_ReturnsFalse** ( :white_check_mark: )
   - **Method(s) under test**: `movePiece(Location, Location)`
   - **State of the system**: `Board(Piece[][])` with `Pawn(WHITE)` at `[6][4]`, empty at `[6][5]`, all other cells `NonePiece`; `WHITE_TURN`; `from = Location(4, 6)`, `to = Location(5, 6)` (sideways move; pawn `isValidMoveShape` is `false`)
   - **Expected output**: return value is `false` (rejected at step 2: invalid move shape)

--- a/docs/bva/Board.md
+++ b/docs/bva/Board.md
@@ -616,7 +616,7 @@ Scope: **Make a Legal Move (phase 1)** — domain execution only. Validates in o
   - **State of the system**: `Board(Piece[][])` with `Knight(WHITE)` at `[7][6]`, `Pawn(WHITE)` at `[6][6]`, all other cells `NonePiece`; `WHITE_TURN`; `from = Location(6, 7)`, `to = Location(5, 5)` (absolute displacement `(1, 2)`)
   - **Expected output**: return value is `true`
 
-- **TC55: MovePiece_DestinationOccupiedByFriendlyPiece_ReturnsFalse** ( :x: )
+- **TC55: MovePiece_DestinationOccupiedByFriendlyPiece_ReturnsFalse** ( :white_check_mark: )
   - **Method(s) under test**: `movePiece(Location, Location)`
   - **State of the system**: `Board(Piece[][])` with `Rook(WHITE)` at `[7][0]`, `Rook(WHITE)` at `[7][3]`, all other cells `NonePiece`; `WHITE_TURN`; `from = Location(0, 7)`, `to = Location(3, 7)`
   - **Expected output**: return value is `false` (rejected at step 1: destination same color)

--- a/docs/bva/Board.md
+++ b/docs/bva/Board.md
@@ -656,7 +656,7 @@ Scope: **Make a Legal Move (phase 1)** — domain execution only. Validates in o
   - **State of the system**: same as TC60
   - **Expected output**: `getPieceAt(3, 5).getType()` is `PAWN` and color is `WHITE`
 
-- **TC63: MovePiece_AfterFailedMove_GameStateUnchanged** ( :x: )
+- **TC63: MovePiece_AfterFailedMove_GameStateUnchanged** ( :white_check_mark: )
   - **Method(s) under test**: `movePiece(Location, Location)`, `getCurrentGameState()`
   - **State of the system**: same as TC55; `from = Location(0, 7)`, `to = Location(3, 7)`
   - **Expected output**: `getCurrentGameState()` is still `WHITE_TURN` after the failed move

--- a/docs/bva/Board.md
+++ b/docs/bva/Board.md
@@ -348,7 +348,7 @@
 
 - **TC35: GetSnapshot_ModifySnapshotDoesNotAffectBoard** ( :white_check_mark: )
   - **Method(s) under test**: `getSnapshot()`
-  - **State of the system**: a board constructed with `StandardBoardInitializer`; set `getSnapshot()[7][0]` to `null`
+  - **State of the system**: a board constructed with `StandardBoardInitializer`; replace `getSnapshot()[7][0]` with `new NonePiece()`
   - **Expected output**: a subsequent `getSnapshot()[7][0]` still has type `ROOK` and color `WHITE`
 
 ---
@@ -535,19 +535,22 @@ Note: `WHITE_WIN`, `BLACK_WIN`, and `DRAW` are reachable only through game-logic
 
 ## Method: `movePiece(Location from, Location to)`
 
-Scope: **Make a Legal Move (one turn)** — domain execution only. Validates in order: destination not same color → move shape → path clear (non-jumpers) → not moving into check (deferred TCs until king-safety slice). Does **not** call `switchTurn()`; the controller switches turn after `true`. Uses `Board(Piece[][])` for injected layouts. Coordinates: `Location.getX()` is file, `Location.getY()` is rank; `getPieceAt(rank, file)` matches that convention.
+Scope: **Make a Legal Move (phase 1)** — domain execution only. Validates in order: destination not same color → move shape → path clear (non-jumpers) → not moving into check (stubbed or vacuous in this slice; king-safety TCs come later). Does **not** call `switchTurn()`; the controller switches turn after `true`. Uses `Board(Piece[][])` for injected layouts; layouts omit kings so `checkNotMoveIntoCheck` is not exercised until a later slice. Coordinates: `Location.getX()` is file, `Location.getY()` is rank; `getPieceAt(rank, file)` matches that convention.
+
+**Deferred to later slices (no TC in this section):** empty `from`, same-square move, out-of-bounds `Location`, wrong turn, pawn double-push, en passant, promotion, castling, win/draw state updates.
 
 ### Step 1: Equivalence Classes
 
-- **Input: `from` square** — occupied by moving piece; empty; out of bounds (invalid — not a BVA boundary per project null/out-of-range policy for public APIs if guarded)
-- **Input: `to` square** — empty; occupied by opponent; occupied by friendly; same square as `from`
-- **Input: moving piece type** — pawn, knight, rook, bishop, queen, king (shape and path rules differ)
-- **Input: board layout** — clear path; blocked sliding path; knight jump over piece
+- **Input: `from` square** — occupied by the moving piece
+- **Input: `to` square** — empty; occupied by opponent; occupied by friendly
+- **Input: moving piece type** — pawn, knight, rook (shape and path rules differ in this slice)
+- **Input: board layout** — clear sliding path; blocked sliding path; knight jump over piece
 - **Output: return value** — `true` (move applied); `false` (board unchanged)
 - **Output: origin after call** — `NonePiece` on success; unchanged on failure
 - **Output: destination after call** — moving piece on success; unchanged on failure
-- **Output: captured piece** — removed on legal capture; N/A on non-capture
+- **Output: captured piece** — opponent removed on legal capture; N/A on non-capture
 - **Output: `hasMoved()` on moved piece** — `true` after success
+- **Output: game state** — unchanged by `movePiece` on both success and failure in this slice
 
 ### Step 2: Data Types (from BVA Catalog)
 
@@ -559,6 +562,7 @@ Scope: **Make a Legal Move (one turn)** — domain execution only. Validates in 
 | Input: piece jump capability | Boolean           | jumper (`KNIGHT`), non-jumper (sliders)         |
 | Output: return value         | Boolean           | `true`, `false`                                 |
 | Output: origin cell type     | Cases             | `NONE` after success; unchanged type on failure |
+| Output: game state           | Cases             | unchanged (`WHITE_TURN` in these TCs)           |
 
 ### Step 3: Boundary Values (from BVA Catalog)
 
@@ -570,13 +574,14 @@ Scope: **Make a Legal Move (one turn)** — domain execution only. Validates in 
 
 **Move shape — Cases:**
 
-- Valid pawn one-step forward (rank delta 1, same file, from starting rank)
+- Valid pawn one-step forward (rank delta 1 toward rank 0, same file)
+- Valid pawn diagonal capture (rank delta 1, file delta 1, opponent on destination)
 - Valid knight L-shape `(2,1)` absolute displacement
-- Invalid pawn move (wrong direction or distance for shape-only check)
+- Invalid pawn sideways move to empty square (`isValidMoveShape` returns `false` at step 2)
 
 **Sliding path — Cases:**
 
-- No intervening pieces (rook horizontal move)
+- No intervening pieces (rook horizontal slide to empty square)
 - One intervening piece between rook and destination (blocked)
 
 **Return value — Boolean:**
@@ -588,12 +593,12 @@ Scope: **Make a Legal Move (one turn)** — domain execution only. Validates in 
 
 - **TC50: MovePiece_LegalPawnForwardOneToEmptySquare_ReturnsTrue** ( :x: )
   - **Method(s) under test**: `movePiece(Location, Location)`
-  - **State of the system**: `Board(Piece[][])` with `Pawn(WHITE)` at rank 6 file 4, empty at rank 5 file 4; `WHITE_TURN`
+  - **State of the system**: `Board(Piece[][])` with `Pawn(WHITE)` at `[6][4]`, all other cells `NonePiece`; `WHITE_TURN`; `from = Location(4, 6)`, `to = Location(4, 5)`
   - **Expected output**: return value is `true`
 
 - **TC51: MovePiece_LegalPawnForwardOneToEmptySquare_OriginBecomesNone** ( :x: )
   - **Method(s) under test**: `movePiece(Location, Location)`
-  - **State of the system**: same as TC50; `from = Location(4, 6)`, `to = Location(4, 5)`
+  - **State of the system**: same as TC50
   - **Expected output**: `getPieceAt(6, 4).getType()` is `NONE` after the call
 
 - **TC52: MovePiece_LegalPawnForwardOneToEmptySquare_DestinationHasPawn** ( :x: )
@@ -608,37 +613,52 @@ Scope: **Make a Legal Move (one turn)** — domain execution only. Validates in 
 
 - **TC54: MovePiece_LegalKnightJumpOverPiece_ReturnsTrue** ( :x: )
   - **Method(s) under test**: `movePiece(Location, Location)`
-  - **State of the system**: `Knight(WHITE)` at rank 7 file 6 with friendly pawn on rank 6 file 6; empty at rank 5 file 5 (valid L-shape)
+  - **State of the system**: `Board(Piece[][])` with `Knight(WHITE)` at `[7][6]`, `Pawn(WHITE)` at `[6][6]`, all other cells `NonePiece`; `WHITE_TURN`; `from = Location(6, 7)`, `to = Location(5, 5)` (absolute displacement `(1, 2)`)
   - **Expected output**: return value is `true`
 
 - **TC55: MovePiece_DestinationOccupiedByFriendlyPiece_ReturnsFalse** ( :x: )
   - **Method(s) under test**: `movePiece(Location, Location)`
-  - **State of the system**: `Rook(WHITE)` at rank 7 file 0; another `Rook(WHITE)` at rank 7 file 3; empty between them
-  - **Expected output**: return value is `false`
+  - **State of the system**: `Board(Piece[][])` with `Rook(WHITE)` at `[7][0]`, `Rook(WHITE)` at `[7][3]`, all other cells `NonePiece`; `WHITE_TURN`; `from = Location(0, 7)`, `to = Location(3, 7)`
+  - **Expected output**: return value is `false` (rejected at step 1: destination same color)
 
 - **TC56: MovePiece_DestinationOccupiedByFriendlyPiece_BoardUnchanged** ( :x: )
   - **Method(s) under test**: `movePiece(Location, Location)`
-  - **State of the system**: same as TC55; snapshot taken before call
+  - **State of the system**: same as TC55; `getSnapshot()` taken before `movePiece`
   - **Expected output**: cell-wise type and color match pre-move snapshot
 
 - **TC57: MovePiece_InvalidMoveShape_ReturnsFalse** ( :x: )
   - **Method(s) under test**: `movePiece(Location, Location)`
-  - **State of the system**: `Pawn(WHITE)` at rank 6 file 4; empty at rank 4 file 4 (two ranks forward without en passant/double-push rules in scope — illegal shape or blocked per implementation)
-  - **Expected output**: return value is `false`
+  - **State of the system**: `Board(Piece[][])` with `Pawn(WHITE)` at `[6][4]`, empty at `[6][5]`, all other cells `NonePiece`; `WHITE_TURN`; `from = Location(4, 6)`, `to = Location(5, 6)` (sideways move; pawn `isValidMoveShape` is `false`)
+  - **Expected output**: return value is `false` (rejected at step 2: invalid move shape)
 
 - **TC58: MovePiece_BlockedRookSlide_ReturnsFalse** ( :x: )
   - **Method(s) under test**: `movePiece(Location, Location)`
-  - **State of the system**: `Rook(WHITE)` at rank 7 file 0; `Pawn(WHITE)` at rank 7 file 1; empty at rank 7 file 3
-  - **Expected output**: return value is `false`
+  - **State of the system**: `Board(Piece[][])` with `Rook(WHITE)` at `[7][0]`, `Pawn(WHITE)` at `[7][1]`, empty at `[7][3]`, all other cells `NonePiece`; `WHITE_TURN`; `from = Location(0, 7)`, `to = Location(3, 7)` (valid rook shape, blocked path)
+  - **Expected output**: return value is `false` (rejected at step 3: obstacle on path)
 
-- **TC59: MovePiece_LegalCapture_RemovesOpponentFromDestination** ( :x: )
+- **TC59: MovePiece_LegalRookSlideToEmptySquare_ReturnsTrue** ( :x: )
   - **Method(s) under test**: `movePiece(Location, Location)`
-  - **State of the system**: `Pawn(WHITE)` at rank 4 file 4; `Pawn(BLACK)` at rank 3 file 5 (diagonal capture shape); `WHITE_TURN`
-  - **Expected output**: return value is `true`; `getPieceAt(3, 5)` is white pawn; `getPieceAt(4, 4)` is `NONE`
+  - **State of the system**: `Board(Piece[][])` with `Rook(WHITE)` at `[7][0]`, empty at `[7][3]`, all other cells `NonePiece`; `WHITE_TURN`; `from = Location(0, 7)`, `to = Location(3, 7)`
+  - **Expected output**: return value is `true`
 
-- **TC60: MovePiece_AfterFailedMove_GameStateUnchanged** ( :x: )
+- **TC60: MovePiece_LegalCapture_ReturnsTrue** ( :x: )
+  - **Method(s) under test**: `movePiece(Location, Location)`
+  - **State of the system**: `Board(Piece[][])` with `Pawn(WHITE)` at `[4][4]`, `Pawn(BLACK)` at `[3][5]`, all other cells `NonePiece`; `WHITE_TURN`; `from = Location(4, 4)`, `to = Location(5, 3)`
+  - **Expected output**: return value is `true`
+
+- **TC61: MovePiece_LegalCapture_OriginBecomesNone** ( :x: )
+  - **Method(s) under test**: `movePiece(Location, Location)`
+  - **State of the system**: same as TC60
+  - **Expected output**: `getPieceAt(4, 4).getType()` is `NONE` after the call
+
+- **TC62: MovePiece_LegalCapture_DestinationHasWhitePawn** ( :x: )
+  - **Method(s) under test**: `movePiece(Location, Location)`
+  - **State of the system**: same as TC60
+  - **Expected output**: `getPieceAt(3, 5).getType()` is `PAWN` and color is `WHITE`
+
+- **TC63: MovePiece_AfterFailedMove_GameStateUnchanged** ( :x: )
   - **Method(s) under test**: `movePiece(Location, Location)`, `getCurrentGameState()`
-  - **State of the system**: same as TC55 (friendly destination)
-  - **Expected output**: `getCurrentGameState()` still `WHITE_TURN` (movePiece does not switch turn)
+  - **State of the system**: same as TC55; `from = Location(0, 7)`, `to = Location(3, 7)`
+  - **Expected output**: `getCurrentGameState()` is still `WHITE_TURN` after the failed move
 
 ---

--- a/docs/bva/Board.md
+++ b/docs/bva/Board.md
@@ -611,7 +611,7 @@ Scope: **Make a Legal Move (phase 1)** — domain execution only. Validates in o
   - **State of the system**: same as TC50
   - **Expected output**: `getPieceAt(5, 4).hasMoved()` is `true`
 
-- **TC54: MovePiece_LegalKnightJumpOverPiece_ReturnsTrue** ( :x: )
+- **TC54: MovePiece_LegalKnightJumpOverPiece_ReturnsTrue** ( :white_check_mark: )
   - **Method(s) under test**: `movePiece(Location, Location)`
   - **State of the system**: `Board(Piece[][])` with `Knight(WHITE)` at `[7][6]`, `Pawn(WHITE)` at `[6][6]`, all other cells `NonePiece`; `WHITE_TURN`; `from = Location(6, 7)`, `to = Location(5, 5)` (absolute displacement `(1, 2)`)
   - **Expected output**: return value is `true`

--- a/docs/bva/Board.md
+++ b/docs/bva/Board.md
@@ -646,12 +646,12 @@ Scope: **Make a Legal Move (phase 1)** — domain execution only. Validates in o
   - **State of the system**: `Board(Piece[][])` with `Pawn(WHITE)` at `[4][4]`, `Pawn(BLACK)` at `[3][5]`, all other cells `NonePiece`; `WHITE_TURN`; `from = Location(4, 4)`, `to = Location(5, 3)`
   - **Expected output**: return value is `true`
 
-- **TC61: MovePiece_LegalCapture_OriginBecomesNone** ( :x: )
+- **TC61: MovePiece_LegalCapture_OriginBecomesNone** ( :white_check_mark: )
   - **Method(s) under test**: `movePiece(Location, Location)`
   - **State of the system**: same as TC60
   - **Expected output**: `getPieceAt(4, 4).getType()` is `NONE` after the call
 
-- **TC62: MovePiece_LegalCapture_DestinationHasWhitePawn** ( :x: )
+- **TC62: MovePiece_LegalCapture_DestinationHasWhitePawn** ( :white_check_mark: )
   - **Method(s) under test**: `movePiece(Location, Location)`
   - **State of the system**: same as TC60
   - **Expected output**: `getPieceAt(3, 5).getType()` is `PAWN` and color is `WHITE`

--- a/docs/bva/Board.md
+++ b/docs/bva/Board.md
@@ -621,7 +621,7 @@ Scope: **Make a Legal Move (phase 1)** — domain execution only. Validates in o
   - **State of the system**: `Board(Piece[][])` with `Rook(WHITE)` at `[7][0]`, `Rook(WHITE)` at `[7][3]`, all other cells `NonePiece`; `WHITE_TURN`; `from = Location(0, 7)`, `to = Location(3, 7)`
   - **Expected output**: return value is `false` (rejected at step 1: destination same color)
 
-- **TC56: MovePiece_DestinationOccupiedByFriendlyPiece_BoardUnchanged** ( :x: )
+- **TC56: MovePiece_DestinationOccupiedByFriendlyPiece_BoardUnchanged** ( :white_check_mark: )
   - **Method(s) under test**: `movePiece(Location, Location)`
   - **State of the system**: same as TC55; `getSnapshot()` taken before `movePiece`
   - **Expected output**: cell-wise type and color match pre-move snapshot

--- a/docs/bva/Board.md
+++ b/docs/bva/Board.md
@@ -636,7 +636,7 @@ Scope: **Make a Legal Move (phase 1)** — domain execution only. Validates in o
   - **State of the system**: `Board(Piece[][])` with `Rook(WHITE)` at `[7][0]`, `Pawn(WHITE)` at `[7][1]`, empty at `[7][3]`, all other cells `NonePiece`; `WHITE_TURN`; `from = Location(0, 7)`, `to = Location(3, 7)` (valid rook shape, blocked path)
   - **Expected output**: return value is `false` (rejected at step 3: obstacle on path)
 
-- **TC59: MovePiece_LegalRookSlideToEmptySquare_ReturnsTrue** ( :x: )
+- **TC59: MovePiece_LegalRookSlideToEmptySquare_ReturnsTrue** ( :white_check_mark: )
   - **Method(s) under test**: `movePiece(Location, Location)`
   - **State of the system**: `Board(Piece[][])` with `Rook(WHITE)` at `[7][0]`, empty at `[7][3]`, all other cells `NonePiece`; `WHITE_TURN`; `from = Location(0, 7)`, `to = Location(3, 7)`
   - **Expected output**: return value is `true`

--- a/docs/bva/Board.md
+++ b/docs/bva/Board.md
@@ -601,7 +601,7 @@ Scope: **Make a Legal Move (phase 1)** — domain execution only. Validates in o
   - **State of the system**: same as TC50
   - **Expected output**: `getPieceAt(6, 4).getType()` is `NONE` after the call
 
-- **TC52: MovePiece_LegalPawnForwardOneToEmptySquare_DestinationHasPawn** ( :x: )
+- **TC52: MovePiece_LegalPawnForwardOneToEmptySquare_DestinationHasPawn** ( :white_check_mark: )
   - **Method(s) under test**: `movePiece(Location, Location)`
   - **State of the system**: same as TC50
   - **Expected output**: `getPieceAt(5, 4).getType()` is `PAWN` and color is `WHITE`

--- a/docs/bva/Board.md
+++ b/docs/bva/Board.md
@@ -631,7 +631,7 @@ Scope: **Make a Legal Move (phase 1)** — domain execution only. Validates in o
   - **State of the system**: `Board(Piece[][])` with `Pawn(WHITE)` at `[6][4]`, empty at `[6][5]`, all other cells `NonePiece`; `WHITE_TURN`; `from = Location(4, 6)`, `to = Location(5, 6)` (sideways move; pawn `isValidMoveShape` is `false`)
   - **Expected output**: return value is `false` (rejected at step 2: invalid move shape)
 
-- **TC58: MovePiece_BlockedRookSlide_ReturnsFalse** ( :x: )
+- **TC58: MovePiece_BlockedRookSlide_ReturnsFalse** ( :white_check_mark: )
   - **Method(s) under test**: `movePiece(Location, Location)`
   - **State of the system**: `Board(Piece[][])` with `Rook(WHITE)` at `[7][0]`, `Pawn(WHITE)` at `[7][1]`, empty at `[7][3]`, all other cells `NonePiece`; `WHITE_TURN`; `from = Location(0, 7)`, `to = Location(3, 7)` (valid rook shape, blocked path)
   - **Expected output**: return value is `false` (rejected at step 3: obstacle on path)

--- a/docs/bva/Board.md
+++ b/docs/bva/Board.md
@@ -119,10 +119,12 @@
 
 - **Input: piece type of the `Piece` at each position** — the `PieceType` held by each object in the array
 - **Input: piece color of the `Piece` at each position** — the `PieceColor` held by each object in the array
+- **Input: moved state of the `Piece` at each position** — whether `hasMoved()` is true or false
 - **Input: row of each piece** — which row (0–7) the piece occupies in the array
 - **Input: column of each piece** — which column (0–7) the piece occupies in the array
 - **Output: piece type at position** — the type of the `Piece` stored on the board after construction
 - **Output: piece color at position** — the color of the `Piece` stored on the board after construction (must equal the input color, not derived from row)
+- **Output: moved state at position** — the `hasMoved()` value stored on the board after construction
 - **Output: initial game state** — the game state immediately after construction
 
 ### Step 2: Data Types (from BVA Catalog)
@@ -131,10 +133,12 @@
 | -------------------------------------------------- | ----------------- | --------------------------------------------- |
 | Input: piece type of the `Piece` at each position  | Cases             | ROOK, KNIGHT, BISHOP, QUEEN, KING, PAWN, NONE |
 | Input: piece color of the `Piece` at each position | Cases             | BLACK, WHITE                                  |
+| Input: moved state of each piece                   | Boolean           | true, false                                   |
 | Input: row of each piece                           | Interval          | [0, 7]                                        |
 | Input: column of each piece                        | Interval          | [0, 7]                                        |
 | Output: piece type at position                     | Cases             | ROOK, KNIGHT, BISHOP, QUEEN, KING, PAWN, NONE |
 | Output: piece color at position                    | Cases             | BLACK, WHITE                                  |
+| Output: moved state at position                    | Boolean           | true, false                                   |
 | Output: initial game state                         | Cases             | WHITE_TURN                                    |
 
 ### Step 3: Boundary Values (from BVA Catalog)
@@ -153,6 +157,11 @@
 
 - BLACK
 - WHITE
+
+**Moved state — Boolean:**
+
+- true
+- false
 
 **Row — Interval [0, 7]:**
 
@@ -230,6 +239,11 @@
   - **State of the system**: `Piece[][]` with a `Rook(BLACK)` at `[0][7]`; all other positions `NonePiece`; board is constructed — covers col 7 (max)
   - **Expected output**: `getSnapshot()[0][7].getType()` equals `ROOK`
   - **Covered by**: TC12 (parameterized test)
+
+- **TC22A: `Constructor_WhenPieceArrayHasMovedPiece_HasMovedIsPreserved`** ( :white_check_mark: )
+  - **Method(s) under test**: `Board(Piece[][])`
+  - **State of the system**: `Piece[][]` with a `Rook(WHITE)` at `[0][0]` whose `hasMoved()` is true; all other positions `NonePiece`; board is constructed
+  - **Expected output**: `getSnapshot()[0][0].hasMoved()` is `true`
 
 ---
 

--- a/docs/bva/King.md
+++ b/docs/bva/King.md
@@ -3,13 +3,14 @@
 ## Design Review Notes
 
 - The design document defines `King` as a subclass of `Piece` with three public methods: `King(PieceColor color)`, `makeCopy()`, and `isValidMoveShape(Location from, Location to)`.
-- The board design notes separate obstacle handling from move-shape validation and model jump capability at the `Piece` level. This BVA analysis focuses on constructor state and copy behavior only.
+- The board design notes separate obstacle handling from move-shape validation and model jump capability at the `Piece` level.
 - The current checkout does not contain the domain implementation, and `docs/requirements/game-rules.md` is still a placeholder. The analysis below uses the UML design plus standard chess rules: a king moves one square in any direction (horizontal, vertical, or diagonal).
 
 ## Specification
 
 - **`public King(PieceColor color)`**: creates a king with the provided color. The created piece has type `KING`, reports the same color through `getColor()`, and reports that it cannot jump through `canJump()`.
 - **`public Piece makeCopy()`**: returns a new `Piece` object representing the same kind of piece as the original king. The returned piece is a distinct object, still has type `KING`, has the same color as the original, and cannot jump.
+- **`public boolean isValidMoveShape(Location from, Location to)`**: returns `true` exactly when the king moves one square horizontally, vertically, or diagonally. Returns `false` for zero displacement and larger displacements.
 
 ---
 
@@ -79,5 +80,28 @@
   - **Method(s) under test**: `makeCopy()`
   - **State of the system**: an existing black king
   - **Expected output**: returned piece is a different object from the original
+
+---
+
+## Method: `isValidMoveShape(Location from, Location to)`
+
+### Step 1-3: Analysis
+
+| Parameter | Catalog clue | Values considered |
+| --------- | ------------ | ----------------- |
+| Input: absolute displacement | Cases | one-square king move, two-or-more-square move |
+| Output: return value | Boolean | `true`, `false` |
+
+### Step 4: Test Cases (Catalog-aligned Each-Choice Strategy)
+
+- **TC8: IsValidMoveShape_OnKing_OneStepDiagonalIsTrue** ( :x: )
+  - **Method(s) under test**: `isValidMoveShape(Location from, Location to)`
+  - **State of the system**: king; `from = Location(4, 7)`, `to = Location(5, 6)`
+  - **Expected output**: returns `true`
+
+- **TC9: IsValidMoveShape_OnKing_TwoStepMoveIsFalse** ( :x: )
+  - **Method(s) under test**: `isValidMoveShape(Location from, Location to)`
+  - **State of the system**: king; `from = Location(4, 7)`, `to = Location(4, 5)`
+  - **Expected output**: returns `false`
 
 ---

--- a/docs/bva/King.md
+++ b/docs/bva/King.md
@@ -94,7 +94,7 @@
 
 ### Step 4: Test Cases (Catalog-aligned Each-Choice Strategy)
 
-- **TC8: IsValidMoveShape_OnKing_OneStepDiagonalIsTrue** ( :x: )
+- **TC8: IsValidMoveShape_OnKing_OneStepDiagonalIsTrue** ( :white_check_mark: )
   - **Method(s) under test**: `isValidMoveShape(Location from, Location to)`
   - **State of the system**: king; `from = Location(4, 7)`, `to = Location(5, 6)`
   - **Expected output**: returns `true`

--- a/docs/bva/King.md
+++ b/docs/bva/King.md
@@ -99,7 +99,7 @@
   - **State of the system**: king; `from = Location(4, 7)`, `to = Location(5, 6)`
   - **Expected output**: returns `true`
 
-- **TC9: IsValidMoveShape_OnKing_TwoStepMoveIsFalse** ( :x: )
+- **TC9: IsValidMoveShape_OnKing_TwoStepMoveIsFalse** ( :white_check_mark: )
   - **Method(s) under test**: `isValidMoveShape(Location from, Location to)`
   - **State of the system**: king; `from = Location(4, 7)`, `to = Location(4, 5)`
   - **Expected output**: returns `false`

--- a/docs/bva/Knight.md
+++ b/docs/bva/Knight.md
@@ -104,7 +104,7 @@
   - **State of the system**: knight; `from = Location(6, 7)`, `to = Location(4, 6)`
   - **Expected output**: returns `true`
 
-- **TC11: IsValidMoveShape_OnKnight_StraightMoveIsFalse** ( :x: )
+- **TC11: IsValidMoveShape_OnKnight_StraightMoveIsFalse** ( :white_check_mark: )
   - **Method(s) under test**: `isValidMoveShape(Location from, Location to)`
   - **State of the system**: knight; `from = Location(6, 7)`, `to = Location(6, 5)`
   - **Expected output**: returns `false`

--- a/docs/bva/Knight.md
+++ b/docs/bva/Knight.md
@@ -99,7 +99,7 @@
   - **State of the system**: knight; `from = Location(6, 7)`, `to = Location(5, 5)`
   - **Expected output**: returns `true`
 
-- **TC10: IsValidMoveShape_OnKnight_OneTwoMoveIsTrue** ( :x: )
+- **TC10: IsValidMoveShape_OnKnight_OneTwoMoveIsTrue** ( :white_check_mark: )
   - **Method(s) under test**: `isValidMoveShape(Location from, Location to)`
   - **State of the system**: knight; `from = Location(6, 7)`, `to = Location(4, 6)`
   - **Expected output**: returns `true`

--- a/docs/bva/Knight.md
+++ b/docs/bva/Knight.md
@@ -94,7 +94,7 @@
 
 ### Step 4: Test Cases (Catalog-aligned Each-Choice Strategy)
 
-- **TC9: IsValidMoveShape_OnKnight_TwoOneMoveIsTrue** ( :x: )
+- **TC9: IsValidMoveShape_OnKnight_TwoOneMoveIsTrue** ( :white_check_mark: )
   - **Method(s) under test**: `isValidMoveShape(Location from, Location to)`
   - **State of the system**: knight; `from = Location(6, 7)`, `to = Location(5, 5)`
   - **Expected output**: returns `true`

--- a/docs/bva/Knight.md
+++ b/docs/bva/Knight.md
@@ -82,3 +82,31 @@
   - **Expected output**: returned piece is a different object from the original
 
 ---
+
+## Method: `isValidMoveShape(Location from, Location to)`
+
+### Step 1-3: Analysis
+
+| Parameter | Catalog clue | Values considered |
+|-----------|--------------|-------------------|
+| Input: absolute displacement | Cases | `(2,1)`, `(1,2)`, other invalid |
+| Output: return value | Boolean | `true`, `false` |
+
+### Step 4: Test Cases (Catalog-aligned Each-Choice Strategy)
+
+- **TC9: IsValidMoveShape_OnKnight_TwoOneMoveIsTrue** ( :x: )
+  - **Method(s) under test**: `isValidMoveShape(Location from, Location to)`
+  - **State of the system**: knight; `from = Location(6, 7)`, `to = Location(5, 5)`
+  - **Expected output**: returns `true`
+
+- **TC10: IsValidMoveShape_OnKnight_OneTwoMoveIsTrue** ( :x: )
+  - **Method(s) under test**: `isValidMoveShape(Location from, Location to)`
+  - **State of the system**: knight; `from = Location(6, 7)`, `to = Location(4, 6)`
+  - **Expected output**: returns `true`
+
+- **TC11: IsValidMoveShape_OnKnight_StraightMoveIsFalse** ( :x: )
+  - **Method(s) under test**: `isValidMoveShape(Location from, Location to)`
+  - **State of the system**: knight; `from = Location(6, 7)`, `to = Location(6, 5)`
+  - **Expected output**: returns `false`
+
+---

--- a/docs/bva/NonePiece.md
+++ b/docs/bva/NonePiece.md
@@ -64,7 +64,7 @@
 
 ### Step 4: Test Cases (Catalog-aligned Each-Choice Strategy)
 
-- **TC6: IsValidMoveShape_OnNonePiece_AnyMoveIsFalse** ( :x: )
+- **TC6: IsValidMoveShape_OnNonePiece_AnyMoveIsFalse** ( :white_check_mark: )
   - **Method(s) under test**: `isValidMoveShape(Location from, Location to)`
   - **State of the system**: `NonePiece`; `from = Location(0, 0)`, `to = Location(0, 1)`
   - **Expected output**: returns `false`

--- a/docs/bva/NonePiece.md
+++ b/docs/bva/NonePiece.md
@@ -52,3 +52,21 @@
   - **Expected output**: returned piece is a different object from the original
 
 ---
+
+## Method: `isValidMoveShape(Location from, Location to)`
+
+### Step 1-3: Analysis
+
+| Parameter | Catalog clue | Values considered |
+|-----------|--------------|-------------------|
+| Input: any displacement | Cases | representative non-zero move |
+| Output: return value | Boolean | `false` only |
+
+### Step 4: Test Cases (Catalog-aligned Each-Choice Strategy)
+
+- **TC6: IsValidMoveShape_OnNonePiece_AnyMoveIsFalse** ( :x: )
+  - **Method(s) under test**: `isValidMoveShape(Location from, Location to)`
+  - **State of the system**: `NonePiece`; `from = Location(0, 0)`, `to = Location(0, 1)`
+  - **Expected output**: returns `false`
+
+---

--- a/docs/bva/Pawn.md
+++ b/docs/bva/Pawn.md
@@ -105,7 +105,7 @@
   - **State of the system**: white pawn; `from = Location(4, 6)`, `to = Location(5, 5)`
   - **Expected output**: returns `true`
 
-- **TC11: IsValidMoveShape_OnWhitePawn_SidewaysIsFalse** ( :x: )
+- **TC11: IsValidMoveShape_OnWhitePawn_SidewaysIsFalse** ( :white_check_mark: )
   - **Method(s) under test**: `isValidMoveShape(Location from, Location to)`
   - **State of the system**: white pawn; `from = Location(4, 6)`, `to = Location(5, 6)`
   - **Expected output**: returns `false`

--- a/docs/bva/Pawn.md
+++ b/docs/bva/Pawn.md
@@ -100,7 +100,7 @@
   - **State of the system**: white pawn; `from = Location(4, 6)`, `to = Location(4, 5)`
   - **Expected output**: returns `true`
 
-- **TC10: IsValidMoveShape_OnWhitePawn_DiagonalForwardIsTrue** ( :x: )
+- **TC10: IsValidMoveShape_OnWhitePawn_DiagonalForwardIsTrue** ( :white_check_mark: )
   - **Method(s) under test**: `isValidMoveShape(Location from, Location to)`
   - **State of the system**: white pawn; `from = Location(4, 6)`, `to = Location(5, 5)`
   - **Expected output**: returns `true`

--- a/docs/bva/Pawn.md
+++ b/docs/bva/Pawn.md
@@ -82,3 +82,32 @@
   - **Expected output**: returned piece is a different object from the original
 
 ---
+
+## Method: `isValidMoveShape(Location from, Location to)`
+
+### Step 1-3: Analysis
+
+| Parameter | Catalog clue | Values considered |
+|-----------|--------------|-------------------|
+| Input: `from` to `to` displacement | Cases | one-step forward, one-step diagonal forward, sideways/other invalid |
+| Input: pawn color | Cases | `WHITE`, `BLACK` |
+| Output: return value | Boolean | `true`, `false` |
+
+### Step 4: Test Cases (Catalog-aligned Each-Choice Strategy)
+
+- **TC9: IsValidMoveShape_OnWhitePawn_OneStepForwardIsTrue** ( :x: )
+  - **Method(s) under test**: `isValidMoveShape(Location from, Location to)`
+  - **State of the system**: white pawn; `from = Location(4, 6)`, `to = Location(4, 5)`
+  - **Expected output**: returns `true`
+
+- **TC10: IsValidMoveShape_OnWhitePawn_DiagonalForwardIsTrue** ( :x: )
+  - **Method(s) under test**: `isValidMoveShape(Location from, Location to)`
+  - **State of the system**: white pawn; `from = Location(4, 6)`, `to = Location(5, 5)`
+  - **Expected output**: returns `true`
+
+- **TC11: IsValidMoveShape_OnWhitePawn_SidewaysIsFalse** ( :x: )
+  - **Method(s) under test**: `isValidMoveShape(Location from, Location to)`
+  - **State of the system**: white pawn; `from = Location(4, 6)`, `to = Location(5, 6)`
+  - **Expected output**: returns `false`
+
+---

--- a/docs/bva/Pawn.md
+++ b/docs/bva/Pawn.md
@@ -95,7 +95,7 @@
 
 ### Step 4: Test Cases (Catalog-aligned Each-Choice Strategy)
 
-- **TC9: IsValidMoveShape_OnWhitePawn_OneStepForwardIsTrue** ( :x: )
+- **TC9: IsValidMoveShape_OnWhitePawn_OneStepForwardIsTrue** ( :white_check_mark: )
   - **Method(s) under test**: `isValidMoveShape(Location from, Location to)`
   - **State of the system**: white pawn; `from = Location(4, 6)`, `to = Location(4, 5)`
   - **Expected output**: returns `true`

--- a/docs/bva/Queen.md
+++ b/docs/bva/Queen.md
@@ -104,7 +104,7 @@
   - **State of the system**: queen; `from = Location(3, 7)`, `to = Location(6, 4)`
   - **Expected output**: returns `true`
 
-- **TC11: IsValidMoveShape_OnQueen_KnightLikeMoveIsFalse** ( :x: )
+- **TC11: IsValidMoveShape_OnQueen_KnightLikeMoveIsFalse** ( :white_check_mark: )
   - **Method(s) under test**: `isValidMoveShape(Location from, Location to)`
   - **State of the system**: queen; `from = Location(3, 7)`, `to = Location(4, 5)`
   - **Expected output**: returns `false`

--- a/docs/bva/Queen.md
+++ b/docs/bva/Queen.md
@@ -94,7 +94,7 @@
 
 ### Step 4: Test Cases (Catalog-aligned Each-Choice Strategy)
 
-- **TC9: IsValidMoveShape_OnQueen_HorizontalMoveIsTrue** ( :x: )
+- **TC9: IsValidMoveShape_OnQueen_HorizontalMoveIsTrue** ( :white_check_mark: )
   - **Method(s) under test**: `isValidMoveShape(Location from, Location to)`
   - **State of the system**: queen; `from = Location(3, 7)`, `to = Location(7, 7)`
   - **Expected output**: returns `true`

--- a/docs/bva/Queen.md
+++ b/docs/bva/Queen.md
@@ -99,7 +99,7 @@
   - **State of the system**: queen; `from = Location(3, 7)`, `to = Location(7, 7)`
   - **Expected output**: returns `true`
 
-- **TC10: IsValidMoveShape_OnQueen_DiagonalMoveIsTrue** ( :x: )
+- **TC10: IsValidMoveShape_OnQueen_DiagonalMoveIsTrue** ( :white_check_mark: )
   - **Method(s) under test**: `isValidMoveShape(Location from, Location to)`
   - **State of the system**: queen; `from = Location(3, 7)`, `to = Location(6, 4)`
   - **Expected output**: returns `true`

--- a/docs/bva/Queen.md
+++ b/docs/bva/Queen.md
@@ -82,3 +82,31 @@
   - **Expected output**: returned piece is a different object from the original
 
 ---
+
+## Method: `isValidMoveShape(Location from, Location to)`
+
+### Step 1-3: Analysis
+
+| Parameter | Catalog clue | Values considered |
+|-----------|--------------|-------------------|
+| Input: displacement shape | Cases | horizontal, vertical, diagonal, other invalid |
+| Output: return value | Boolean | `true`, `false` |
+
+### Step 4: Test Cases (Catalog-aligned Each-Choice Strategy)
+
+- **TC9: IsValidMoveShape_OnQueen_HorizontalMoveIsTrue** ( :x: )
+  - **Method(s) under test**: `isValidMoveShape(Location from, Location to)`
+  - **State of the system**: queen; `from = Location(3, 7)`, `to = Location(7, 7)`
+  - **Expected output**: returns `true`
+
+- **TC10: IsValidMoveShape_OnQueen_DiagonalMoveIsTrue** ( :x: )
+  - **Method(s) under test**: `isValidMoveShape(Location from, Location to)`
+  - **State of the system**: queen; `from = Location(3, 7)`, `to = Location(6, 4)`
+  - **Expected output**: returns `true`
+
+- **TC11: IsValidMoveShape_OnQueen_KnightLikeMoveIsFalse** ( :x: )
+  - **Method(s) under test**: `isValidMoveShape(Location from, Location to)`
+  - **State of the system**: queen; `from = Location(3, 7)`, `to = Location(4, 5)`
+  - **Expected output**: returns `false`
+
+---

--- a/docs/bva/Queen.md
+++ b/docs/bva/Queen.md
@@ -104,7 +104,12 @@
   - **State of the system**: queen; `from = Location(3, 7)`, `to = Location(6, 4)`
   - **Expected output**: returns `true`
 
-- **TC11: IsValidMoveShape_OnQueen_KnightLikeMoveIsFalse** ( :white_check_mark: )
+- **TC11: IsValidMoveShape_OnQueen_VerticalMoveIsTrue** ( :white_check_mark: )
+  - **Method(s) under test**: `isValidMoveShape(Location from, Location to)`
+  - **State of the system**: queen; `from = Location(3, 7)`, `to = Location(3, 4)`
+  - **Expected output**: returns `true`
+
+- **TC12: IsValidMoveShape_OnQueen_KnightLikeMoveIsFalse** ( :white_check_mark: )
   - **Method(s) under test**: `isValidMoveShape(Location from, Location to)`
   - **State of the system**: queen; `from = Location(3, 7)`, `to = Location(4, 5)`
   - **Expected output**: returns `false`

--- a/docs/bva/Rook.md
+++ b/docs/bva/Rook.md
@@ -104,7 +104,7 @@
   - **State of the system**: rook; `from = Location(0, 7)`, `to = Location(0, 4)`
   - **Expected output**: returns `true`
 
-- **TC11: IsValidMoveShape_OnRook_DiagonalMoveIsFalse** ( :x: )
+- **TC11: IsValidMoveShape_OnRook_DiagonalMoveIsFalse** ( :white_check_mark: )
   - **Method(s) under test**: `isValidMoveShape(Location from, Location to)`
   - **State of the system**: rook; `from = Location(0, 7)`, `to = Location(3, 4)`
   - **Expected output**: returns `false`

--- a/docs/bva/Rook.md
+++ b/docs/bva/Rook.md
@@ -82,3 +82,31 @@
   - **Expected output**: returned piece is a different object from the original
 
 ---
+
+## Method: `isValidMoveShape(Location from, Location to)`
+
+### Step 1-3: Analysis
+
+| Parameter | Catalog clue | Values considered |
+|-----------|--------------|-------------------|
+| Input: `from` to `to` displacement | Cases | horizontal non-zero, vertical non-zero, diagonal/zero invalid |
+| Output: return value | Boolean | `true`, `false` |
+
+### Step 4: Test Cases (Catalog-aligned Each-Choice Strategy)
+
+- **TC9: IsValidMoveShape_OnRook_HorizontalMoveIsTrue** ( :x: )
+  - **Method(s) under test**: `isValidMoveShape(Location from, Location to)`
+  - **State of the system**: rook; `from = Location(0, 7)`, `to = Location(3, 7)`
+  - **Expected output**: returns `true`
+
+- **TC10: IsValidMoveShape_OnRook_VerticalMoveIsTrue** ( :x: )
+  - **Method(s) under test**: `isValidMoveShape(Location from, Location to)`
+  - **State of the system**: rook; `from = Location(0, 7)`, `to = Location(0, 4)`
+  - **Expected output**: returns `true`
+
+- **TC11: IsValidMoveShape_OnRook_DiagonalMoveIsFalse** ( :x: )
+  - **Method(s) under test**: `isValidMoveShape(Location from, Location to)`
+  - **State of the system**: rook; `from = Location(0, 7)`, `to = Location(3, 4)`
+  - **Expected output**: returns `false`
+
+---

--- a/docs/bva/Rook.md
+++ b/docs/bva/Rook.md
@@ -94,7 +94,7 @@
 
 ### Step 4: Test Cases (Catalog-aligned Each-Choice Strategy)
 
-- **TC9: IsValidMoveShape_OnRook_HorizontalMoveIsTrue** ( :x: )
+- **TC9: IsValidMoveShape_OnRook_HorizontalMoveIsTrue** ( :white_check_mark: )
   - **Method(s) under test**: `isValidMoveShape(Location from, Location to)`
   - **State of the system**: rook; `from = Location(0, 7)`, `to = Location(3, 7)`
   - **Expected output**: returns `true`

--- a/docs/bva/Rook.md
+++ b/docs/bva/Rook.md
@@ -99,7 +99,7 @@
   - **State of the system**: rook; `from = Location(0, 7)`, `to = Location(3, 7)`
   - **Expected output**: returns `true`
 
-- **TC10: IsValidMoveShape_OnRook_VerticalMoveIsTrue** ( :x: )
+- **TC10: IsValidMoveShape_OnRook_VerticalMoveIsTrue** ( :white_check_mark: )
   - **Method(s) under test**: `isValidMoveShape(Location from, Location to)`
   - **State of the system**: rook; `from = Location(0, 7)`, `to = Location(0, 4)`
   - **Expected output**: returns `true`

--- a/src/main/java/domain/Board.java
+++ b/src/main/java/domain/Board.java
@@ -93,11 +93,41 @@ public class Board {
         if (toPiece.getType() != PieceType.NONE && fromPiece.isSameColor(toPiece)) {
             return false;
         }
+        if (!isValidMoveShape(fromPiece, fromRank, fromFile, toRank, toFile, toPiece)) {
+            return false;
+        }
 
         Piece movedPiece = fromPiece.makeCopy();
         movedPiece.changeToMoved();
         pieces[toRank][toFile] = movedPiece;
         pieces[fromRank][fromFile] = new NonePiece();
         return true;
+    }
+
+    private boolean isValidMoveShape(Piece piece, int fromRank, int fromFile, int toRank, int toFile, Piece toPiece) {
+        int rankDelta = toRank - fromRank;
+        int fileDelta = toFile - fromFile;
+        int absRankDelta = Math.abs(rankDelta);
+        int absFileDelta = Math.abs(fileDelta);
+
+        PieceType type = piece.getType();
+        if (type == PieceType.KNIGHT) {
+            return (absRankDelta == 2 && absFileDelta == 1)
+                    || (absRankDelta == 1 && absFileDelta == 2);
+        }
+        if (type == PieceType.ROOK) {
+            return (rankDelta == 0 && fileDelta != 0)
+                    || (fileDelta == 0 && rankDelta != 0);
+        }
+        if (type == PieceType.PAWN) {
+            int forward = piece.getColor() == PieceColor.WHITE ? -1 : 1;
+            boolean isForwardMove = fileDelta == 0 && rankDelta == forward && toPiece.getType() == PieceType.NONE;
+            boolean isDiagonalCapture = absFileDelta == 1
+                    && rankDelta == forward
+                    && toPiece.getType() != PieceType.NONE
+                    && !piece.isSameColor(toPiece);
+            return isForwardMove || isDiagonalCapture;
+        }
+        return false;
     }
 }

--- a/src/main/java/domain/Board.java
+++ b/src/main/java/domain/Board.java
@@ -64,19 +64,14 @@ public class Board {
     }
 
     public Piece getPieceAt(int rank, int file) {
-        Piece sourcePiece = pieces[rank][file];
-        Piece copiedPiece = sourcePiece.makeCopy();
-        if (sourcePiece.hasMoved()) {
-            copiedPiece.changeToMoved();
-        }
-        return copiedPiece;
+        return copyPiecePreservingState(pieces[rank][file]);
     }
 
     public Piece[][] getSnapshot() {
         Piece[][] snapshot = new Piece[BOARD_SIZE][BOARD_SIZE];
         for (int row = 0; row < BOARD_SIZE; row++) {
             for (int col = 0; col < BOARD_SIZE; col++) {
-                snapshot[row][col] = pieces[row][col].makeCopy();
+                snapshot[row][col] = copyPiecePreservingState(pieces[row][col]);
             }
         }
         return snapshot;
@@ -151,5 +146,13 @@ public class Board {
             file += fileStep;
         }
         return true;
+    }
+
+    private Piece copyPiecePreservingState(Piece sourcePiece) {
+        Piece copiedPiece = sourcePiece.makeCopy();
+        if (sourcePiece.hasMoved()) {
+            copiedPiece.changeToMoved();
+        }
+        return copiedPiece;
     }
 }

--- a/src/main/java/domain/Board.java
+++ b/src/main/java/domain/Board.java
@@ -88,7 +88,13 @@ public class Board {
         int toRank = to.getY();
         int toFile = to.getX();
 
-        Piece movedPiece = pieces[fromRank][fromFile].makeCopy();
+        Piece fromPiece = pieces[fromRank][fromFile];
+        Piece toPiece = pieces[toRank][toFile];
+        if (toPiece.getType() != PieceType.NONE && fromPiece.isSameColor(toPiece)) {
+            return false;
+        }
+
+        Piece movedPiece = fromPiece.makeCopy();
         movedPiece.changeToMoved();
         pieces[toRank][toFile] = movedPiece;
         pieces[fromRank][fromFile] = new NonePiece();

--- a/src/main/java/domain/Board.java
+++ b/src/main/java/domain/Board.java
@@ -88,7 +88,7 @@ public class Board {
         if (toPiece.getType() != PieceType.NONE && fromPiece.isSameColor(toPiece)) {
             return false;
         }
-        if (!isValidMoveShape(fromPiece, fromRank, fromFile, toRank, toFile, toPiece)) {
+        if (!isValidMoveShape(fromPiece, from, to, toPiece)) {
             return false;
         }
         if (!hasNoObstacle(fromPiece, fromRank, fromFile, toRank, toFile)) {
@@ -102,31 +102,20 @@ public class Board {
         return true;
     }
 
-    private boolean isValidMoveShape(Piece piece, int fromRank, int fromFile, int toRank, int toFile, Piece toPiece) {
-        int rankDelta = toRank - fromRank;
-        int fileDelta = toFile - fromFile;
-        int absRankDelta = Math.abs(rankDelta);
-        int absFileDelta = Math.abs(fileDelta);
+    private boolean isValidMoveShape(Piece piece, Location from, Location to, Piece toPiece) {
+        if (!piece.isValidMoveShape(from, to)) {
+            return false;
+        }
+        if (piece.getType() != PieceType.PAWN) {
+            return true;
+        }
 
-        PieceType type = piece.getType();
-        if (type == PieceType.KNIGHT) {
-            return (absRankDelta == 2 && absFileDelta == 1)
-                    || (absRankDelta == 1 && absFileDelta == 2);
-        }
-        if (type == PieceType.ROOK) {
-            return (rankDelta == 0 && fileDelta != 0)
-                    || (fileDelta == 0 && rankDelta != 0);
-        }
-        if (type == PieceType.PAWN) {
-            int forward = piece.getColor() == PieceColor.WHITE ? -1 : 1;
-            boolean isForwardMove = fileDelta == 0 && rankDelta == forward && toPiece.getType() == PieceType.NONE;
-            boolean isDiagonalCapture = absFileDelta == 1
-                    && rankDelta == forward
-                    && toPiece.getType() != PieceType.NONE
-                    && !piece.isSameColor(toPiece);
-            return isForwardMove || isDiagonalCapture;
-        }
-        return false;
+        int fileDelta = to.getX() - from.getX();
+        boolean isForwardMove = fileDelta == 0 && toPiece.getType() == PieceType.NONE;
+        boolean isDiagonalCapture = Math.abs(fileDelta) == 1
+                && toPiece.getType() != PieceType.NONE
+                && !piece.isSameColor(toPiece);
+        return isForwardMove || isDiagonalCapture;
     }
 
     private boolean hasNoObstacle(Piece piece, int fromRank, int fromFile, int toRank, int toFile) {

--- a/src/main/java/domain/Board.java
+++ b/src/main/java/domain/Board.java
@@ -78,6 +78,10 @@ public class Board {
     }
 
     public boolean movePiece(Location from, Location to) {
+        int fromRank = from.getY();
+        int fromFile = from.getX();
+
+        pieces[fromRank][fromFile] = new NonePiece();
         return true;
     }
 }

--- a/src/main/java/domain/Board.java
+++ b/src/main/java/domain/Board.java
@@ -64,7 +64,12 @@ public class Board {
     }
 
     public Piece getPieceAt(int rank, int file) {
-        return pieces[rank][file].makeCopy();
+        Piece sourcePiece = pieces[rank][file];
+        Piece copiedPiece = sourcePiece.makeCopy();
+        if (sourcePiece.hasMoved()) {
+            copiedPiece.changeToMoved();
+        }
+        return copiedPiece;
     }
 
     public Piece[][] getSnapshot() {
@@ -83,7 +88,9 @@ public class Board {
         int toRank = to.getY();
         int toFile = to.getX();
 
-        pieces[toRank][toFile] = pieces[fromRank][fromFile].makeCopy();
+        Piece movedPiece = pieces[fromRank][fromFile].makeCopy();
+        movedPiece.changeToMoved();
+        pieces[toRank][toFile] = movedPiece;
         pieces[fromRank][fromFile] = new NonePiece();
         return true;
     }

--- a/src/main/java/domain/Board.java
+++ b/src/main/java/domain/Board.java
@@ -96,6 +96,9 @@ public class Board {
         if (!isValidMoveShape(fromPiece, fromRank, fromFile, toRank, toFile, toPiece)) {
             return false;
         }
+        if (!hasNoObstacle(fromPiece, fromRank, fromFile, toRank, toFile)) {
+            return false;
+        }
 
         Piece movedPiece = fromPiece.makeCopy();
         movedPiece.changeToMoved();
@@ -129,5 +132,24 @@ public class Board {
             return isForwardMove || isDiagonalCapture;
         }
         return false;
+    }
+
+    private boolean hasNoObstacle(Piece piece, int fromRank, int fromFile, int toRank, int toFile) {
+        if (piece.canJump()) {
+            return true;
+        }
+
+        int rankStep = Integer.compare(toRank, fromRank);
+        int fileStep = Integer.compare(toFile, fromFile);
+        int rank = fromRank + rankStep;
+        int file = fromFile + fileStep;
+        while (rank != toRank || file != toFile) {
+            if (pieces[rank][file].getType() != PieceType.NONE) {
+                return false;
+            }
+            rank += rankStep;
+            file += fileStep;
+        }
+        return true;
     }
 }

--- a/src/main/java/domain/Board.java
+++ b/src/main/java/domain/Board.java
@@ -11,6 +11,7 @@ import domain.piece.PieceColor;
 import domain.piece.PieceType;
 import domain.piece.Queen;
 import domain.piece.Rook;
+import domain.location.Location;
 
 public class Board {
 
@@ -74,5 +75,9 @@ public class Board {
             }
         }
         return snapshot;
+    }
+
+    public boolean movePiece(Location from, Location to) {
+        return true;
     }
 }

--- a/src/main/java/domain/Board.java
+++ b/src/main/java/domain/Board.java
@@ -80,7 +80,10 @@ public class Board {
     public boolean movePiece(Location from, Location to) {
         int fromRank = from.getY();
         int fromFile = from.getX();
+        int toRank = to.getY();
+        int toFile = to.getX();
 
+        pieces[toRank][toFile] = pieces[fromRank][fromFile].makeCopy();
         pieces[fromRank][fromFile] = new NonePiece();
         return true;
     }

--- a/src/main/java/domain/Board.java
+++ b/src/main/java/domain/Board.java
@@ -24,7 +24,7 @@ public class Board {
     public Board(Piece[][] initialPieces) {
         for (int row = 0; row < BOARD_SIZE; row++) {
             for (int col = 0; col < BOARD_SIZE; col++) {
-                pieces[row][col] = initialPieces[row][col].makeCopy();
+                pieces[row][col] = copyPiecePreservingState(initialPieces[row][col]);
             }
         }
     }

--- a/src/main/java/domain/piece/Bishop.java
+++ b/src/main/java/domain/piece/Bishop.java
@@ -1,5 +1,7 @@
 package domain.piece;
 
+import domain.location.Location;
+
 public class Bishop extends Piece {
 
   public Bishop(PieceColor color) {
@@ -9,5 +11,12 @@ public class Bishop extends Piece {
   @Override
   public Piece makeCopy() {
     return new Bishop(getColor());
+  }
+
+  @Override
+  public boolean isValidMoveShape(Location from, Location to) {
+    int absRankDelta = Math.abs(to.getY() - from.getY());
+    int absFileDelta = Math.abs(to.getX() - from.getX());
+    return absRankDelta != 0 && absRankDelta == absFileDelta;
   }
 }

--- a/src/main/java/domain/piece/King.java
+++ b/src/main/java/domain/piece/King.java
@@ -1,5 +1,7 @@
 package domain.piece;
 
+import domain.location.Location;
+
 public class King extends Piece {
 
   public King(PieceColor color) {
@@ -9,5 +11,13 @@ public class King extends Piece {
   @Override
   public Piece makeCopy() {
     return new King(getColor());
+  }
+
+  @Override
+  public boolean isValidMoveShape(Location from, Location to) {
+    int absRankDelta = Math.abs(to.getY() - from.getY());
+    int absFileDelta = Math.abs(to.getX() - from.getX());
+    return absRankDelta <= 1 && absFileDelta <= 1
+        && (absRankDelta != 0 || absFileDelta != 0);
   }
 }

--- a/src/main/java/domain/piece/Knight.java
+++ b/src/main/java/domain/piece/Knight.java
@@ -17,6 +17,7 @@ public class Knight extends Piece {
   public boolean isValidMoveShape(Location from, Location to) {
     int absRankDelta = Math.abs(to.getY() - from.getY());
     int absFileDelta = Math.abs(to.getX() - from.getX());
-    return absRankDelta == 2 && absFileDelta == 1;
+    return (absRankDelta == 2 && absFileDelta == 1)
+        || (absRankDelta == 1 && absFileDelta == 2);
   }
 }

--- a/src/main/java/domain/piece/Knight.java
+++ b/src/main/java/domain/piece/Knight.java
@@ -1,5 +1,7 @@
 package domain.piece;
 
+import domain.location.Location;
+
 public class Knight extends Piece {
 
   public Knight(PieceColor color) {
@@ -9,5 +11,12 @@ public class Knight extends Piece {
   @Override
   public Piece makeCopy() {
     return new Knight(getColor());
+  }
+
+  @Override
+  public boolean isValidMoveShape(Location from, Location to) {
+    int absRankDelta = Math.abs(to.getY() - from.getY());
+    int absFileDelta = Math.abs(to.getX() - from.getX());
+    return absRankDelta == 2 && absFileDelta == 1;
   }
 }

--- a/src/main/java/domain/piece/NonePiece.java
+++ b/src/main/java/domain/piece/NonePiece.java
@@ -1,5 +1,7 @@
 package domain.piece;
 
+import domain.location.Location;
+
 public class NonePiece extends Piece {
 
     public NonePiece() {
@@ -9,5 +11,10 @@ public class NonePiece extends Piece {
     @Override
     public Piece makeCopy() {
         return new NonePiece();
+    }
+
+    @Override
+    public boolean isValidMoveShape(Location from, Location to) {
+        return false;
     }
 }

--- a/src/main/java/domain/piece/Pawn.java
+++ b/src/main/java/domain/piece/Pawn.java
@@ -18,6 +18,8 @@ public class Pawn extends Piece {
     int rankDelta = to.getY() - from.getY();
     int fileDelta = to.getX() - from.getX();
     int forward = getColor() == PieceColor.WHITE ? -1 : 1;
-    return fileDelta == 0 && rankDelta == forward;
+    boolean isForwardMove = fileDelta == 0 && rankDelta == forward;
+    boolean isDiagonalMove = Math.abs(fileDelta) == 1 && rankDelta == forward;
+    return isForwardMove || isDiagonalMove;
   }
 }

--- a/src/main/java/domain/piece/Pawn.java
+++ b/src/main/java/domain/piece/Pawn.java
@@ -1,5 +1,7 @@
 package domain.piece;
 
+import domain.location.Location;
+
 public class Pawn extends Piece {
 
   public Pawn(PieceColor color) {
@@ -9,5 +11,13 @@ public class Pawn extends Piece {
   @Override
   public Piece makeCopy() {
     return new Pawn(getColor());
+  }
+
+  @Override
+  public boolean isValidMoveShape(Location from, Location to) {
+    int rankDelta = to.getY() - from.getY();
+    int fileDelta = to.getX() - from.getX();
+    int forward = getColor() == PieceColor.WHITE ? -1 : 1;
+    return fileDelta == 0 && rankDelta == forward;
   }
 }

--- a/src/main/java/domain/piece/Piece.java
+++ b/src/main/java/domain/piece/Piece.java
@@ -1,5 +1,7 @@
 package domain.piece;
 
+import domain.location.Location;
+
 public abstract class Piece {
 
   private final PieceType type;
@@ -43,6 +45,10 @@ public abstract class Piece {
   }
 
   public abstract Piece makeCopy();
+
+  public boolean isValidMoveShape(Location from, Location to) {
+    return false;
+  }
 
   @Override
   public String toString() {

--- a/src/main/java/domain/piece/Piece.java
+++ b/src/main/java/domain/piece/Piece.java
@@ -46,9 +46,7 @@ public abstract class Piece {
 
   public abstract Piece makeCopy();
 
-  public boolean isValidMoveShape(Location from, Location to) {
-    return false;
-  }
+  public abstract boolean isValidMoveShape(Location from, Location to);
 
   @Override
   public String toString() {

--- a/src/main/java/domain/piece/Queen.java
+++ b/src/main/java/domain/piece/Queen.java
@@ -17,6 +17,10 @@ public class Queen extends Piece {
   public boolean isValidMoveShape(Location from, Location to) {
     int rankDelta = to.getY() - from.getY();
     int fileDelta = to.getX() - from.getX();
-    return rankDelta == 0 && fileDelta != 0;
+    int absRankDelta = Math.abs(rankDelta);
+    int absFileDelta = Math.abs(fileDelta);
+    boolean isHorizontalMove = rankDelta == 0 && fileDelta != 0;
+    boolean isDiagonalMove = absRankDelta != 0 && absRankDelta == absFileDelta;
+    return isHorizontalMove || isDiagonalMove;
   }
 }

--- a/src/main/java/domain/piece/Queen.java
+++ b/src/main/java/domain/piece/Queen.java
@@ -20,7 +20,8 @@ public class Queen extends Piece {
     int absRankDelta = Math.abs(rankDelta);
     int absFileDelta = Math.abs(fileDelta);
     boolean isHorizontalMove = rankDelta == 0 && fileDelta != 0;
+    boolean isVerticalMove = fileDelta == 0 && rankDelta != 0;
     boolean isDiagonalMove = absRankDelta != 0 && absRankDelta == absFileDelta;
-    return isHorizontalMove || isDiagonalMove;
+    return isHorizontalMove || isVerticalMove || isDiagonalMove;
   }
 }

--- a/src/main/java/domain/piece/Queen.java
+++ b/src/main/java/domain/piece/Queen.java
@@ -1,5 +1,7 @@
 package domain.piece;
 
+import domain.location.Location;
+
 public class Queen extends Piece {
 
   public Queen(PieceColor color) {
@@ -9,5 +11,12 @@ public class Queen extends Piece {
   @Override
   public Piece makeCopy() {
     return new Queen(getColor());
+  }
+
+  @Override
+  public boolean isValidMoveShape(Location from, Location to) {
+    int rankDelta = to.getY() - from.getY();
+    int fileDelta = to.getX() - from.getX();
+    return rankDelta == 0 && fileDelta != 0;
   }
 }

--- a/src/main/java/domain/piece/Rook.java
+++ b/src/main/java/domain/piece/Rook.java
@@ -1,5 +1,7 @@
 package domain.piece;
 
+import domain.location.Location;
+
 public class Rook extends Piece {
 
   public Rook(PieceColor color) {
@@ -9,5 +11,12 @@ public class Rook extends Piece {
   @Override
   public Piece makeCopy() {
     return new Rook(getColor());
+  }
+
+  @Override
+  public boolean isValidMoveShape(Location from, Location to) {
+    int rankDelta = to.getY() - from.getY();
+    int fileDelta = to.getX() - from.getX();
+    return rankDelta == 0 && fileDelta != 0;
   }
 }

--- a/src/main/java/domain/piece/Rook.java
+++ b/src/main/java/domain/piece/Rook.java
@@ -17,6 +17,7 @@ public class Rook extends Piece {
   public boolean isValidMoveShape(Location from, Location to) {
     int rankDelta = to.getY() - from.getY();
     int fileDelta = to.getX() - from.getX();
-    return rankDelta == 0 && fileDelta != 0;
+    return (rankDelta == 0 && fileDelta != 0)
+        || (fileDelta == 0 && rankDelta != 0);
   }
 }

--- a/src/test/java/domain/BoardTest.java
+++ b/src/test/java/domain/BoardTest.java
@@ -510,6 +510,27 @@ class BoardTest {
         assertEquals(expectedColor, actualColor);
     }
 
+    @Test
+    void MovePiece_AfterFailedMove_GameStateUnchanged() {
+        Piece[][] layout = new Piece[8][8];
+        for (Piece[] row : layout) {
+            Arrays.fill(row, new NonePiece());
+        }
+        layout[7][0] = new Rook(PieceColor.WHITE);
+        layout[7][3] = new Rook(PieceColor.WHITE);
+
+        Board board = new Board(layout);
+
+        Location from = new Location(0, 7);
+        Location to = new Location(3, 7);
+
+        board.movePiece(from, to);
+
+        GameState expected = GameState.WHITE_TURN;
+        GameState actual = board.getCurrentGameState();
+        assertEquals(expected, actual);
+    }
+
     private boolean boardsMatchByTypeAndColor(Piece[][] left, Piece[][] right) {
         for (int rank = 0; rank < 8; rank++) {
             for (int file = 0; file < 8; file++) {

--- a/src/test/java/domain/BoardTest.java
+++ b/src/test/java/domain/BoardTest.java
@@ -386,7 +386,7 @@ class BoardTest {
 
         Piece[][] afterMove = board.getSnapshot();
         boolean expected = true;
-        boolean actual = boardsMatchByTypeAndColor(beforeMove, afterMove);
+        boolean actual = boardsMatchByTypeColorAndMovedState(beforeMove, afterMove);
         assertEquals(expected, actual);
     }
 
@@ -531,7 +531,23 @@ class BoardTest {
         assertEquals(expected, actual);
     }
 
-    private boolean boardsMatchByTypeAndColor(Piece[][] left, Piece[][] right) {
+    @Test
+    void GetSnapshot_AfterMove_MovedPieceHasMovedTrue() {
+        Piece[][] layout = new Piece[8][8];
+        for (Piece[] row : layout) {
+            Arrays.fill(row, new NonePiece());
+        }
+        layout[6][4] = new Pawn(PieceColor.WHITE);
+
+        Board board = new Board(layout);
+        board.movePiece(new Location(4, 6), new Location(4, 5));
+
+        boolean expected = true;
+        boolean actual = board.getSnapshot()[5][4].hasMoved();
+        assertEquals(expected, actual);
+    }
+
+    private boolean boardsMatchByTypeColorAndMovedState(Piece[][] left, Piece[][] right) {
         for (int rank = 0; rank < 8; rank++) {
             for (int file = 0; file < 8; file++) {
                 Piece leftPiece = left[rank][file];
@@ -540,6 +556,9 @@ class BoardTest {
                     return false;
                 }
                 if (leftPiece.getColor() != rightPiece.getColor()) {
+                    return false;
+                }
+                if (leftPiece.hasMoved() != rightPiece.hasMoved()) {
                     return false;
                 }
             }

--- a/src/test/java/domain/BoardTest.java
+++ b/src/test/java/domain/BoardTest.java
@@ -427,6 +427,24 @@ class BoardTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void MovePiece_LegalRookSlideToEmptySquare_ReturnsTrue() {
+        Piece[][] layout = new Piece[8][8];
+        for (Piece[] row : layout) {
+            Arrays.fill(row, new NonePiece());
+        }
+        layout[7][0] = new Rook(PieceColor.WHITE);
+
+        Board board = new Board(layout);
+
+        Location from = new Location(0, 7);
+        Location to = new Location(3, 7);
+
+        boolean expected = true;
+        boolean actual = board.movePiece(from, to);
+        assertEquals(expected, actual);
+    }
+
     private boolean boardsMatchByTypeAndColor(Piece[][] left, Piece[][] right) {
         for (int rank = 0; rank < 8; rank++) {
             for (int file = 0; file < 8; file++) {

--- a/src/test/java/domain/BoardTest.java
+++ b/src/test/java/domain/BoardTest.java
@@ -329,4 +329,23 @@ class BoardTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void MovePiece_LegalKnightJumpOverPiece_ReturnsTrue() {
+        Piece[][] layout = new Piece[8][8];
+        for (Piece[] row : layout) {
+            Arrays.fill(row, new NonePiece());
+        }
+        layout[7][6] = new Knight(PieceColor.WHITE);
+        layout[6][6] = new Pawn(PieceColor.WHITE);
+
+        Board board = new Board(layout);
+
+        Location from = new Location(6, 7);
+        Location to = new Location(5, 5);
+
+        boolean expected = true;
+        boolean actual = board.movePiece(from, to);
+        assertEquals(expected, actual);
+    }
+
 }

--- a/src/test/java/domain/BoardTest.java
+++ b/src/test/java/domain/BoardTest.java
@@ -309,4 +309,24 @@ class BoardTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void MovePiece_LegalPawnForwardOneToEmptySquare_MovedPawnHasMovedTrue() {
+        Piece[][] layout = new Piece[8][8];
+        for (Piece[] row : layout) {
+            Arrays.fill(row, new NonePiece());
+        }
+        layout[6][4] = new Pawn(PieceColor.WHITE);
+
+        Board board = new Board(layout);
+
+        Location from = new Location(4, 6);
+        Location to = new Location(4, 5);
+
+        board.movePiece(from, to);
+
+        boolean expected = true;
+        boolean actual = board.getPieceAt(5, 4).hasMoved();
+        assertEquals(expected, actual);
+    }
+
 }

--- a/src/test/java/domain/BoardTest.java
+++ b/src/test/java/domain/BoardTest.java
@@ -464,6 +464,52 @@ class BoardTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void MovePiece_LegalCapture_OriginBecomesNone() {
+        Piece[][] layout = new Piece[8][8];
+        for (Piece[] row : layout) {
+            Arrays.fill(row, new NonePiece());
+        }
+        layout[4][4] = new Pawn(PieceColor.WHITE);
+        layout[3][5] = new Pawn(PieceColor.BLACK);
+
+        Board board = new Board(layout);
+
+        Location from = new Location(4, 4);
+        Location to = new Location(5, 3);
+
+        board.movePiece(from, to);
+
+        PieceType expected = PieceType.NONE;
+        PieceType actual = board.getPieceAt(4, 4).getType();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void MovePiece_LegalCapture_DestinationHasWhitePawn() {
+        Piece[][] layout = new Piece[8][8];
+        for (Piece[] row : layout) {
+            Arrays.fill(row, new NonePiece());
+        }
+        layout[4][4] = new Pawn(PieceColor.WHITE);
+        layout[3][5] = new Pawn(PieceColor.BLACK);
+
+        Board board = new Board(layout);
+
+        Location from = new Location(4, 4);
+        Location to = new Location(5, 3);
+
+        board.movePiece(from, to);
+
+        PieceType expectedType = PieceType.PAWN;
+        PieceType actualType = board.getPieceAt(3, 5).getType();
+        assertEquals(expectedType, actualType);
+
+        PieceColor expectedColor = PieceColor.WHITE;
+        PieceColor actualColor = board.getPieceAt(3, 5).getColor();
+        assertEquals(expectedColor, actualColor);
+    }
+
     private boolean boardsMatchByTypeAndColor(Piece[][] left, Piece[][] right) {
         for (int rank = 0; rank < 8; rank++) {
             for (int file = 0; file < 8; file++) {

--- a/src/test/java/domain/BoardTest.java
+++ b/src/test/java/domain/BoardTest.java
@@ -289,4 +289,24 @@ class BoardTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void MovePiece_LegalPawnForwardOneToEmptySquare_DestinationHasPawn() {
+        Piece[][] layout = new Piece[8][8];
+        for (Piece[] row : layout) {
+            Arrays.fill(row, new NonePiece());
+        }
+        layout[6][4] = new Pawn(PieceColor.WHITE);
+
+        Board board = new Board(layout);
+
+        Location from = new Location(4, 6);
+        Location to = new Location(4, 5);
+
+        board.movePiece(from, to);
+
+        PieceType expected = PieceType.PAWN;
+        PieceType actual = board.getPieceAt(5, 4).getType();
+        assertEquals(expected, actual);
+    }
+
 }

--- a/src/test/java/domain/BoardTest.java
+++ b/src/test/java/domain/BoardTest.java
@@ -348,4 +348,23 @@ class BoardTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void MovePiece_DestinationOccupiedByFriendlyPiece_ReturnsFalse() {
+        Piece[][] layout = new Piece[8][8];
+        for (Piece[] row : layout) {
+            Arrays.fill(row, new NonePiece());
+        }
+        layout[7][0] = new Rook(PieceColor.WHITE);
+        layout[7][3] = new Rook(PieceColor.WHITE);
+
+        Board board = new Board(layout);
+
+        Location from = new Location(0, 7);
+        Location to = new Location(3, 7);
+
+        boolean expected = false;
+        boolean actual = board.movePiece(from, to);
+        assertEquals(expected, actual);
+    }
+
 }

--- a/src/test/java/domain/BoardTest.java
+++ b/src/test/java/domain/BoardTest.java
@@ -367,4 +367,43 @@ class BoardTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void MovePiece_DestinationOccupiedByFriendlyPiece_BoardUnchanged() {
+        Piece[][] layout = new Piece[8][8];
+        for (Piece[] row : layout) {
+            Arrays.fill(row, new NonePiece());
+        }
+        layout[7][0] = new Rook(PieceColor.WHITE);
+        layout[7][3] = new Rook(PieceColor.WHITE);
+
+        Board board = new Board(layout);
+        Piece[][] beforeMove = board.getSnapshot();
+
+        Location from = new Location(0, 7);
+        Location to = new Location(3, 7);
+
+        board.movePiece(from, to);
+
+        Piece[][] afterMove = board.getSnapshot();
+        boolean expected = true;
+        boolean actual = boardsMatchByTypeAndColor(beforeMove, afterMove);
+        assertEquals(expected, actual);
+    }
+
+    private boolean boardsMatchByTypeAndColor(Piece[][] left, Piece[][] right) {
+        for (int rank = 0; rank < 8; rank++) {
+            for (int file = 0; file < 8; file++) {
+                Piece leftPiece = left[rank][file];
+                Piece rightPiece = right[rank][file];
+                if (leftPiece.getType() != rightPiece.getType()) {
+                    return false;
+                }
+                if (leftPiece.getColor() != rightPiece.getColor()) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
 }

--- a/src/test/java/domain/BoardTest.java
+++ b/src/test/java/domain/BoardTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.util.Arrays;
 import org.easymock.EasyMock;
 import org.junit.jupiter.api.Test;
+import domain.location.Location;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
@@ -247,6 +248,25 @@ class BoardTest {
         assertNotSame(piece1, piece2);
         assertEquals(piece1.getType(), piece2.getType());
         assertEquals(piece1.getColor(), piece2.getColor());
+    }
+
+    @Test
+    void MovePiece_LegalPawnForwardOneToEmptySquare_ReturnsTrue() {
+        Piece[][] layout = new Piece[8][8];
+        for (Piece[] row : layout) {
+            Arrays.fill(row, new NonePiece());
+        }
+        layout[6][4] = new Pawn(PieceColor.WHITE);
+
+        Board board = new Board(layout);
+
+        Location from = new Location(4, 6);
+        Location to = new Location(4, 5);
+
+        boolean actual = board.movePiece(from, to);
+
+        boolean expected = true;
+        assertEquals(expected, actual);
     }
 
 }

--- a/src/test/java/domain/BoardTest.java
+++ b/src/test/java/domain/BoardTest.java
@@ -269,4 +269,24 @@ class BoardTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void MovePiece_LegalPawnForwardOneToEmptySquare_OriginBecomesNone() {
+        Piece[][] layout = new Piece[8][8];
+        for (Piece[] row : layout) {
+            Arrays.fill(row, new NonePiece());
+        }
+        layout[6][4] = new Pawn(PieceColor.WHITE);
+
+        Board board = new Board(layout);
+
+        Location from = new Location(4, 6);
+        Location to = new Location(4, 5);
+
+        board.movePiece(from, to);
+
+        PieceType expected = PieceType.NONE;
+        PieceType actual = board.getPieceAt(6, 4).getType();
+        assertEquals(expected, actual);
+    }
+
 }

--- a/src/test/java/domain/BoardTest.java
+++ b/src/test/java/domain/BoardTest.java
@@ -408,6 +408,25 @@ class BoardTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void MovePiece_BlockedRookSlide_ReturnsFalse() {
+        Piece[][] layout = new Piece[8][8];
+        for (Piece[] row : layout) {
+            Arrays.fill(row, new NonePiece());
+        }
+        layout[7][0] = new Rook(PieceColor.WHITE);
+        layout[7][1] = new Pawn(PieceColor.WHITE);
+
+        Board board = new Board(layout);
+
+        Location from = new Location(0, 7);
+        Location to = new Location(3, 7);
+
+        boolean expected = false;
+        boolean actual = board.movePiece(from, to);
+        assertEquals(expected, actual);
+    }
+
     private boolean boardsMatchByTypeAndColor(Piece[][] left, Piece[][] right) {
         for (int rank = 0; rank < 8; rank++) {
             for (int file = 0; file < 8; file++) {

--- a/src/test/java/domain/BoardTest.java
+++ b/src/test/java/domain/BoardTest.java
@@ -390,6 +390,24 @@ class BoardTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void MovePiece_InvalidMoveShape_ReturnsFalse() {
+        Piece[][] layout = new Piece[8][8];
+        for (Piece[] row : layout) {
+            Arrays.fill(row, new NonePiece());
+        }
+        layout[6][4] = new Pawn(PieceColor.WHITE);
+
+        Board board = new Board(layout);
+
+        Location from = new Location(4, 6);
+        Location to = new Location(5, 6);
+
+        boolean expected = false;
+        boolean actual = board.movePiece(from, to);
+        assertEquals(expected, actual);
+    }
+
     private boolean boardsMatchByTypeAndColor(Piece[][] left, Piece[][] right) {
         for (int rank = 0; rank < 8; rank++) {
             for (int file = 0; file < 8; file++) {

--- a/src/test/java/domain/BoardTest.java
+++ b/src/test/java/domain/BoardTest.java
@@ -445,6 +445,25 @@ class BoardTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void MovePiece_LegalCapture_ReturnsTrue() {
+        Piece[][] layout = new Piece[8][8];
+        for (Piece[] row : layout) {
+            Arrays.fill(row, new NonePiece());
+        }
+        layout[4][4] = new Pawn(PieceColor.WHITE);
+        layout[3][5] = new Pawn(PieceColor.BLACK);
+
+        Board board = new Board(layout);
+
+        Location from = new Location(4, 4);
+        Location to = new Location(5, 3);
+
+        boolean expected = true;
+        boolean actual = board.movePiece(from, to);
+        assertEquals(expected, actual);
+    }
+
     private boolean boardsMatchByTypeAndColor(Piece[][] left, Piece[][] right) {
         for (int rank = 0; rank < 8; rank++) {
             for (int file = 0; file < 8; file++) {

--- a/src/test/java/domain/BoardTest.java
+++ b/src/test/java/domain/BoardTest.java
@@ -94,6 +94,23 @@ class BoardTest {
     }
 
     @Test
+    void Constructor_WhenPieceArrayHasMovedPiece_HasMovedIsPreserved() {
+        Piece[][] layout = new Piece[8][8];
+        for (Piece[] row : layout) {
+            Arrays.fill(row, new NonePiece());
+        }
+        Rook rook = new Rook(PieceColor.WHITE);
+        rook.changeToMoved();
+        layout[0][0] = rook;
+
+        Board board = new Board(layout);
+
+        boolean expected = true;
+        boolean actual = board.getSnapshot()[0][0].hasMoved();
+        assertEquals(expected, actual);
+    }
+
+    @Test
     void Constructor_WithPieceArray_OnNewBoard_GameStateIsWhiteTurn() {
         Piece[][] layout = new Piece[8][8];
         for (Piece[] r : layout) Arrays.fill(r, new NonePiece());

--- a/src/test/java/domain/piece/BishopTest.java
+++ b/src/test/java/domain/piece/BishopTest.java
@@ -86,4 +86,16 @@ class BishopTest {
         boolean actual = bishop.isValidMoveShape(from, to);
         assertEquals(expected, actual);
     }
+
+    @Test
+    void IsValidMoveShape_OnBishop_HorizontalMoveIsFalse() {
+        Bishop bishop = new Bishop(PieceColor.WHITE);
+
+        Location from = new Location(2, 7);
+        Location to = new Location(5, 7);
+
+        boolean expected = false;
+        boolean actual = bishop.isValidMoveShape(from, to);
+        assertEquals(expected, actual);
+    }
 }

--- a/src/test/java/domain/piece/BishopTest.java
+++ b/src/test/java/domain/piece/BishopTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 
+import domain.location.Location;
 import org.junit.jupiter.api.Test;
 
 class BishopTest {
@@ -72,5 +73,17 @@ class BishopTest {
         Bishop bishop = new Bishop(PieceColor.BLACK);
 
         assertNotSame(bishop, bishop.makeCopy());
+    }
+
+    @Test
+    void IsValidMoveShape_OnBishop_DiagonalMoveIsTrue() {
+        Bishop bishop = new Bishop(PieceColor.WHITE);
+
+        Location from = new Location(2, 7);
+        Location to = new Location(5, 4);
+
+        boolean expected = true;
+        boolean actual = bishop.isValidMoveShape(from, to);
+        assertEquals(expected, actual);
     }
 }

--- a/src/test/java/domain/piece/KingTest.java
+++ b/src/test/java/domain/piece/KingTest.java
@@ -86,4 +86,16 @@ class KingTest {
         boolean actual = king.isValidMoveShape(from, to);
         assertEquals(expected, actual);
     }
+
+    @Test
+    void IsValidMoveShape_OnKing_TwoStepMoveIsFalse() {
+        King king = new King(PieceColor.WHITE);
+
+        Location from = new Location(4, 7);
+        Location to = new Location(4, 5);
+
+        boolean expected = false;
+        boolean actual = king.isValidMoveShape(from, to);
+        assertEquals(expected, actual);
+    }
 }

--- a/src/test/java/domain/piece/KingTest.java
+++ b/src/test/java/domain/piece/KingTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 
+import domain.location.Location;
 import org.junit.jupiter.api.Test;
 
 class KingTest {
@@ -72,5 +73,17 @@ class KingTest {
         King king = new King(PieceColor.BLACK);
 
         assertNotSame(king, king.makeCopy());
+    }
+
+    @Test
+    void IsValidMoveShape_OnKing_OneStepDiagonalIsTrue() {
+        King king = new King(PieceColor.WHITE);
+
+        Location from = new Location(4, 7);
+        Location to = new Location(5, 6);
+
+        boolean expected = true;
+        boolean actual = king.isValidMoveShape(from, to);
+        assertEquals(expected, actual);
     }
 }

--- a/src/test/java/domain/piece/KnightTest.java
+++ b/src/test/java/domain/piece/KnightTest.java
@@ -103,4 +103,16 @@ class KnightTest {
         boolean actual = knight.isValidMoveShape(from, to);
         assertEquals(expected, actual);
     }
+
+    @Test
+    void IsValidMoveShape_OnKnight_StraightMoveIsFalse() {
+        Knight knight = new Knight(PieceColor.WHITE);
+
+        Location from = new Location(6, 7);
+        Location to = new Location(6, 5);
+
+        boolean expected = false;
+        boolean actual = knight.isValidMoveShape(from, to);
+        assertEquals(expected, actual);
+    }
 }

--- a/src/test/java/domain/piece/KnightTest.java
+++ b/src/test/java/domain/piece/KnightTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import domain.location.Location;
 import org.junit.jupiter.api.Test;
 
 class KnightTest {
@@ -77,5 +78,17 @@ class KnightTest {
         Knight knight = new Knight(PieceColor.BLACK);
 
         assertNotSame(knight, knight.makeCopy());
+    }
+
+    @Test
+    void IsValidMoveShape_OnKnight_TwoOneMoveIsTrue() {
+        Knight knight = new Knight(PieceColor.WHITE);
+
+        Location from = new Location(6, 7);
+        Location to = new Location(5, 5);
+
+        boolean expected = true;
+        boolean actual = knight.isValidMoveShape(from, to);
+        assertEquals(expected, actual);
     }
 }

--- a/src/test/java/domain/piece/KnightTest.java
+++ b/src/test/java/domain/piece/KnightTest.java
@@ -91,4 +91,16 @@ class KnightTest {
         boolean actual = knight.isValidMoveShape(from, to);
         assertEquals(expected, actual);
     }
+
+    @Test
+    void IsValidMoveShape_OnKnight_OneTwoMoveIsTrue() {
+        Knight knight = new Knight(PieceColor.WHITE);
+
+        Location from = new Location(6, 7);
+        Location to = new Location(4, 6);
+
+        boolean expected = true;
+        boolean actual = knight.isValidMoveShape(from, to);
+        assertEquals(expected, actual);
+    }
 }

--- a/src/test/java/domain/piece/NonePieceTest.java
+++ b/src/test/java/domain/piece/NonePieceTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 
+import domain.location.Location;
 import org.junit.jupiter.api.Test;
 
 class NonePieceTest {
@@ -47,5 +48,17 @@ class NonePieceTest {
         NonePiece nonePiece = new NonePiece();
 
         assertNotSame(nonePiece, nonePiece.makeCopy());
+    }
+
+    @Test
+    void IsValidMoveShape_OnNonePiece_AnyMoveIsFalse() {
+        NonePiece nonePiece = new NonePiece();
+
+        Location from = new Location(0, 0);
+        Location to = new Location(0, 1);
+
+        boolean expected = false;
+        boolean actual = nonePiece.isValidMoveShape(from, to);
+        assertEquals(expected, actual);
     }
 }

--- a/src/test/java/domain/piece/PawnTest.java
+++ b/src/test/java/domain/piece/PawnTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 
+import domain.location.Location;
 import org.junit.jupiter.api.Test;
 
 class PawnTest {
@@ -72,5 +73,17 @@ class PawnTest {
         Pawn pawn = new Pawn(PieceColor.BLACK);
 
         assertNotSame(pawn, pawn.makeCopy());
+    }
+
+    @Test
+    void IsValidMoveShape_OnWhitePawn_OneStepForwardIsTrue() {
+        Pawn pawn = new Pawn(PieceColor.WHITE);
+
+        Location from = new Location(4, 6);
+        Location to = new Location(4, 5);
+
+        boolean expected = true;
+        boolean actual = pawn.isValidMoveShape(from, to);
+        assertEquals(expected, actual);
     }
 }

--- a/src/test/java/domain/piece/PawnTest.java
+++ b/src/test/java/domain/piece/PawnTest.java
@@ -98,4 +98,16 @@ class PawnTest {
         boolean actual = pawn.isValidMoveShape(from, to);
         assertEquals(expected, actual);
     }
+
+    @Test
+    void IsValidMoveShape_OnWhitePawn_SidewaysIsFalse() {
+        Pawn pawn = new Pawn(PieceColor.WHITE);
+
+        Location from = new Location(4, 6);
+        Location to = new Location(5, 6);
+
+        boolean expected = false;
+        boolean actual = pawn.isValidMoveShape(from, to);
+        assertEquals(expected, actual);
+    }
 }

--- a/src/test/java/domain/piece/PawnTest.java
+++ b/src/test/java/domain/piece/PawnTest.java
@@ -86,4 +86,16 @@ class PawnTest {
         boolean actual = pawn.isValidMoveShape(from, to);
         assertEquals(expected, actual);
     }
+
+    @Test
+    void IsValidMoveShape_OnWhitePawn_DiagonalForwardIsTrue() {
+        Pawn pawn = new Pawn(PieceColor.WHITE);
+
+        Location from = new Location(4, 6);
+        Location to = new Location(5, 5);
+
+        boolean expected = true;
+        boolean actual = pawn.isValidMoveShape(from, to);
+        assertEquals(expected, actual);
+    }
 }

--- a/src/test/java/domain/piece/QueenTest.java
+++ b/src/test/java/domain/piece/QueenTest.java
@@ -86,4 +86,16 @@ class QueenTest {
         boolean actual = queen.isValidMoveShape(from, to);
         assertEquals(expected, actual);
     }
+
+    @Test
+    void IsValidMoveShape_OnQueen_DiagonalMoveIsTrue() {
+        Queen queen = new Queen(PieceColor.WHITE);
+
+        Location from = new Location(3, 7);
+        Location to = new Location(6, 4);
+
+        boolean expected = true;
+        boolean actual = queen.isValidMoveShape(from, to);
+        assertEquals(expected, actual);
+    }
 }

--- a/src/test/java/domain/piece/QueenTest.java
+++ b/src/test/java/domain/piece/QueenTest.java
@@ -100,6 +100,18 @@ class QueenTest {
     }
 
     @Test
+    void IsValidMoveShape_OnQueen_VerticalMoveIsTrue() {
+        Queen queen = new Queen(PieceColor.WHITE);
+
+        Location from = new Location(3, 7);
+        Location to = new Location(3, 4);
+
+        boolean expected = true;
+        boolean actual = queen.isValidMoveShape(from, to);
+        assertEquals(expected, actual);
+    }
+
+    @Test
     void IsValidMoveShape_OnQueen_KnightLikeMoveIsFalse() {
         Queen queen = new Queen(PieceColor.WHITE);
 

--- a/src/test/java/domain/piece/QueenTest.java
+++ b/src/test/java/domain/piece/QueenTest.java
@@ -98,4 +98,16 @@ class QueenTest {
         boolean actual = queen.isValidMoveShape(from, to);
         assertEquals(expected, actual);
     }
+
+    @Test
+    void IsValidMoveShape_OnQueen_KnightLikeMoveIsFalse() {
+        Queen queen = new Queen(PieceColor.WHITE);
+
+        Location from = new Location(3, 7);
+        Location to = new Location(4, 5);
+
+        boolean expected = false;
+        boolean actual = queen.isValidMoveShape(from, to);
+        assertEquals(expected, actual);
+    }
 }

--- a/src/test/java/domain/piece/QueenTest.java
+++ b/src/test/java/domain/piece/QueenTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 
+import domain.location.Location;
 import org.junit.jupiter.api.Test;
 
 class QueenTest {
@@ -72,5 +73,17 @@ class QueenTest {
         Queen queen = new Queen(PieceColor.BLACK);
 
         assertNotSame(queen, queen.makeCopy());
+    }
+
+    @Test
+    void IsValidMoveShape_OnQueen_HorizontalMoveIsTrue() {
+        Queen queen = new Queen(PieceColor.WHITE);
+
+        Location from = new Location(3, 7);
+        Location to = new Location(7, 7);
+
+        boolean expected = true;
+        boolean actual = queen.isValidMoveShape(from, to);
+        assertEquals(expected, actual);
     }
 }

--- a/src/test/java/domain/piece/RookTest.java
+++ b/src/test/java/domain/piece/RookTest.java
@@ -98,4 +98,16 @@ class RookTest {
         boolean actual = rook.isValidMoveShape(from, to);
         assertEquals(expected, actual);
     }
+
+    @Test
+    void IsValidMoveShape_OnRook_DiagonalMoveIsFalse() {
+        Rook rook = new Rook(PieceColor.WHITE);
+
+        Location from = new Location(0, 7);
+        Location to = new Location(3, 4);
+
+        boolean expected = false;
+        boolean actual = rook.isValidMoveShape(from, to);
+        assertEquals(expected, actual);
+    }
 }

--- a/src/test/java/domain/piece/RookTest.java
+++ b/src/test/java/domain/piece/RookTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 
+import domain.location.Location;
 import org.junit.jupiter.api.Test;
 
 class RookTest {
@@ -72,5 +73,17 @@ class RookTest {
         Rook rook = new Rook(PieceColor.BLACK);
 
         assertNotSame(rook, rook.makeCopy());
+    }
+
+    @Test
+    void IsValidMoveShape_OnRook_HorizontalMoveIsTrue() {
+        Rook rook = new Rook(PieceColor.WHITE);
+
+        Location from = new Location(0, 7);
+        Location to = new Location(3, 7);
+
+        boolean expected = true;
+        boolean actual = rook.isValidMoveShape(from, to);
+        assertEquals(expected, actual);
     }
 }

--- a/src/test/java/domain/piece/RookTest.java
+++ b/src/test/java/domain/piece/RookTest.java
@@ -86,4 +86,16 @@ class RookTest {
         boolean actual = rook.isValidMoveShape(from, to);
         assertEquals(expected, actual);
     }
+
+    @Test
+    void IsValidMoveShape_OnRook_VerticalMoveIsTrue() {
+        Rook rook = new Rook(PieceColor.WHITE);
+
+        Location from = new Location(0, 7);
+        Location to = new Location(0, 4);
+
+        boolean expected = true;
+        boolean actual = rook.isValidMoveShape(from, to);
+        assertEquals(expected, actual);
+    }
 }


### PR DESCRIPTION
## Description

Implements the phase-1 `Board.movePiece(Location from, Location to)` behavior using TDD, with unit tests and BVA updates for TC50–TC63 in `Board.md`.

## Type of Change

- [x] Feature (new functionality)
- [ ] Bug fix
- [x] Documentation update
- [ ] Refactor
- [x] Test addition/update

## Related Work

Closes #(issue number) | Related to `docs/bva/Board.md`

## Changes Made

- [x] Added/updated `BoardTest` methods for TC50–TC63 move cases (legal pawn move, knight jump, friendly-block rejection, invalid shape, blocked rook, legal rook slide, capture outcomes, failed-move game state).
- [x] Implemented `Board.movePiece(...)` phase-1 flow: same-color destination rejection, shape checks (pawn/knight/rook), obstacle checks, move application, and moved-state marking.
- [x] Updated `docs/bva/Board.md` statuses to mark TC50–TC63 as implemented (`:white_check_mark:`).

## BVA & Testing

- BVA documented in: `docs/bva/Board.md`
- Test cases implemented: TC50, TC51, TC52, TC53, TC54, TC55, TC56, TC57, TC58, TC59, TC60, TC61, TC62, TC63
- All tests passing: [x]

## Design Alignment

- [x] Changes align with `docs/design/chess-full-design.puml`
- [x] No breaking changes to existing methods
- [x] New methods follow the established patterns

## Implementation Notes

- `movePiece` currently covers the documented phase-1 slice only (pawn/knight/rook movement, path blocking, captures, same-color destination rejection, moved flag updates).
- `getPieceAt` preserves the `hasMoved` state on returned defensive copies.
- Deferred rules remain out of scope for this PR (e.g., king-safety validation, castling, promotion, en passant, wrong-turn enforcement, out-of-bounds guards), consistent with the current BVA scope.

## Checklist

- [x] BVA analysis is documented
- [x] TDD workflow followed (tests before code)
- [x] Code compiles and all tests pass
- [x] No new compiler warnings
- [x] Documentation updated (if applicable)
- [x] Commit messages are clear and follow TDD workflow