### PR TITLE
[FEAT] Board Controller Move Piece

### DIFF
--- a/docs/bva/BoardController.md
+++ b/docs/bva/BoardController.md
@@ -2,20 +2,20 @@
 
 Package: `ui.BoardController`
 
-Scope: **Game Initialization** — selection state, snapshot/turn delegation to `domain.Board`, first-click policy, optional `BoardView` wiring. The real `Board` implementation is another feature branch; **unit tests use EasyMock** (`createMock` / `createNiceMock`, `expect`, `replay`, `verify`) to stub `getSnapshot()`, `getCurrentGameState()`, and `getPieceAt()` with test-built `Piece[][]` grids.
+Scope: **Game Initialization** and **Make a Legal Move (one turn)** — selection state, snapshot/turn delegation to `domain.Board`, first-click policy, second-click move completion, optional `BoardView` wiring. **Unit tests use EasyMock** (`createMock` / `createNiceMock`, `expect`, `replay`, `verify`) to stub `getSnapshot()`, `getCurrentGameState()`, `getPieceAt()`, and (for move completion) `movePiece(Location, Location)` / `switchTurn()` with test-built `Piece[][]` grids.
 
 ### Step 1: Input and output equivalence classes
 
-| Concern           | Equivalence classes                                                                 |
-| ----------------- | ----------------------------------------------------------------------------------- |
-| Object life cycle | Fresh instance; no clicks yet                                                       |
+| Concern           | Equivalence classes                                           |
+| ----------------- | ------------------------------------------------------------- |
+| Object life cycle | Fresh instance; no clicks yet                                 |
 | Collaborators     | `Board` (mocked); **no `BoardView`** in controller unit tests |
 
 ### Step 2: BVA catalog data types
 
-| Variable / output     | Catalog type | Rationale                                      |
-| --------------------- | ------------ | ---------------------------------------------- |
-| `lastSelectedLoc`     | Optional     | `Optional.empty()` vs `Optional.of(Location)` |
+| Variable / output | Catalog type | Rationale                                     |
+| ----------------- | ------------ | --------------------------------------------- |
+| `lastSelectedLoc` | Optional     | `Optional.empty()` vs `Optional.of(Location)` |
 
 ### Step 3: Concrete boundary values
 
@@ -40,16 +40,16 @@ Scope: **Game Initialization** — selection state, snapshot/turn delegation to 
 
 ### Step 1: Input and output equivalence classes
 
-| Input (implicit) | Classes                                                          |
-| ---------------- | ---------------------------------------------------------------- |
+| Input (implicit) | Classes                                                        |
+| ---------------- | -------------------------------------------------------------- |
 | Underlying board | Standard init; fixed Chess960 init; seeded Fischer Random init |
 
-| Output    | Classes                                                                        |
-| --------- | ------------------------------------------------------------------------------ |
-| Grid      | Always 8×8                                                                     |
-| Cells     | `Piece` per cell; empty squares use `PieceType.NONE` (`NonePiece`)             |
-| Counts    | 16 white and 16 black pieces at standard start                                 |
-| Readiness | All non-`NONE` pieces `hasMoved() == false`; turn `WHITE_TURN` via `Board`     |
+| Output    | Classes                                                                    |
+| --------- | -------------------------------------------------------------------------- |
+| Grid      | Always 8×8                                                                 |
+| Cells     | `Piece` per cell; empty squares use `PieceType.NONE` (`NonePiece`)         |
+| Counts    | 16 white and 16 black pieces at standard start                             |
+| Readiness | All non-`NONE` pieces `hasMoved() == false`; turn `WHITE_TURN` via `Board` |
 
 ### Step 4: Test cases
 
@@ -145,7 +145,6 @@ Scope: **Game Initialization** — selection state, snapshot/turn delegation to 
 - **BC-TC24: GetBoardSnapshot_Chess960_SeedOne_StandardPawnRows** ( :white_check_mark: )
 - **BC-TC25: GetBoardSnapshot_Chess960_SeedOne_OneQueenTwoKnightsOnBackRank_WhiteBackRank** ( :white_check_mark: )
 - **BC-TC26: GetBoardSnapshot_Chess960_SeedOne_OneQueenTwoKnightsOnBackRank_BlackBackRank** ( :white_check_mark: )
-
   - **Method(s) under test**: `getBoardSnapshot()` with mock returning seed-`1L` Chess960 grid (built in test)
   - **State of the system**: `chess960Seed == 1L`
   - **Expected output**: same predicates as BC-TC11–BC-TC18 for the seeded layout
@@ -156,16 +155,16 @@ Scope: **Game Initialization** — selection state, snapshot/turn delegation to 
 
 ### Step 1: Input and output equivalence classes
 
-| Output                    | Equivalence classes                                      |
-| ------------------------- | -------------------------------------------------------- |
-| `hasSelection()`          | `true` / `false`                                         |
-| `getSelectedLocation()`   | `Optional.empty()` / `Optional.of(Location)`              |
+| Output                  | Equivalence classes                          |
+| ----------------------- | -------------------------------------------- |
+| `hasSelection()`        | `true` / `false`                             |
+| `getSelectedLocation()` | `Optional.empty()` / `Optional.of(Location)` |
 
 ### Step 2: BVA catalog data types
 
-| Concern           | Catalog type                          |
-| ----------------- | ------------------------------------- |
-| Selection state   | Optional: empty vs present            |
+| Concern         | Catalog type               |
+| --------------- | -------------------------- |
+| Selection state | Optional: empty vs present |
 
 ### Step 4: Test cases
 
@@ -177,13 +176,13 @@ _(BC-TC1, BC-TC2 cover fresh instance; selection-after-click covered under `hand
 
 ### Step 1: Input and output equivalence classes
 
-| Input           | Classes                                       |
-| --------------- | --------------------------------------------- |
-| `loc`           | In-bounds; out-of-bounds                      |
-| Square at start | `NonePiece`; white piece; black piece         |
+| Input           | Classes                               |
+| --------------- | ------------------------------------- |
+| `loc`           | In-bounds; out-of-bounds              |
+| Square at start | `NonePiece`; white piece; black piece |
 
-| Effect            | Classes                                              |
-| ----------------- | ---------------------------------------------------- |
+| Effect            | Classes                                                |
+| ----------------- | ------------------------------------------------------ |
 | Selection / guard | White may select; black or empty must not change board |
 
 ### Step 4: Test cases
@@ -267,3 +266,91 @@ _(BC-TC1, BC-TC2 cover fresh instance; selection-after-click covered under `hand
   - **Method(s) under test**: `handleSquareClick(Location)`, `getCurrentGameState()`
   - **State of the system**: Chess960 fixed start; white piece click
   - **Expected output**: `GameState.WHITE_TURN`
+
+---
+
+## Method: `handleSquareClick(loc: Location)` — move completion (second click)
+
+Scope: **Make a Legal Move (one turn)** — applies when `lastSelectedLoc` is present. Depends on `Board.movePiece` returning `true`/`false`. Team policy for illegal destination: **clear selection** after failed move (document in implementation notes).
+
+### Step 1: Input and output equivalence classes
+
+| Input                       | Classes                                                                  |
+| --------------------------- | ------------------------------------------------------------------------ |
+| Selection state             | `Optional.of(origin)` vs `Optional.empty()` (first click — above)        |
+| Destination at second click | Legal empty; legal capture; illegal shape/path; friendly square          |
+| Active turn                 | `WHITE_TURN` (black move completion deferred to Alternating Turns story) |
+
+| Output / side effect        | Classes                                                             |
+| --------------------------- | ------------------------------------------------------------------- |
+| `Board.movePiece`           | Called once with selected origin and clicked destination on attempt |
+| `Board.switchTurn`          | Called only after `movePiece` returns `true`                        |
+| Selection after success     | Cleared (`hasSelection()` false)                                    |
+| Selection after failed move | Cleared (team policy)                                               |
+| `BoardView.repaint`         | Invoked when view is set                                            |
+| Snapshot                    | Updated only when real board used; unchanged when mock rejects move |
+
+### Step 2: BVA catalog data types
+
+| Variable / output       | Catalog type | Rationale                          |
+| ----------------------- | ------------ | ---------------------------------- |
+| `lastSelectedLoc`       | Optional     | present only for second-click path |
+| `movePiece` return      | Boolean      | success vs rejection               |
+| `getCurrentGameState()` | Cases        | `WHITE_TURN`, `BLACK_TURN`         |
+
+### Step 4: Test cases
+
+- **BC-TC43: HandleSquareClick_WithSelection_LegalDestination_CallsMovePiece** ( :x: )
+  - **Method(s) under test**: `handleSquareClick(Location)` with mocked `Board`
+  - **State of the system**: white pawn selected at `Location(4, 6)`; second click `Location(4, 5)`; mock `movePiece(from, to)` returns `true`
+  - **Expected output**: `movePiece` invoked once with matching `from`/`to`; `verify(boardMock)` passes
+
+- **BC-TC44: HandleSquareClick_WithSelection_LegalDestination_CallsSwitchTurn** ( :x: )
+  - **Method(s) under test**: `handleSquareClick(Location)` with mocked `Board`
+  - **State of the system**: same as BC-TC43; `movePiece` returns `true`
+  - **Expected output**: `switchTurn()` called once after successful move
+
+- **BC-TC45: HandleSquareClick_WithSelection_LegalDestination_ClearsSelection** ( :x: )
+  - **Method(s) under test**: `handleSquareClick(Location)`, `hasSelection()`
+  - **State of the system**: same as BC-TC43
+  - **Expected output**: `hasSelection()` is `false` after second click
+
+- **BC-TC46: HandleSquareClick_WithSelection_LegalDestination_TurnBecomesBlack** ( :x: )
+  - **Method(s) under test**: `handleSquareClick(Location)`, `getCurrentGameState()`
+  - **State of the system**: integration-style test with real `Board(Piece[][])` and legal white pawn move; or mock returning `BLACK_TURN` after `switchTurn`
+  - **Expected output**: `getCurrentGameState()` is `BLACK_TURN`
+
+- **BC-TC47: HandleSquareClick_WithSelection_LegalDestination_RepaintsBoardView** ( :x: )
+  - **Method(s) under test**: `handleSquareClick(Location)` with `BoardView` test double or spy
+  - **State of the system**: `setBoardView` called; successful move
+  - **Expected output**: `repaint()` invoked at least once after successful move
+
+- **BC-TC48: HandleSquareClick_WithSelection_IllegalDestination_DoesNotCallSwitchTurn** ( :x: )
+  - **Method(s) under test**: `handleSquareClick(Location)` with mocked `Board`
+  - **State of the system**: white piece selected; second click illegal; mock `movePiece` returns `false`
+  - **Expected output**: `switchTurn()` never called; `verify(boardMock)` passes
+
+- **BC-TC49: HandleSquareClick_WithSelection_IllegalDestination_TurnRemainsWhite** ( :x: )
+  - **Method(s) under test**: `handleSquareClick(Location)`, `getCurrentGameState()`
+  - **State of the system**: same as BC-TC48; mock `getCurrentGameState()` returns `WHITE_TURN`
+  - **Expected output**: `getCurrentGameState()` is `WHITE_TURN`
+
+- **BC-TC50: HandleSquareClick_WithSelection_IllegalDestination_ClearsSelection** ( :x: )
+  - **Method(s) under test**: `handleSquareClick(Location)`, `hasSelection()`
+  - **State of the system**: same as BC-TC48
+  - **Expected output**: `hasSelection()` is `false`
+
+- **BC-TC51: HandleSquareClick_WithSelection_OnFriendlyPiece_ChangesSelection** ( :x: )
+  - **Method(s) under test**: `handleSquareClick(Location)`, `getSelectedLocation()`
+  - **State of the system**: white rook selected at `Location(0, 7)`; second click white knight at `Location(1, 6)`; `movePiece` not called
+  - **Expected output**: `getSelectedLocation()` present with knight coordinates; `hasSelection()` true
+
+- **BC-TC52: HandleSquareClick_WithSelection_OnFriendlyPiece_DoesNotSwitchTurn** ( :x: )
+  - **Method(s) under test**: `handleSquareClick(Location)`, `getCurrentGameState()`
+  - **State of the system**: same as BC-TC51
+  - **Expected output**: `getCurrentGameState()` is `WHITE_TURN`; `switchTurn()` not called
+
+- **BC-TC53: HandleSquareClick_AfterSuccessfulMove_SnapshotReflectsNewPosition** ( :x: )
+  - **Method(s) under test**: `handleSquareClick(Location)`, `getBoardSnapshot()`
+  - **State of the system**: real `Board` with standard start; select white pawn at `(4,6)`; click `(4,5)`
+  - **Expected output**: snapshot shows pawn on rank 5 file 4 and `NONE` on rank 6 file 4

--- a/docs/bva/BoardController.md
+++ b/docs/bva/BoardController.md
@@ -344,7 +344,7 @@ _(BC-TC1, BC-TC2 cover fresh instance; selection-after-click covered under `hand
 
 ### Step 4: Test cases
 
-- **BC-TC43: SetBoardView_NoPreviousView_StoresBoardView** ( :x: )
+- **BC-TC43: SetBoardView_NoPreviousView_StoresBoardView** ( :white_check_mark: )
   - **Method(s) under test**: `setBoardView(BoardView)`
   - **State of the system**: controller constructed with injected `Board`; no view assigned yet; package-visible `getBoardView()` used only as a test observation point
   - **Expected output**: `getBoardView()` returns the same `BoardView` reference passed to `setBoardView`

--- a/docs/bva/BoardController.md
+++ b/docs/bva/BoardController.md
@@ -2,20 +2,24 @@
 
 Package: `ui.BoardController`
 
-Scope: **Game Initialization** and **Make a Legal Move (one turn)** — selection state, snapshot/turn delegation to `domain.Board`, first-click policy, second-click move completion, optional `BoardView` wiring. **Unit tests use EasyMock** (`createMock` / `createNiceMock`, `expect`, `replay`, `verify`) to stub `getSnapshot()`, `getCurrentGameState()`, `getPieceAt()`, and (for move completion) `movePiece(Location, Location)` / `switchTurn()` with test-built `Piece[][]` grids.
+Scope: **Game Initialization** and **Make a Legal Move (one turn)** — injected `domain.Board`, selection state, snapshot/turn delegation, first-click policy, second-click move completion, and optional `BoardView` wiring. **Unit tests use EasyMock** (`createMock` / `createNiceMock`, `expect`, `replay`, `verify`) to stub board collaborators. The second-click move-completion TCs are future TDD rows and require the `Board.movePiece(Location, Location): boolean` contract to be added to `Board.md` before implementation.
+
+## Method: `BoardController(board: Board)`
 
 ### Step 1: Input and output equivalence classes
 
-| Concern           | Equivalence classes                                           |
-| ----------------- | ------------------------------------------------------------- |
-| Object life cycle | Fresh instance; no clicks yet                                 |
-| Collaborators     | `Board` (mocked); **no `BoardView`** in controller unit tests |
+| Concern           | Equivalence classes                                                            |
+| ----------------- | ------------------------------------------------------------------------------ |
+| Object life cycle | Fresh controller created with an injected `Board`; no clicks yet               |
+| Collaborators     | `Board` mock or stub; no `BoardView`; `BoardView` set through `setBoardView()` |
 
 ### Step 2: BVA catalog data types
 
-| Variable / output | Catalog type | Rationale                                     |
-| ----------------- | ------------ | --------------------------------------------- |
-| `lastSelectedLoc` | Optional     | `Optional.empty()` vs `Optional.of(Location)` |
+| Variable / output | Catalog type | Rationale                                      |
+| ----------------- | ------------ | ---------------------------------------------- |
+| `board`           | Pointers     | injected collaborator object                   |
+| `boardView`       | Optional     | unset vs set through `setBoardView(BoardView)` |
+| `lastSelectedLoc` | Optional     | `Optional.empty()` vs `Optional.of(Location)`  |
 
 ### Step 3: Concrete boundary values
 
@@ -25,13 +29,13 @@ Scope: **Game Initialization** and **Make a Legal Move (one turn)** — selectio
 ### Step 4: Test cases
 
 - **BC-TC1: Constructor_FreshInstance_LastSelectedUnset** ( :white_check_mark: )
-  - **Method(s) under test**: `BoardController()`, `hasSelection()`
-  - **State of the system**: newly constructed controller
+  - **Method(s) under test**: `BoardController(Board)`, `hasSelection()`
+  - **State of the system**: newly constructed controller with an injected `Board` mock; no clicks yet
   - **Expected output**: `hasSelection()` is `false`
 
 - **BC-TC2: GetSelectedLocation_FreshInstance_ReturnsEmpty** ( :white_check_mark: )
   - **Method(s) under test**: `getSelectedLocation()`
-  - **State of the system**: newly constructed controller; no clicks yet
+  - **State of the system**: newly constructed controller with an injected `Board` mock; no clicks yet
   - **Expected output**: `Optional.empty()`
 
 ---
@@ -51,11 +55,26 @@ Scope: **Game Initialization** and **Make a Legal Move (one turn)** — selectio
 | Counts    | 16 white and 16 black pieces at standard start                             |
 | Readiness | All non-`NONE` pieces `hasMoved() == false`; turn `WHITE_TURN` via `Board` |
 
+### Step 2: BVA catalog data types
+
+| Variable / output | Catalog type | Rationale / boundaries                                     |
+| ----------------- | ------------ | ---------------------------------------------------------- |
+| Snapshot grid     | Collection   | outer collection of 8 rows; each row collection of 8 cells |
+| Snapshot cells    | Cases        | occupied piece vs `NonePiece`                              |
+| Piece color count | Counts       | 0 through 16 per color in reachable start states           |
+| Initializer mode  | Cases        | standard, fixed Chess960, seeded Fischer Random            |
+
+### Step 3: Concrete boundary values
+
+- Grid dimensions: exactly 8 rows and exactly 8 columns per row.
+- Standard start piece counts: 16 white pieces, 16 black pieces, and 32 empty cells.
+- Chess960 constraints: bishops on opposite colors; king between rooks; mirrored back-rank piece types.
+
 ### Step 4: Test cases
 
 - **BC-TC3: GetBoardSnapshot_AfterStandardInit_EightByEightGrid** ( :white_check_mark: )
   - **Method(s) under test**: `getBoardSnapshot()`
-  - **State of the system**: `new BoardController()`
+  - **State of the system**: `BoardController` constructed with a board stub whose snapshot is a standard starting grid
   - **Expected output**: outer length 8; each inner array length 8
 
 - **BC-TC4: GetBoardSnapshot_AfterStandardInit_CornerCellsOccupied** ( :white_check_mark: )
@@ -77,11 +96,6 @@ Scope: **Game Initialization** and **Make a Legal Move (one turn)** — selectio
   - **Method(s) under test**: `getBoardSnapshot()`
   - **State of the system**: standard initialization
   - **Expected output**: count of black pieces with `type != NONE` is `16`
-
-- **BC-TC8: GameStart_Standard_WhiteTurn** ( :white_check_mark: )
-  - **Method(s) under test**: `getCurrentGameState()`
-  - **State of the system**: immediately after standard new game
-  - **Expected output**: `GameState.WHITE_TURN`
 
 - **BC-TC9: GameStart_Standard_NoOccupiedPieceHasMoved** ( :white_check_mark: )
   - **Method(s) under test**: `getBoardSnapshot()`
@@ -151,6 +165,35 @@ Scope: **Game Initialization** and **Make a Legal Move (one turn)** — selectio
 
 ---
 
+## Method: `getCurrentGameState(): GameState`
+
+### Step 1: Input and output equivalence classes
+
+| Input / output         | Classes                      |
+| ---------------------- | ---------------------------- |
+| Underlying board state | white to move; black to move |
+| Returned game state    | `WHITE_TURN`; `BLACK_TURN`   |
+
+### Step 2: BVA catalog data types
+
+| Variable / output | Catalog type | Rationale                                                       |
+| ----------------- | ------------ | --------------------------------------------------------------- |
+| `GameState`       | Cases        | controller delegates and returns the board's current enum value |
+
+### Step 3: Concrete boundary values
+
+- New board state: `WHITE_TURN`.
+- After a successful turn switch: `BLACK_TURN`.
+
+### Step 4: Test cases
+
+- **BC-TC8: GameStart_Standard_WhiteTurn** ( :white_check_mark: )
+  - **Method(s) under test**: `getCurrentGameState()`
+  - **State of the system**: immediately after standard new game
+  - **Expected output**: `GameState.WHITE_TURN`
+
+---
+
 ## Method: `hasSelection(): boolean` / `getSelectedLocation(): Optional<Location>`
 
 ### Step 1: Input and output equivalence classes
@@ -165,6 +208,11 @@ Scope: **Game Initialization** and **Make a Legal Move (one turn)** — selectio
 | Concern         | Catalog type               |
 | --------------- | -------------------------- |
 | Selection state | Optional: empty vs present |
+
+### Step 3: Concrete boundary values
+
+- Empty selection: new controller before any valid piece click.
+- Present selection: after a valid white-piece first click.
 
 ### Step 4: Test cases
 
@@ -259,7 +307,7 @@ _(BC-TC1, BC-TC2 cover fresh instance; selection-after-click covered under `hand
 
 - **BC-TC41: HandleSquareClick_Chess960Start_FirstWhiteSelection_SelectedLocationMatches** ( :white_check_mark: )
   - **Method(s) under test**: `handleSquareClick(Location)`, `getSelectedLocation()`
-  - **State of the system**: Chess960 fixed start; click `Location(0, 1)`
+  - **State of the system**: Chess960 fixed start; click white pawn at `Location(0, 6)`
   - **Expected output**: `getSelectedLocation()` present with same coordinates
 
 - **BC-TC42: HandleSquareClick_Chess960Start_FirstWhiteSelection_TurnRemainsWhite** ( :white_check_mark: )
@@ -269,17 +317,58 @@ _(BC-TC1, BC-TC2 cover fresh instance; selection-after-click covered under `hand
 
 ---
 
-## Method: `handleSquareClick(loc: Location)` — move completion (second click)
-
-Scope: **Make a Legal Move (one turn)** — applies when `lastSelectedLoc` is present. Depends on `Board.movePiece` returning `true`/`false`. Team policy for illegal destination: **clear selection** after failed move (document in implementation notes).
+## Method: `setBoardView(boardView: BoardView)`
 
 ### Step 1: Input and output equivalence classes
 
-| Input                       | Classes                                                                  |
-| --------------------------- | ------------------------------------------------------------------------ |
-| Selection state             | `Optional.of(origin)` vs `Optional.empty()` (first click — above)        |
-| Destination at second click | Legal empty; legal capture; illegal shape/path; friendly square          |
-| Active turn                 | `WHITE_TURN` (black move completion deferred to Alternating Turns story) |
+| Input / state | Classes                           |
+| ------------- | --------------------------------- |
+| `boardView`   | concrete `BoardView` collaborator |
+| Prior state   | no view set; view already set     |
+
+| Output / side effect | Classes                                           |
+| -------------------- | ------------------------------------------------- |
+| Stored collaborator  | subsequent repaint path can use the assigned view |
+
+### Step 2: BVA catalog data types
+
+| Variable / output | Catalog type | Rationale                          |
+| ----------------- | ------------ | ---------------------------------- |
+| `boardView`       | Pointers     | real collaborator object reference |
+| Previous view     | Optional     | unset vs present                   |
+
+### Step 3: Concrete boundary values
+
+- No previous view assigned.
+- One previous view assigned and replaced by another view.
+
+### Step 4: Test cases
+
+- **BC-TC43: SetBoardView_NoPreviousView_StoresBoardView** ( :x: )
+  - **Method(s) under test**: `setBoardView(BoardView)`
+  - **State of the system**: controller constructed with injected `Board`; no view assigned yet; package-visible `getBoardView()` used only as a test observation point
+  - **Expected output**: `getBoardView()` returns the same `BoardView` reference passed to `setBoardView`
+
+- **BC-TC44: SetBoardView_ExistingView_ReplacesBoardView** ( :x: )
+  - **Method(s) under test**: `setBoardView(BoardView)`
+  - **State of the system**: controller has one view assigned; `setBoardView` called again with a different `BoardView`
+  - **Expected output**: `getBoardView()` returns the second `BoardView` reference
+
+---
+
+## Method: `handleSquareClick(loc: Location)` — move completion (second click)
+
+Scope: **Make a Legal Move (one turn)** — applies when `lastSelectedLoc` is present. Depends on the future `Board.movePiece(Location, Location): boolean` contract. Before implementing these controller TCs, add the matching public method BVA and production API to `Board`. Team policy: an illegal destination clears selection; clicking a friendly piece is a separate reselection case and keeps selection.
+
+### Step 1: Input and output equivalence classes
+
+| Input                   | Classes                                                                  |
+| ----------------------- | ------------------------------------------------------------------------ |
+| Selection state         | `Optional.of(origin)` vs `Optional.empty()` (first-click path above)     |
+| Destination coordinates | in-bounds; out-of-bounds low; out-of-bounds high                         |
+| Destination square      | legal empty; legal capture; illegal shape/path; friendly occupied square |
+| Active turn             | `WHITE_TURN` (black move completion deferred to Alternating Turns story) |
+| View collaborator       | no `BoardView` set; `BoardView` set                                      |
 
 | Output / side effect        | Classes                                                             |
 | --------------------------- | ------------------------------------------------------------------- |
@@ -287,70 +376,85 @@ Scope: **Make a Legal Move (one turn)** — applies when `lastSelectedLoc` is pr
 | `Board.switchTurn`          | Called only after `movePiece` returns `true`                        |
 | Selection after success     | Cleared (`hasSelection()` false)                                    |
 | Selection after failed move | Cleared (team policy)                                               |
+| Selection after friendly    | Changed to the friendly destination                                 |
 | `BoardView.repaint`         | Invoked when view is set                                            |
-| Snapshot                    | Updated only when real board used; unchanged when mock rejects move |
+| Snapshot                    | Delegated through `Board.getSnapshot()` after board state changes   |
 
 ### Step 2: BVA catalog data types
 
-| Variable / output       | Catalog type | Rationale                          |
-| ----------------------- | ------------ | ---------------------------------- |
-| `lastSelectedLoc`       | Optional     | present only for second-click path |
-| `movePiece` return      | Boolean      | success vs rejection               |
-| `getCurrentGameState()` | Cases        | `WHITE_TURN`, `BLACK_TURN`         |
+| Variable / output       | Catalog type        | Rationale / boundaries                                  |
+| ----------------------- | ------------------- | ------------------------------------------------------- |
+| `loc.x`, `loc.y`        | Intervals           | invalid `-1`, valid min `0`, valid max `7`, invalid `8` |
+| `lastSelectedLoc`       | Optional            | empty vs present; present selects second-click path     |
+| Destination square      | Cases               | empty, enemy piece, friendly piece                      |
+| `movePiece` return      | Boolean             | success vs rejection                                    |
+| `getCurrentGameState()` | Cases               | `WHITE_TURN`, `BLACK_TURN`                              |
+| `boardView`             | Optional / Pointers | no view set vs concrete view reference                  |
+
+### Step 3: Concrete boundary values
+
+- In-bounds destination examples: `Location(4, 5)` for a legal white pawn advance; `Location(4, 4)` for an illegal two-step shape after state is not initial.
+- Out-of-bounds destination examples: `Location(-1, 5)`, `Location(8, 5)`, `Location(4, -1)`, `Location(4, 8)`.
+- Friendly reselection example: selected white rook at `Location(0, 7)`, second click white knight at `Location(1, 7)` in a standard starting grid.
 
 ### Step 4: Test cases
 
-- **BC-TC43: HandleSquareClick_WithSelection_LegalDestination_CallsMovePiece** ( :x: )
+- **BC-TC45: HandleSquareClick_WithSelection_LegalDestination_CallsMovePiece** ( :x: )
   - **Method(s) under test**: `handleSquareClick(Location)` with mocked `Board`
   - **State of the system**: white pawn selected at `Location(4, 6)`; second click `Location(4, 5)`; mock `movePiece(from, to)` returns `true`
   - **Expected output**: `movePiece` invoked once with matching `from`/`to`; `verify(boardMock)` passes
 
-- **BC-TC44: HandleSquareClick_WithSelection_LegalDestination_CallsSwitchTurn** ( :x: )
+- **BC-TC46: HandleSquareClick_WithSelection_LegalDestination_CallsSwitchTurn** ( :x: )
   - **Method(s) under test**: `handleSquareClick(Location)` with mocked `Board`
-  - **State of the system**: same as BC-TC43; `movePiece` returns `true`
+  - **State of the system**: same as BC-TC45; `movePiece` returns `true`
   - **Expected output**: `switchTurn()` called once after successful move
 
-- **BC-TC45: HandleSquareClick_WithSelection_LegalDestination_ClearsSelection** ( :x: )
+- **BC-TC47: HandleSquareClick_WithSelection_LegalDestination_ClearsSelection** ( :x: )
   - **Method(s) under test**: `handleSquareClick(Location)`, `hasSelection()`
-  - **State of the system**: same as BC-TC43
+  - **State of the system**: same as BC-TC45
   - **Expected output**: `hasSelection()` is `false` after second click
 
-- **BC-TC46: HandleSquareClick_WithSelection_LegalDestination_TurnBecomesBlack** ( :x: )
+- **BC-TC48: HandleSquareClick_WithSelection_LegalDestination_TurnBecomesBlack** ( :x: )
   - **Method(s) under test**: `handleSquareClick(Location)`, `getCurrentGameState()`
-  - **State of the system**: integration-style test with real `Board(Piece[][])` and legal white pawn move; or mock returning `BLACK_TURN` after `switchTurn`
+  - **State of the system**: controller unit test with mocked `Board`; selected white pawn; `movePiece` returns `true`; `getCurrentGameState()` returns `BLACK_TURN` after `switchTurn()`
   - **Expected output**: `getCurrentGameState()` is `BLACK_TURN`
 
-- **BC-TC47: HandleSquareClick_WithSelection_LegalDestination_RepaintsBoardView** ( :x: )
-  - **Method(s) under test**: `handleSquareClick(Location)` with `BoardView` test double or spy
-  - **State of the system**: `setBoardView` called; successful move
-  - **Expected output**: `repaint()` invoked at least once after successful move
+- **BC-TC49: HandleSquareClick_WithSelection_LegalDestination_RepaintsBoardView** ( :x: )
+  - **Method(s) under test**: `handleSquareClick(Location)` with mocked `BoardView`
+  - **State of the system**: `setBoardView` called with a view mock; selected white pawn; `movePiece` returns `true`
+  - **Expected output**: `repaint()` invoked once after successful move; `verify(boardViewMock)` passes
 
-- **BC-TC48: HandleSquareClick_WithSelection_IllegalDestination_DoesNotCallSwitchTurn** ( :x: )
+- **BC-TC50: HandleSquareClick_WithSelection_IllegalDestination_DoesNotCallSwitchTurn** ( :x: )
   - **Method(s) under test**: `handleSquareClick(Location)` with mocked `Board`
   - **State of the system**: white piece selected; second click illegal; mock `movePiece` returns `false`
   - **Expected output**: `switchTurn()` never called; `verify(boardMock)` passes
 
-- **BC-TC49: HandleSquareClick_WithSelection_IllegalDestination_TurnRemainsWhite** ( :x: )
+- **BC-TC51: HandleSquareClick_WithSelection_IllegalDestination_TurnRemainsWhite** ( :x: )
   - **Method(s) under test**: `handleSquareClick(Location)`, `getCurrentGameState()`
-  - **State of the system**: same as BC-TC48; mock `getCurrentGameState()` returns `WHITE_TURN`
+  - **State of the system**: same as BC-TC50; mock `getCurrentGameState()` returns `WHITE_TURN`
   - **Expected output**: `getCurrentGameState()` is `WHITE_TURN`
 
-- **BC-TC50: HandleSquareClick_WithSelection_IllegalDestination_ClearsSelection** ( :x: )
+- **BC-TC52: HandleSquareClick_WithSelection_IllegalDestination_ClearsSelection** ( :x: )
   - **Method(s) under test**: `handleSquareClick(Location)`, `hasSelection()`
-  - **State of the system**: same as BC-TC48
+  - **State of the system**: same as BC-TC50
   - **Expected output**: `hasSelection()` is `false`
 
-- **BC-TC51: HandleSquareClick_WithSelection_OnFriendlyPiece_ChangesSelection** ( :x: )
+- **BC-TC53: HandleSquareClick_WithSelection_OnFriendlyPiece_ChangesSelection** ( :x: )
   - **Method(s) under test**: `handleSquareClick(Location)`, `getSelectedLocation()`
-  - **State of the system**: white rook selected at `Location(0, 7)`; second click white knight at `Location(1, 6)`; `movePiece` not called
+  - **State of the system**: white rook selected at `Location(0, 7)`; second click white knight at `Location(1, 7)`; `movePiece` not called
   - **Expected output**: `getSelectedLocation()` present with knight coordinates; `hasSelection()` true
 
-- **BC-TC52: HandleSquareClick_WithSelection_OnFriendlyPiece_DoesNotSwitchTurn** ( :x: )
+- **BC-TC54: HandleSquareClick_WithSelection_OnFriendlyPiece_DoesNotSwitchTurn** ( :x: )
   - **Method(s) under test**: `handleSquareClick(Location)`, `getCurrentGameState()`
-  - **State of the system**: same as BC-TC51
+  - **State of the system**: same as BC-TC53
   - **Expected output**: `getCurrentGameState()` is `WHITE_TURN`; `switchTurn()` not called
 
-- **BC-TC53: HandleSquareClick_AfterSuccessfulMove_SnapshotReflectsNewPosition** ( :x: )
+- **BC-TC55: HandleSquareClick_WithSelection_OutOfBoundsDestination_DoesNotCallMovePiece** ( :x: )
+  - **Method(s) under test**: `handleSquareClick(Location)`, `hasSelection()`
+  - **State of the system**: white pawn selected at `Location(4, 6)`; second click out of bounds at `Location(8, 5)`
+  - **Expected output**: `movePiece` and `switchTurn` are not called; selection remains on the original pawn
+
+- **BC-TC56: HandleSquareClick_AfterSuccessfulMove_SnapshotReflectsNewPosition** ( :x: )
   - **Method(s) under test**: `handleSquareClick(Location)`, `getBoardSnapshot()`
-  - **State of the system**: real `Board` with standard start; select white pawn at `(4,6)`; click `(4,5)`
+  - **State of the system**: controller unit test with mocked `Board`; selected white pawn; `movePiece` returns `true`; later `getSnapshot()` returns a test-built post-move grid
   - **Expected output**: snapshot shows pawn on rank 5 file 4 and `NONE` on rank 6 file 4

--- a/docs/bva/BoardController.md
+++ b/docs/bva/BoardController.md
@@ -444,7 +444,7 @@ Scope: **Make a Legal Move (one turn)** — applies when `lastSelectedLoc` is pr
   - **State of the system**: white rook selected at `Location(0, 7)`; second click white knight at `Location(1, 7)`; `movePiece` not called
   - **Expected output**: `getSelectedLocation()` present with knight coordinates; `hasSelection()` true
 
-- **BC-TC54: HandleSquareClick_WithSelection_OnFriendlyPiece_DoesNotSwitchTurn** ( :x: )
+- **BC-TC54: HandleSquareClick_WithSelection_OnFriendlyPiece_DoesNotSwitchTurn** ( :white_check_mark: )
   - **Method(s) under test**: `handleSquareClick(Location)`, `getCurrentGameState()`
   - **State of the system**: same as BC-TC53
   - **Expected output**: `getCurrentGameState()` is `WHITE_TURN`; `switchTurn()` not called

--- a/docs/bva/BoardController.md
+++ b/docs/bva/BoardController.md
@@ -399,7 +399,7 @@ Scope: **Make a Legal Move (one turn)** — applies when `lastSelectedLoc` is pr
 
 ### Step 4: Test cases
 
-- **BC-TC45: HandleSquareClick_WithSelection_LegalDestination_CallsMovePiece** ( :x: )
+- **BC-TC45: HandleSquareClick_WithSelection_LegalDestination_CallsMovePiece** ( :white_check_mark: )
   - **Method(s) under test**: `handleSquareClick(Location)` with mocked `Board`
   - **State of the system**: white pawn selected at `Location(4, 6)`; second click `Location(4, 5)`; mock `movePiece(from, to)` returns `true`
   - **Expected output**: `movePiece` invoked once with matching `from`/`to`; `verify(boardMock)` passes

--- a/docs/bva/BoardController.md
+++ b/docs/bva/BoardController.md
@@ -409,7 +409,7 @@ Scope: **Make a Legal Move (one turn)** — applies when `lastSelectedLoc` is pr
   - **State of the system**: same as BC-TC45; `movePiece` returns `true`
   - **Expected output**: `switchTurn()` called once after successful move
 
-- **BC-TC47: HandleSquareClick_WithSelection_LegalDestination_ClearsSelection** ( :x: )
+- **BC-TC47: HandleSquareClick_WithSelection_LegalDestination_ClearsSelection** ( :white_check_mark: )
   - **Method(s) under test**: `handleSquareClick(Location)`, `hasSelection()`
   - **State of the system**: same as BC-TC45
   - **Expected output**: `hasSelection()` is `false` after second click

--- a/docs/bva/BoardController.md
+++ b/docs/bva/BoardController.md
@@ -449,7 +449,7 @@ Scope: **Make a Legal Move (one turn)** — applies when `lastSelectedLoc` is pr
   - **State of the system**: same as BC-TC53
   - **Expected output**: `getCurrentGameState()` is `WHITE_TURN`; `switchTurn()` not called
 
-- **BC-TC55: HandleSquareClick_WithSelection_OutOfBoundsDestination_DoesNotCallMovePiece** ( :x: )
+- **BC-TC55: HandleSquareClick_WithSelection_OutOfBoundsDestination_DoesNotCallMovePiece** ( :white_check_mark: )
   - **Method(s) under test**: `handleSquareClick(Location)`, `hasSelection()`
   - **State of the system**: white pawn selected at `Location(4, 6)`; second click out of bounds at `Location(8, 5)`
   - **Expected output**: `movePiece` and `switchTurn` are not called; selection remains on the original pawn

--- a/docs/bva/BoardController.md
+++ b/docs/bva/BoardController.md
@@ -434,7 +434,7 @@ Scope: **Make a Legal Move (one turn)** — applies when `lastSelectedLoc` is pr
   - **State of the system**: same as BC-TC50; mock `getCurrentGameState()` returns `WHITE_TURN`
   - **Expected output**: `getCurrentGameState()` is `WHITE_TURN`
 
-- **BC-TC52: HandleSquareClick_WithSelection_IllegalDestination_ClearsSelection** ( :x: )
+- **BC-TC52: HandleSquareClick_WithSelection_IllegalDestination_ClearsSelection** ( :white_check_mark: )
   - **Method(s) under test**: `handleSquareClick(Location)`, `hasSelection()`
   - **State of the system**: same as BC-TC50
   - **Expected output**: `hasSelection()` is `false`

--- a/docs/bva/BoardController.md
+++ b/docs/bva/BoardController.md
@@ -419,7 +419,7 @@ Scope: **Make a Legal Move (one turn)** — applies when `lastSelectedLoc` is pr
   - **State of the system**: controller unit test with mocked `Board`; selected white pawn; `movePiece` returns `true`; `getCurrentGameState()` returns `BLACK_TURN` after `switchTurn()`
   - **Expected output**: `getCurrentGameState()` is `BLACK_TURN`
 
-- **BC-TC49: HandleSquareClick_WithSelection_LegalDestination_RepaintsBoardView** ( :x: )
+- **BC-TC49: HandleSquareClick_WithSelection_LegalDestination_RepaintsBoardView** ( :white_check_mark: )
   - **Method(s) under test**: `handleSquareClick(Location)` with mocked `BoardView`
   - **State of the system**: `setBoardView` called with a view mock; selected white pawn; `movePiece` returns `true`
   - **Expected output**: `repaint()` invoked once after successful move; `verify(boardViewMock)` passes

--- a/docs/bva/BoardController.md
+++ b/docs/bva/BoardController.md
@@ -454,7 +454,7 @@ Scope: **Make a Legal Move (one turn)** — applies when `lastSelectedLoc` is pr
   - **State of the system**: white pawn selected at `Location(4, 6)`; second click out of bounds at `Location(8, 5)`
   - **Expected output**: `movePiece` and `switchTurn` are not called; selection remains on the original pawn
 
-- **BC-TC56: HandleSquareClick_AfterSuccessfulMove_SnapshotReflectsNewPosition** ( :x: )
+- **BC-TC56: HandleSquareClick_AfterSuccessfulMove_SnapshotReflectsNewPosition** ( :white_check_mark: )
   - **Method(s) under test**: `handleSquareClick(Location)`, `getBoardSnapshot()`
   - **State of the system**: controller unit test with mocked `Board`; selected white pawn; `movePiece` returns `true`; later `getSnapshot()` returns a test-built post-move grid
   - **Expected output**: snapshot shows pawn on rank 5 file 4 and `NONE` on rank 6 file 4

--- a/docs/bva/BoardController.md
+++ b/docs/bva/BoardController.md
@@ -424,7 +424,7 @@ Scope: **Make a Legal Move (one turn)** — applies when `lastSelectedLoc` is pr
   - **State of the system**: `setBoardView` called with a view mock; selected white pawn; `movePiece` returns `true`
   - **Expected output**: `repaint()` invoked once after successful move; `verify(boardViewMock)` passes
 
-- **BC-TC50: HandleSquareClick_WithSelection_IllegalDestination_DoesNotCallSwitchTurn** ( :x: )
+- **BC-TC50: HandleSquareClick_WithSelection_IllegalDestination_DoesNotCallSwitchTurn** ( :white_check_mark: )
   - **Method(s) under test**: `handleSquareClick(Location)` with mocked `Board`
   - **State of the system**: white piece selected; second click illegal; mock `movePiece` returns `false`
   - **Expected output**: `switchTurn()` never called; `verify(boardMock)` passes

--- a/docs/bva/BoardController.md
+++ b/docs/bva/BoardController.md
@@ -429,7 +429,7 @@ Scope: **Make a Legal Move (one turn)** — applies when `lastSelectedLoc` is pr
   - **State of the system**: white piece selected; second click illegal; mock `movePiece` returns `false`
   - **Expected output**: `switchTurn()` never called; `verify(boardMock)` passes
 
-- **BC-TC51: HandleSquareClick_WithSelection_IllegalDestination_TurnRemainsWhite** ( :x: )
+- **BC-TC51: HandleSquareClick_WithSelection_IllegalDestination_TurnRemainsWhite** ( :white_check_mark: )
   - **Method(s) under test**: `handleSquareClick(Location)`, `getCurrentGameState()`
   - **State of the system**: same as BC-TC50; mock `getCurrentGameState()` returns `WHITE_TURN`
   - **Expected output**: `getCurrentGameState()` is `WHITE_TURN`

--- a/docs/bva/BoardController.md
+++ b/docs/bva/BoardController.md
@@ -404,7 +404,7 @@ Scope: **Make a Legal Move (one turn)** — applies when `lastSelectedLoc` is pr
   - **State of the system**: white pawn selected at `Location(4, 6)`; second click `Location(4, 5)`; mock `movePiece(from, to)` returns `true`
   - **Expected output**: `movePiece` invoked once with matching `from`/`to`; `verify(boardMock)` passes
 
-- **BC-TC46: HandleSquareClick_WithSelection_LegalDestination_CallsSwitchTurn** ( :x: )
+- **BC-TC46: HandleSquareClick_WithSelection_LegalDestination_CallsSwitchTurn** ( :white_check_mark: )
   - **Method(s) under test**: `handleSquareClick(Location)` with mocked `Board`
   - **State of the system**: same as BC-TC45; `movePiece` returns `true`
   - **Expected output**: `switchTurn()` called once after successful move

--- a/docs/bva/BoardController.md
+++ b/docs/bva/BoardController.md
@@ -349,7 +349,7 @@ _(BC-TC1, BC-TC2 cover fresh instance; selection-after-click covered under `hand
   - **State of the system**: controller constructed with injected `Board`; no view assigned yet; package-visible `getBoardView()` used only as a test observation point
   - **Expected output**: `getBoardView()` returns the same `BoardView` reference passed to `setBoardView`
 
-- **BC-TC44: SetBoardView_ExistingView_ReplacesBoardView** ( :x: )
+- **BC-TC44: SetBoardView_ExistingView_ReplacesBoardView** ( :white_check_mark: )
   - **Method(s) under test**: `setBoardView(BoardView)`
   - **State of the system**: controller has one view assigned; `setBoardView` called again with a different `BoardView`
   - **Expected output**: `getBoardView()` returns the second `BoardView` reference

--- a/docs/bva/BoardController.md
+++ b/docs/bva/BoardController.md
@@ -439,7 +439,7 @@ Scope: **Make a Legal Move (one turn)** — applies when `lastSelectedLoc` is pr
   - **State of the system**: same as BC-TC50
   - **Expected output**: `hasSelection()` is `false`
 
-- **BC-TC53: HandleSquareClick_WithSelection_OnFriendlyPiece_ChangesSelection** ( :x: )
+- **BC-TC53: HandleSquareClick_WithSelection_OnFriendlyPiece_ChangesSelection** ( :white_check_mark: )
   - **Method(s) under test**: `handleSquareClick(Location)`, `getSelectedLocation()`
   - **State of the system**: white rook selected at `Location(0, 7)`; second click white knight at `Location(1, 7)`; `movePiece` not called
   - **Expected output**: `getSelectedLocation()` present with knight coordinates; `hasSelection()` true

--- a/docs/bva/BoardController.md
+++ b/docs/bva/BoardController.md
@@ -414,7 +414,7 @@ Scope: **Make a Legal Move (one turn)** — applies when `lastSelectedLoc` is pr
   - **State of the system**: same as BC-TC45
   - **Expected output**: `hasSelection()` is `false` after second click
 
-- **BC-TC48: HandleSquareClick_WithSelection_LegalDestination_TurnBecomesBlack** ( :x: )
+- **BC-TC48: HandleSquareClick_WithSelection_LegalDestination_TurnBecomesBlack** ( :white_check_mark: )
   - **Method(s) under test**: `handleSquareClick(Location)`, `getCurrentGameState()`
   - **State of the system**: controller unit test with mocked `Board`; selected white pawn; `movePiece` returns `true`; `getCurrentGameState()` returns `BLACK_TURN` after `switchTurn()`
   - **Expected output**: `getCurrentGameState()` is `BLACK_TURN`

--- a/src/main/java/domain/Board.java
+++ b/src/main/java/domain/Board.java
@@ -1,6 +1,7 @@
 package domain;
 
 import domain.gamestate.GameState;
+import domain.location.Location;
 import domain.piece.Bishop;
 import domain.piece.King;
 import domain.piece.Knight;
@@ -74,5 +75,9 @@ public class Board {
             }
         }
         return snapshot;
+    }
+
+    public boolean movePiece(Location from, Location to) {
+        return false;
     }
 }

--- a/src/main/java/ui/BoardController.java
+++ b/src/main/java/ui/BoardController.java
@@ -47,6 +47,8 @@ public class BoardController {
         board.switchTurn();
         lastSelectedLoc = Optional.empty();
         repaintBoardView();
+      } else {
+        lastSelectedLoc = Optional.empty();
       }
       return;
     }

--- a/src/main/java/ui/BoardController.java
+++ b/src/main/java/ui/BoardController.java
@@ -42,7 +42,10 @@ public class BoardController {
       return;
     }
     if (lastSelectedLoc.isPresent()) {
-      board.movePiece(lastSelectedLoc.get(), loc);
+      boolean moved = board.movePiece(lastSelectedLoc.get(), loc);
+      if (moved) {
+        board.switchTurn();
+      }
       return;
     }
     int file = loc.getX();

--- a/src/main/java/ui/BoardController.java
+++ b/src/main/java/ui/BoardController.java
@@ -45,6 +45,7 @@ public class BoardController {
       boolean moved = board.movePiece(lastSelectedLoc.get(), loc);
       if (moved) {
         board.switchTurn();
+        lastSelectedLoc = Optional.empty();
       }
       return;
     }

--- a/src/main/java/ui/BoardController.java
+++ b/src/main/java/ui/BoardController.java
@@ -41,6 +41,10 @@ public class BoardController {
     if (!isInBounds(loc)) {
       return;
     }
+    if (lastSelectedLoc.isPresent()) {
+      board.movePiece(lastSelectedLoc.get(), loc);
+      return;
+    }
     int file = loc.getX();
     int rank = loc.getY();
     Piece at = board.getPieceAt(rank, file);

--- a/src/main/java/ui/BoardController.java
+++ b/src/main/java/ui/BoardController.java
@@ -46,6 +46,7 @@ public class BoardController {
       if (moved) {
         board.switchTurn();
         lastSelectedLoc = Optional.empty();
+        repaintBoardView();
       }
       return;
     }

--- a/src/main/java/ui/BoardController.java
+++ b/src/main/java/ui/BoardController.java
@@ -42,6 +42,14 @@ public class BoardController {
       return;
     }
     if (lastSelectedLoc.isPresent()) {
+      int file = loc.getX();
+      int rank = loc.getY();
+      Piece at = board.getPieceAt(rank, file);
+      if (at.getType() != PieceType.NONE && at.getColor() == PieceColor.WHITE) {
+        lastSelectedLoc = Optional.of(loc);
+        repaintBoardView();
+        return;
+      }
       boolean moved = board.movePiece(lastSelectedLoc.get(), loc);
       if (moved) {
         board.switchTurn();

--- a/src/test/java/ui/BoardControllerTest.java
+++ b/src/test/java/ui/BoardControllerTest.java
@@ -852,6 +852,29 @@ class BoardControllerTest {
         EasyMock.verify(boardMock);
     }
 
+    @Test
+    void HandleSquareClick_WithSelection_OnFriendlyPiece_DoesNotSwitchTurn() {
+        Location origin = new Location(0, 7);
+        Location destination = new Location(1, 7);
+        Board boardMock = EasyMock.createMock(Board.class);
+        EasyMock.expect(boardMock.getPieceAt(origin.getY(), origin.getX()))
+                .andReturn(new Rook(PieceColor.WHITE));
+        EasyMock.expect(boardMock.getCurrentGameState()).andReturn(GameState.WHITE_TURN);
+        EasyMock.expect(boardMock.getPieceAt(destination.getY(), destination.getX()))
+                .andReturn(new Knight(PieceColor.WHITE));
+        EasyMock.expect(boardMock.getCurrentGameState()).andReturn(GameState.WHITE_TURN);
+        EasyMock.replay(boardMock);
+        BoardController controller = new BoardController(boardMock);
+
+        controller.handleSquareClick(origin);
+        controller.handleSquareClick(destination);
+
+        GameState expected = GameState.WHITE_TURN;
+        GameState actual = controller.getCurrentGameState();
+        assertEquals(expected, actual);
+        EasyMock.verify(boardMock);
+    }
+
     private static Board replayNiceBoard() {
         Board boardMock = EasyMock.createNiceMock(Board.class);
         EasyMock.replay(boardMock);

--- a/src/test/java/ui/BoardControllerTest.java
+++ b/src/test/java/ui/BoardControllerTest.java
@@ -793,6 +793,27 @@ class BoardControllerTest {
         EasyMock.verify(boardMock);
     }
 
+    @Test
+    void HandleSquareClick_WithSelection_IllegalDestination_ClearsSelection() {
+        Location origin = new Location(4, 6);
+        Location destination = new Location(4, 4);
+        Board boardMock = EasyMock.createMock(Board.class);
+        EasyMock.expect(boardMock.getCurrentGameState()).andStubReturn(GameState.WHITE_TURN);
+        EasyMock.expect(boardMock.getPieceAt(origin.getY(), origin.getX()))
+                .andReturn(new Pawn(PieceColor.WHITE));
+        EasyMock.expect(boardMock.movePiece(origin, destination)).andReturn(false);
+        EasyMock.replay(boardMock);
+        BoardController controller = new BoardController(boardMock);
+
+        controller.handleSquareClick(origin);
+        controller.handleSquareClick(destination);
+
+        boolean expected = false;
+        boolean actual = controller.hasSelection();
+        assertEquals(expected, actual);
+        EasyMock.verify(boardMock);
+    }
+
     private static Board replayNiceBoard() {
         Board boardMock = EasyMock.createNiceMock(Board.class);
         EasyMock.replay(boardMock);

--- a/src/test/java/ui/BoardControllerTest.java
+++ b/src/test/java/ui/BoardControllerTest.java
@@ -686,6 +686,27 @@ class BoardControllerTest {
         EasyMock.verify(boardMock);
     }
 
+    @Test
+    void HandleSquareClick_WithSelection_LegalDestination_ClearsSelection() {
+        Location origin = new Location(4, 6);
+        Location destination = new Location(4, 5);
+        Board boardMock = EasyMock.createNiceMock(Board.class);
+        EasyMock.expect(boardMock.getCurrentGameState()).andStubReturn(GameState.WHITE_TURN);
+        EasyMock.expect(boardMock.getPieceAt(origin.getY(), origin.getX()))
+                .andReturn(new Pawn(PieceColor.WHITE));
+        EasyMock.expect(boardMock.movePiece(origin, destination)).andReturn(true);
+        EasyMock.replay(boardMock);
+        BoardController controller = new BoardController(boardMock);
+
+        controller.handleSquareClick(origin);
+        controller.handleSquareClick(destination);
+
+        boolean expected = false;
+        boolean actual = controller.hasSelection();
+        assertEquals(expected, actual);
+        EasyMock.verify(boardMock);
+    }
+
     private static Board replayNiceBoard() {
         Board boardMock = EasyMock.createNiceMock(Board.class);
         EasyMock.replay(boardMock);

--- a/src/test/java/ui/BoardControllerTest.java
+++ b/src/test/java/ui/BoardControllerTest.java
@@ -648,6 +648,24 @@ class BoardControllerTest {
         EasyMock.verify(boardMock, originalViewMock, replacementViewMock);
     }
 
+    @Test
+    void HandleSquareClick_WithSelection_LegalDestination_CallsMovePiece() {
+        Location origin = new Location(4, 6);
+        Location destination = new Location(4, 5);
+        Board boardMock = EasyMock.createMock(Board.class);
+        EasyMock.expect(boardMock.getCurrentGameState()).andStubReturn(GameState.WHITE_TURN);
+        EasyMock.expect(boardMock.getPieceAt(origin.getY(), origin.getX()))
+                .andReturn(new Pawn(PieceColor.WHITE));
+        EasyMock.expect(boardMock.movePiece(origin, destination)).andReturn(true);
+        EasyMock.replay(boardMock);
+        BoardController controller = new BoardController(boardMock);
+
+        controller.handleSquareClick(origin);
+        controller.handleSquareClick(destination);
+
+        EasyMock.verify(boardMock);
+    }
+
     private static Board replayNiceBoard() {
         Board boardMock = EasyMock.createNiceMock(Board.class);
         EasyMock.replay(boardMock);

--- a/src/test/java/ui/BoardControllerTest.java
+++ b/src/test/java/ui/BoardControllerTest.java
@@ -707,6 +707,30 @@ class BoardControllerTest {
         EasyMock.verify(boardMock);
     }
 
+    @Test
+    void HandleSquareClick_WithSelection_LegalDestination_TurnBecomesBlack() {
+        Location origin = new Location(4, 6);
+        Location destination = new Location(4, 5);
+        Board boardMock = EasyMock.createMock(Board.class);
+        EasyMock.expect(boardMock.getPieceAt(origin.getY(), origin.getX()))
+                .andReturn(new Pawn(PieceColor.WHITE));
+        EasyMock.expect(boardMock.getCurrentGameState()).andReturn(GameState.WHITE_TURN);
+        EasyMock.expect(boardMock.movePiece(origin, destination)).andReturn(true);
+        boardMock.switchTurn();
+        EasyMock.expectLastCall();
+        EasyMock.expect(boardMock.getCurrentGameState()).andReturn(GameState.BLACK_TURN);
+        EasyMock.replay(boardMock);
+        BoardController controller = new BoardController(boardMock);
+
+        controller.handleSquareClick(origin);
+        controller.handleSquareClick(destination);
+
+        GameState expected = GameState.BLACK_TURN;
+        GameState actual = controller.getCurrentGameState();
+        assertEquals(expected, actual);
+        EasyMock.verify(boardMock);
+    }
+
     private static Board replayNiceBoard() {
         Board boardMock = EasyMock.createNiceMock(Board.class);
         EasyMock.replay(boardMock);

--- a/src/test/java/ui/BoardControllerTest.java
+++ b/src/test/java/ui/BoardControllerTest.java
@@ -656,6 +656,8 @@ class BoardControllerTest {
         EasyMock.expect(boardMock.getCurrentGameState()).andStubReturn(GameState.WHITE_TURN);
         EasyMock.expect(boardMock.getPieceAt(origin.getY(), origin.getX()))
                 .andReturn(new Pawn(PieceColor.WHITE));
+        EasyMock.expect(boardMock.getPieceAt(destination.getY(), destination.getX()))
+                .andReturn(new NonePiece());
         EasyMock.expect(boardMock.movePiece(origin, destination)).andReturn(true);
         EasyMock.replay(boardMock);
         BoardController controller = new BoardController(boardMock);
@@ -674,6 +676,8 @@ class BoardControllerTest {
         EasyMock.expect(boardMock.getCurrentGameState()).andStubReturn(GameState.WHITE_TURN);
         EasyMock.expect(boardMock.getPieceAt(origin.getY(), origin.getX()))
                 .andReturn(new Pawn(PieceColor.WHITE));
+        EasyMock.expect(boardMock.getPieceAt(destination.getY(), destination.getX()))
+                .andReturn(new NonePiece());
         EasyMock.expect(boardMock.movePiece(origin, destination)).andReturn(true);
         boardMock.switchTurn();
         EasyMock.expectLastCall();
@@ -694,6 +698,8 @@ class BoardControllerTest {
         EasyMock.expect(boardMock.getCurrentGameState()).andStubReturn(GameState.WHITE_TURN);
         EasyMock.expect(boardMock.getPieceAt(origin.getY(), origin.getX()))
                 .andReturn(new Pawn(PieceColor.WHITE));
+        EasyMock.expect(boardMock.getPieceAt(destination.getY(), destination.getX()))
+                .andReturn(new NonePiece());
         EasyMock.expect(boardMock.movePiece(origin, destination)).andReturn(true);
         EasyMock.replay(boardMock);
         BoardController controller = new BoardController(boardMock);
@@ -714,6 +720,8 @@ class BoardControllerTest {
         Board boardMock = EasyMock.createMock(Board.class);
         EasyMock.expect(boardMock.getPieceAt(origin.getY(), origin.getX()))
                 .andReturn(new Pawn(PieceColor.WHITE));
+        EasyMock.expect(boardMock.getPieceAt(destination.getY(), destination.getX()))
+                .andReturn(new NonePiece());
         EasyMock.expect(boardMock.getCurrentGameState()).andReturn(GameState.WHITE_TURN);
         EasyMock.expect(boardMock.movePiece(origin, destination)).andReturn(true);
         boardMock.switchTurn();
@@ -739,6 +747,8 @@ class BoardControllerTest {
         EasyMock.expect(boardMock.getCurrentGameState()).andStubReturn(GameState.WHITE_TURN);
         EasyMock.expect(boardMock.getPieceAt(origin.getY(), origin.getX()))
                 .andReturn(new Pawn(PieceColor.WHITE));
+        EasyMock.expect(boardMock.getPieceAt(destination.getY(), destination.getX()))
+                .andReturn(new NonePiece());
         EasyMock.expect(boardMock.movePiece(origin, destination)).andReturn(true);
         BoardView boardViewMock = EasyMock.createMock(BoardView.class);
         boardViewMock.repaint();
@@ -761,6 +771,8 @@ class BoardControllerTest {
         EasyMock.expect(boardMock.getCurrentGameState()).andStubReturn(GameState.WHITE_TURN);
         EasyMock.expect(boardMock.getPieceAt(origin.getY(), origin.getX()))
                 .andReturn(new Pawn(PieceColor.WHITE));
+        EasyMock.expect(boardMock.getPieceAt(destination.getY(), destination.getX()))
+                .andReturn(new NonePiece());
         EasyMock.expect(boardMock.movePiece(origin, destination)).andReturn(false);
         EasyMock.replay(boardMock);
         BoardController controller = new BoardController(boardMock);
@@ -778,6 +790,8 @@ class BoardControllerTest {
         Board boardMock = EasyMock.createMock(Board.class);
         EasyMock.expect(boardMock.getPieceAt(origin.getY(), origin.getX()))
                 .andReturn(new Pawn(PieceColor.WHITE));
+        EasyMock.expect(boardMock.getPieceAt(destination.getY(), destination.getX()))
+                .andReturn(new NonePiece());
         EasyMock.expect(boardMock.getCurrentGameState()).andReturn(GameState.WHITE_TURN);
         EasyMock.expect(boardMock.movePiece(origin, destination)).andReturn(false);
         EasyMock.expect(boardMock.getCurrentGameState()).andReturn(GameState.WHITE_TURN);
@@ -801,6 +815,8 @@ class BoardControllerTest {
         EasyMock.expect(boardMock.getCurrentGameState()).andStubReturn(GameState.WHITE_TURN);
         EasyMock.expect(boardMock.getPieceAt(origin.getY(), origin.getX()))
                 .andReturn(new Pawn(PieceColor.WHITE));
+        EasyMock.expect(boardMock.getPieceAt(destination.getY(), destination.getX()))
+                .andReturn(new NonePiece());
         EasyMock.expect(boardMock.movePiece(origin, destination)).andReturn(false);
         EasyMock.replay(boardMock);
         BoardController controller = new BoardController(boardMock);
@@ -810,6 +826,28 @@ class BoardControllerTest {
 
         boolean expected = false;
         boolean actual = controller.hasSelection();
+        assertEquals(expected, actual);
+        EasyMock.verify(boardMock);
+    }
+
+    @Test
+    void HandleSquareClick_WithSelection_OnFriendlyPiece_ChangesSelection() {
+        Location origin = new Location(0, 7);
+        Location destination = new Location(1, 7);
+        Board boardMock = EasyMock.createMock(Board.class);
+        EasyMock.expect(boardMock.getCurrentGameState()).andStubReturn(GameState.WHITE_TURN);
+        EasyMock.expect(boardMock.getPieceAt(origin.getY(), origin.getX()))
+                .andReturn(new Rook(PieceColor.WHITE));
+        EasyMock.expect(boardMock.getPieceAt(destination.getY(), destination.getX()))
+                .andReturn(new Knight(PieceColor.WHITE));
+        EasyMock.replay(boardMock);
+        BoardController controller = new BoardController(boardMock);
+
+        controller.handleSquareClick(origin);
+        controller.handleSquareClick(destination);
+
+        boolean expected = true;
+        boolean actual = selectedLocationMatches(controller.getSelectedLocation(), destination);
         assertEquals(expected, actual);
         EasyMock.verify(boardMock);
     }

--- a/src/test/java/ui/BoardControllerTest.java
+++ b/src/test/java/ui/BoardControllerTest.java
@@ -631,6 +631,23 @@ class BoardControllerTest {
         EasyMock.verify(boardMock, boardViewMock);
     }
 
+    @Test
+    void SetBoardView_ExistingView_ReplacesBoardView() {
+        Board boardMock = replayNiceBoard();
+        BoardView originalViewMock = EasyMock.createNiceMock(BoardView.class);
+        BoardView replacementViewMock = EasyMock.createNiceMock(BoardView.class);
+        EasyMock.replay(originalViewMock, replacementViewMock);
+        BoardController controller = new BoardController(boardMock);
+
+        controller.setBoardView(originalViewMock);
+        controller.setBoardView(replacementViewMock);
+
+        BoardView expected = replacementViewMock;
+        BoardView actual = controller.getBoardView();
+        assertEquals(expected, actual);
+        EasyMock.verify(boardMock, originalViewMock, replacementViewMock);
+    }
+
     private static Board replayNiceBoard() {
         Board boardMock = EasyMock.createNiceMock(Board.class);
         EasyMock.replay(boardMock);

--- a/src/test/java/ui/BoardControllerTest.java
+++ b/src/test/java/ui/BoardControllerTest.java
@@ -666,6 +666,26 @@ class BoardControllerTest {
         EasyMock.verify(boardMock);
     }
 
+    @Test
+    void HandleSquareClick_WithSelection_LegalDestination_CallsSwitchTurn() {
+        Location origin = new Location(4, 6);
+        Location destination = new Location(4, 5);
+        Board boardMock = EasyMock.createMock(Board.class);
+        EasyMock.expect(boardMock.getCurrentGameState()).andStubReturn(GameState.WHITE_TURN);
+        EasyMock.expect(boardMock.getPieceAt(origin.getY(), origin.getX()))
+                .andReturn(new Pawn(PieceColor.WHITE));
+        EasyMock.expect(boardMock.movePiece(origin, destination)).andReturn(true);
+        boardMock.switchTurn();
+        EasyMock.expectLastCall();
+        EasyMock.replay(boardMock);
+        BoardController controller = new BoardController(boardMock);
+
+        controller.handleSquareClick(origin);
+        controller.handleSquareClick(destination);
+
+        EasyMock.verify(boardMock);
+    }
+
     private static Board replayNiceBoard() {
         Board boardMock = EasyMock.createNiceMock(Board.class);
         EasyMock.replay(boardMock);

--- a/src/test/java/ui/BoardControllerTest.java
+++ b/src/test/java/ui/BoardControllerTest.java
@@ -659,6 +659,8 @@ class BoardControllerTest {
         EasyMock.expect(boardMock.getPieceAt(destination.getY(), destination.getX()))
                 .andReturn(new NonePiece());
         EasyMock.expect(boardMock.movePiece(origin, destination)).andReturn(true);
+        boardMock.switchTurn();
+        EasyMock.expectLastCall();
         EasyMock.replay(boardMock);
         BoardController controller = new BoardController(boardMock);
 

--- a/src/test/java/ui/BoardControllerTest.java
+++ b/src/test/java/ui/BoardControllerTest.java
@@ -753,6 +753,24 @@ class BoardControllerTest {
         EasyMock.verify(boardMock, boardViewMock);
     }
 
+    @Test
+    void HandleSquareClick_WithSelection_IllegalDestination_DoesNotCallSwitchTurn() {
+        Location origin = new Location(4, 6);
+        Location destination = new Location(4, 4);
+        Board boardMock = EasyMock.createMock(Board.class);
+        EasyMock.expect(boardMock.getCurrentGameState()).andStubReturn(GameState.WHITE_TURN);
+        EasyMock.expect(boardMock.getPieceAt(origin.getY(), origin.getX()))
+                .andReturn(new Pawn(PieceColor.WHITE));
+        EasyMock.expect(boardMock.movePiece(origin, destination)).andReturn(false);
+        EasyMock.replay(boardMock);
+        BoardController controller = new BoardController(boardMock);
+
+        controller.handleSquareClick(origin);
+        controller.handleSquareClick(destination);
+
+        EasyMock.verify(boardMock);
+    }
+
     private static Board replayNiceBoard() {
         Board boardMock = EasyMock.createNiceMock(Board.class);
         EasyMock.replay(boardMock);

--- a/src/test/java/ui/BoardControllerTest.java
+++ b/src/test/java/ui/BoardControllerTest.java
@@ -731,6 +731,28 @@ class BoardControllerTest {
         EasyMock.verify(boardMock);
     }
 
+    @Test
+    void HandleSquareClick_WithSelection_LegalDestination_RepaintsBoardView() {
+        Location origin = new Location(4, 6);
+        Location destination = new Location(4, 5);
+        Board boardMock = EasyMock.createNiceMock(Board.class);
+        EasyMock.expect(boardMock.getCurrentGameState()).andStubReturn(GameState.WHITE_TURN);
+        EasyMock.expect(boardMock.getPieceAt(origin.getY(), origin.getX()))
+                .andReturn(new Pawn(PieceColor.WHITE));
+        EasyMock.expect(boardMock.movePiece(origin, destination)).andReturn(true);
+        BoardView boardViewMock = EasyMock.createMock(BoardView.class);
+        boardViewMock.repaint();
+        EasyMock.expectLastCall();
+        EasyMock.replay(boardMock, boardViewMock);
+        BoardController controller = new BoardController(boardMock);
+
+        controller.handleSquareClick(origin);
+        controller.setBoardView(boardViewMock);
+        controller.handleSquareClick(destination);
+
+        EasyMock.verify(boardMock, boardViewMock);
+    }
+
     private static Board replayNiceBoard() {
         Board boardMock = EasyMock.createNiceMock(Board.class);
         EasyMock.replay(boardMock);

--- a/src/test/java/ui/BoardControllerTest.java
+++ b/src/test/java/ui/BoardControllerTest.java
@@ -771,6 +771,28 @@ class BoardControllerTest {
         EasyMock.verify(boardMock);
     }
 
+    @Test
+    void HandleSquareClick_WithSelection_IllegalDestination_TurnRemainsWhite() {
+        Location origin = new Location(4, 6);
+        Location destination = new Location(4, 4);
+        Board boardMock = EasyMock.createMock(Board.class);
+        EasyMock.expect(boardMock.getPieceAt(origin.getY(), origin.getX()))
+                .andReturn(new Pawn(PieceColor.WHITE));
+        EasyMock.expect(boardMock.getCurrentGameState()).andReturn(GameState.WHITE_TURN);
+        EasyMock.expect(boardMock.movePiece(origin, destination)).andReturn(false);
+        EasyMock.expect(boardMock.getCurrentGameState()).andReturn(GameState.WHITE_TURN);
+        EasyMock.replay(boardMock);
+        BoardController controller = new BoardController(boardMock);
+
+        controller.handleSquareClick(origin);
+        controller.handleSquareClick(destination);
+
+        GameState expected = GameState.WHITE_TURN;
+        GameState actual = controller.getCurrentGameState();
+        assertEquals(expected, actual);
+        EasyMock.verify(boardMock);
+    }
+
     private static Board replayNiceBoard() {
         Board boardMock = EasyMock.createNiceMock(Board.class);
         EasyMock.replay(boardMock);

--- a/src/test/java/ui/BoardControllerTest.java
+++ b/src/test/java/ui/BoardControllerTest.java
@@ -616,6 +616,21 @@ class BoardControllerTest {
         EasyMock.verify(boardMock);
     }
 
+    @Test
+    void SetBoardView_NoPreviousView_StoresBoardView() {
+        Board boardMock = replayNiceBoard();
+        BoardView boardViewMock = EasyMock.createNiceMock(BoardView.class);
+        EasyMock.replay(boardViewMock);
+        BoardController controller = new BoardController(boardMock);
+
+        controller.setBoardView(boardViewMock);
+
+        BoardView expected = boardViewMock;
+        BoardView actual = controller.getBoardView();
+        assertEquals(expected, actual);
+        EasyMock.verify(boardMock, boardViewMock);
+    }
+
     private static Board replayNiceBoard() {
         Board boardMock = EasyMock.createNiceMock(Board.class);
         EasyMock.replay(boardMock);

--- a/src/test/java/ui/BoardControllerTest.java
+++ b/src/test/java/ui/BoardControllerTest.java
@@ -875,6 +875,26 @@ class BoardControllerTest {
         EasyMock.verify(boardMock);
     }
 
+    @Test
+    void HandleSquareClick_WithSelection_OutOfBoundsDestination_DoesNotCallMovePiece() {
+        Location origin = new Location(4, 6);
+        Location destination = new Location(8, 5);
+        Board boardMock = EasyMock.createMock(Board.class);
+        EasyMock.expect(boardMock.getCurrentGameState()).andStubReturn(GameState.WHITE_TURN);
+        EasyMock.expect(boardMock.getPieceAt(origin.getY(), origin.getX()))
+                .andReturn(new Pawn(PieceColor.WHITE));
+        EasyMock.replay(boardMock);
+        BoardController controller = new BoardController(boardMock);
+
+        controller.handleSquareClick(origin);
+        controller.handleSquareClick(destination);
+
+        boolean expected = true;
+        boolean actual = selectedLocationMatches(controller.getSelectedLocation(), origin);
+        assertEquals(expected, actual);
+        EasyMock.verify(boardMock);
+    }
+
     private static Board replayNiceBoard() {
         Board boardMock = EasyMock.createNiceMock(Board.class);
         EasyMock.replay(boardMock);

--- a/src/test/java/ui/BoardControllerTest.java
+++ b/src/test/java/ui/BoardControllerTest.java
@@ -895,6 +895,33 @@ class BoardControllerTest {
         EasyMock.verify(boardMock);
     }
 
+    @Test
+    void HandleSquareClick_AfterSuccessfulMove_SnapshotReflectsNewPosition() {
+        Location origin = new Location(4, 6);
+        Location destination = new Location(4, 5);
+        Piece[][] postMoveGrid = newStandardStartingGrid();
+        postMoveGrid[6][4] = new NonePiece();
+        postMoveGrid[5][4] = new Pawn(PieceColor.WHITE);
+        Board boardMock = EasyMock.createNiceMock(Board.class);
+        EasyMock.expect(boardMock.getCurrentGameState()).andStubReturn(GameState.WHITE_TURN);
+        EasyMock.expect(boardMock.getPieceAt(origin.getY(), origin.getX()))
+                .andReturn(new Pawn(PieceColor.WHITE));
+        EasyMock.expect(boardMock.getPieceAt(destination.getY(), destination.getX()))
+                .andReturn(new NonePiece());
+        EasyMock.expect(boardMock.movePiece(origin, destination)).andReturn(true);
+        EasyMock.expect(boardMock.getSnapshot()).andReturn(postMoveGrid);
+        EasyMock.replay(boardMock);
+        BoardController controller = new BoardController(boardMock);
+
+        controller.handleSquareClick(origin);
+        controller.handleSquareClick(destination);
+
+        boolean expected = true;
+        boolean actual = snapshotHasWhitePawnMovedFromE2ToE3(controller.getBoardSnapshot());
+        assertEquals(expected, actual);
+        EasyMock.verify(boardMock);
+    }
+
     private static Board replayNiceBoard() {
         Board boardMock = EasyMock.createNiceMock(Board.class);
         EasyMock.replay(boardMock);
@@ -1040,6 +1067,14 @@ class BoardControllerTest {
             }
         }
         return true;
+    }
+
+    private static boolean snapshotHasWhitePawnMovedFromE2ToE3(Piece[][] snapshot) {
+        Piece origin = snapshot[6][4];
+        Piece destination = snapshot[5][4];
+        return origin.getType() == PieceType.NONE
+                && destination.getType() == PieceType.PAWN
+                && destination.getColor() == PieceColor.WHITE;
     }
 
     private static boolean bishopsOnOppositeColorSquaresOnRank(


### PR DESCRIPTION
## Description

Implements the BoardController second-click move-completion flow using mocked `Board` collaborators, plus `setBoardView` BVA coverage.

## Type of Change

- [x] Feature (new functionality)
- [ ] Bug fix
- [x] Documentation update
- [ ] Refactor
- [x] Test addition/update

## Related Work

Related to `docs/bva/BoardController.md` and the board move-piece work in PR #47.

## Changes Made

- [x] Added BoardController BVA rows for `setBoardView(...)` and second-click move completion.
- [x] Added mocked BoardController tests for BC-TC43 through BC-TC56.
- [x] Implemented controller behavior for successful moves, rejected moves, friendly-piece reselection, out-of-bounds second clicks, turn switching, selection clearing, and repainting.
- [x] Added a minimal `Board.movePiece(Location, Location)` signature so BoardController can mock the future board movement contract.

## BVA & Testing

- BVA documented in: `docs/bva/BoardController.md`
- Test cases implemented: BC-TC43, BC-TC44, BC-TC45, BC-TC46, BC-TC47, BC-TC48, BC-TC49, BC-TC50, BC-TC51, BC-TC52, BC-TC53, BC-TC54, BC-TC55, BC-TC56
- All tests passing: [x]

## Design Alignment

- [x] Changes align with `docs/design/chess-full-design.puml`
- [x] No breaking changes to existing methods
- [x] New methods follow the established patterns

## Implementation Notes

BoardController tests mock `Board.movePiece(...)` and related board calls. The real board movement implementation is intentionally not duplicated here; this branch only depends on the future `Board.movePiece(Location, Location): boolean` contract.

This PR should be merged after, or alongside, the board-move implementation PR so real UI moves do not depend on the temporary `Board.movePiece(...)` placeholder.

## Checklist

- [x] BVA analysis is documented
- [x] TDD workflow followed (tests before code)
- [x] Code compiles and all tests pass
- [x] No new compiler warnings
- [x] Documentation updated (if applicable)
- [x] Commit messages are clear and follow TDD workflow