### PR TITLE
[FEAT] Move Generator

### DIFF
--- a/docs/bva/MoveGenerator.md
+++ b/docs/bva/MoveGenerator.md
@@ -72,12 +72,12 @@ Scope: Add basic legal move generation for all piece types (pawn, knight, bishop
   - State of the system: from (3,3) holds NonePiece
   - Expected output: returned move list size is 0
 
-- MG-TC3: GenerateLegalMoves_OnKnightAtCenter_ReturnsEightMoves ( :x: )
+- MG-TC3: GenerateLegalMoves_OnKnightAtCenter_ReturnsEightMoves ( :white_check_mark: )
   - Method(s) under test: generateLegalMoves(Location)
   - State of the system: white knight at (4,4), all other squares NonePiece
   - Expected output: returned move list size is 8
 
-- MG-TC4: GenerateLegalMoves_OnBishopAtCenter_ReturnsThirteenMoves ( :x: )
+- MG-TC4: GenerateLegalMoves_OnBishopAtCenter_ReturnsThirteenMoves ( :white_check_mark: )
   - Method(s) under test: generateLegalMoves(Location)
   - State of the system: white bishop at (4,4), all other squares NonePiece
   - Expected output: returned move list size is 13

--- a/docs/bva/MoveGenerator.md
+++ b/docs/bva/MoveGenerator.md
@@ -92,7 +92,7 @@ Scope: Add basic legal move generation for all piece types (pawn, knight, bishop
   - State of the system: white queen at (4,4), all other squares NonePiece
   - Expected output: returned move list size is 27
 
-- MG-TC7: GenerateLegalMoves_OnKingAtCenter_ReturnsEightMoves ( :x: )
+- MG-TC7: GenerateLegalMoves_OnKingAtCenter_ReturnsEightMoves ( :white_check_mark: )
   - Method(s) under test: generateLegalMoves(Location)
   - State of the system: white king at (4,4), all other squares NonePiece
   - Expected output: returned move list size is 8

--- a/docs/bva/MoveGenerator.md
+++ b/docs/bva/MoveGenerator.md
@@ -29,7 +29,7 @@ Scope: Add basic legal move generation for all piece types (pawn, knight, bishop
 
 ### Step 4: Test cases
 
-- MG-TC1: Constructor_WithBoardAndEmptyEnPassant_GenerateLegalMovesUsable ( :x: )
+- MG-TC1: Constructor_WithBoardAndEmptyEnPassant_GenerateLegalMovesUsable ( :white_check_mark: )
   - Method(s) under test: MoveGenerator(Piece[][], Optional<Location>), generateLegalMoves(Location)
   - State of the system: 8x8 board, white knight at (4,4), enPassantTarget is Optional.empty()
   - Expected output: generateLegalMoves(new Location(4,4)) returns a non-null list

--- a/docs/bva/MoveGenerator.md
+++ b/docs/bva/MoveGenerator.md
@@ -200,7 +200,7 @@ Scope: Add basic legal move generation for all piece types (pawn, knight, bishop
   - State of the system: white king on same file as black rook with empty squares between
   - Expected output: isInCheck(PieceColor.WHITE) is true
 
-- MG-TC13: IsInCheck_WhenKingNotAttacked_ReturnsFalse ( :x: )
+- MG-TC13: IsInCheck_WhenKingNotAttacked_ReturnsFalse ( :white_check_mark: )
   - Method(s) under test: isInCheck(PieceColor)
   - State of the system: white king present and no black piece attacks it
   - Expected output: isInCheck(PieceColor.WHITE) is false

--- a/docs/bva/MoveGenerator.md
+++ b/docs/bva/MoveGenerator.md
@@ -1,0 +1,206 @@
+# BVA Analysis for MoveGenerator
+
+Package: domain.MoveGenerator
+
+Scope: Add basic legal move generation for all piece types (pawn, knight, bishop, rook, queen, king) on a board snapshot.
+
+## Method: MoveGenerator(Piece[][] board, Optional<Location> enPassantTarget)
+
+### Step 1: Inputs and outputs
+
+| Input / state   | Equivalence classes                                           |
+| --------------- | ------------------------------------------------------------- |
+| board           | Collections - 8x8 board with Piece objects                    |
+| enPassantTarget | Optional - empty or present                                   |
+| Output          | Cases - generator stores references for later move generation |
+
+### Step 2: Catalog data types
+
+| Variable / output   | Catalog data type |
+| ------------------- | ----------------- |
+| board               | Collections       |
+| enPassantTarget     | Optional          |
+| generator readiness | Cases             |
+
+### Step 3: Concrete boundary values
+
+- board: 8x8 array filled with NonePiece except test-specific piece placements.
+- enPassantTarget: Optional.empty() for basic move tests.
+
+### Step 4: Test cases
+
+- MG-TC1: Constructor_WithBoardAndEmptyEnPassant_GenerateLegalMovesUsable ( :x: )
+  - Method(s) under test: MoveGenerator(Piece[][], Optional<Location>), generateLegalMoves(Location)
+  - State of the system: 8x8 board, white knight at (4,4), enPassantTarget is Optional.empty()
+  - Expected output: generateLegalMoves(new Location(4,4)) returns a non-null list
+
+---
+
+## Method: generateLegalMoves(Location from)
+
+### Step 1: Inputs and outputs
+
+| Input / state   | Equivalence classes                                          |
+| --------------- | ------------------------------------------------------------ |
+| from            | Pairs of variables - file/rank on board                      |
+| piece at from   | Cases - NONE, PAWN, KNIGHT, BISHOP, ROOK, QUEEN, KING        |
+| board occupancy | Collections - empty paths, blockers, capturable enemy pieces |
+| Output          | Collection - list of legal moves                             |
+
+### Step 2: Catalog data types
+
+| Variable / output | Catalog data type |
+| ----------------- | ----------------- |
+| from.x, from.y    | Intervals [0,7]   |
+| piece type        | Cases             |
+| move list         | Collections       |
+
+### Step 3: Concrete boundary values
+
+- Center location: (4,4) for full directional coverage.
+- Knight center expected count: 8.
+- Bishop center expected count on empty board: 13.
+- Rook center expected count on empty board: 14.
+- Queen center expected count on empty board: 27.
+- King center expected count on empty board: 8.
+- White pawn start rank location: (4,6), expected forward targets (4,5) and (4,4).
+
+### Step 4: Test cases
+
+- MG-TC2: GenerateLegalMoves_OnEmptySquare_ReturnsEmptyList ( :x: )
+  - Method(s) under test: generateLegalMoves(Location)
+  - State of the system: from (3,3) holds NonePiece
+  - Expected output: returned move list size is 0
+
+- MG-TC3: GenerateLegalMoves_OnKnightAtCenter_ReturnsEightMoves ( :x: )
+  - Method(s) under test: generateLegalMoves(Location)
+  - State of the system: white knight at (4,4), all other squares NonePiece
+  - Expected output: returned move list size is 8
+
+- MG-TC4: GenerateLegalMoves_OnBishopAtCenter_ReturnsThirteenMoves ( :x: )
+  - Method(s) under test: generateLegalMoves(Location)
+  - State of the system: white bishop at (4,4), all other squares NonePiece
+  - Expected output: returned move list size is 13
+
+- MG-TC5: GenerateLegalMoves_OnRookAtCenter_ReturnsFourteenMoves ( :x: )
+  - Method(s) under test: generateLegalMoves(Location)
+  - State of the system: white rook at (4,4), all other squares NonePiece
+  - Expected output: returned move list size is 14
+
+- MG-TC6: GenerateLegalMoves_OnQueenAtCenter_ReturnsTwentySevenMoves ( :x: )
+  - Method(s) under test: generateLegalMoves(Location)
+  - State of the system: white queen at (4,4), all other squares NonePiece
+  - Expected output: returned move list size is 27
+
+- MG-TC7: GenerateLegalMoves_OnKingAtCenter_ReturnsEightMoves ( :x: )
+  - Method(s) under test: generateLegalMoves(Location)
+  - State of the system: white king at (4,4), all other squares NonePiece
+  - Expected output: returned move list size is 8
+
+- MG-TC8: GenerateLegalMoves_OnWhitePawnAtStart_ReturnsOneAndTwoStepMoves ( :x: )
+  - Method(s) under test: generateLegalMoves(Location)
+  - State of the system: white pawn at (4,6), squares (4,5) and (4,4) empty
+  - Expected output: returned move list size is 2
+
+---
+
+## Method: generateAllLegalMovesForColor(PieceColor color)
+
+### Step 1: Inputs and outputs
+
+| Input / state      | Equivalence classes                                           |
+| ------------------ | ------------------------------------------------------------- |
+| color              | Cases - WHITE, BLACK                                          |
+| board distribution | Collections - pieces of both colors                           |
+| Output             | Collection - concatenated legal moves for all pieces of color |
+
+### Step 2: Catalog data types
+
+| Variable / output | Catalog data type |
+| ----------------- | ----------------- |
+| color             | Cases             |
+| move list         | Collections       |
+
+### Step 3: Concrete boundary values
+
+- White-only board sample: white knight at (4,4), black king at (0,0).
+
+### Step 4: Test cases
+
+- MG-TC9: GenerateAllLegalMovesForColor_OnSingleWhiteKnight_ReturnsEightMoves ( :x: )
+  - Method(s) under test: generateAllLegalMovesForColor(PieceColor)
+  - State of the system: only movable white piece is knight at (4,4)
+  - Expected output: returned move list size is 8 for PieceColor.WHITE
+
+---
+
+## Method: hasLegalMovesForColor(PieceColor color)
+
+### Step 1: Inputs and outputs
+
+| Input / state      | Equivalence classes                                    |
+| ------------------ | ------------------------------------------------------ |
+| color              | Cases - WHITE, BLACK                                   |
+| board distribution | Collections - side has at least one legal move vs none |
+| Output             | Boolean - true or false                                |
+
+### Step 2: Catalog data types
+
+| Variable / output | Catalog data type |
+| ----------------- | ----------------- |
+| color             | Cases             |
+| result            | Boolean           |
+
+### Step 3: Concrete boundary values
+
+- Movable sample: white knight at (4,4) on empty board.
+- No-move sample: board with only NonePiece for target color.
+
+### Step 4: Test cases
+
+- MG-TC10: HasLegalMovesForColor_OnMovableWhitePiece_ReturnsTrue ( :x: )
+  - Method(s) under test: hasLegalMovesForColor(PieceColor)
+  - State of the system: white knight at (4,4)
+  - Expected output: hasLegalMovesForColor(PieceColor.WHITE) is true
+
+- MG-TC11: HasLegalMovesForColor_OnNoPiecesForColor_ReturnsFalse ( :x: )
+  - Method(s) under test: hasLegalMovesForColor(PieceColor)
+  - State of the system: board has no black pieces
+  - Expected output: hasLegalMovesForColor(PieceColor.BLACK) is false
+
+---
+
+## Method: isInCheck(PieceColor color)
+
+### Step 1: Inputs and outputs
+
+| Input / state     | Equivalence classes              |
+| ----------------- | -------------------------------- |
+| color             | Cases - WHITE, BLACK             |
+| king attack state | Cases - attacked vs not attacked |
+| king presence     | Cases - king present vs absent   |
+| Output            | Boolean - true or false          |
+
+### Step 2: Catalog data types
+
+| Variable / output | Catalog data type |
+| ----------------- | ----------------- |
+| color             | Cases             |
+| result            | Boolean           |
+
+### Step 3: Concrete boundary values
+
+- Attacked king sample: white king at (4,4), black rook at (4,0), clear file.
+- Safe king sample: white king at (4,4), no black attacking line.
+
+### Step 4: Test cases
+
+- MG-TC12: IsInCheck_WhenRookAttacksKing_ReturnsTrue ( :x: )
+  - Method(s) under test: isInCheck(PieceColor)
+  - State of the system: white king on same file as black rook with empty squares between
+  - Expected output: isInCheck(PieceColor.WHITE) is true
+
+- MG-TC13: IsInCheck_WhenKingNotAttacked_ReturnsFalse ( :x: )
+  - Method(s) under test: isInCheck(PieceColor)
+  - State of the system: white king present and no black piece attacks it
+  - Expected output: isInCheck(PieceColor.WHITE) is false

--- a/docs/bva/MoveGenerator.md
+++ b/docs/bva/MoveGenerator.md
@@ -97,7 +97,7 @@ Scope: Add basic legal move generation for all piece types (pawn, knight, bishop
   - State of the system: white king at (4,4), all other squares NonePiece
   - Expected output: returned move list size is 8
 
-- MG-TC8: GenerateLegalMoves_OnWhitePawnAtStart_ReturnsOneAndTwoStepMoves ( :x: )
+- MG-TC8: GenerateLegalMoves_OnWhitePawnAtStart_ReturnsOneAndTwoStepMoves ( :white_check_mark: )
   - Method(s) under test: generateLegalMoves(Location)
   - State of the system: white pawn at (4,6), squares (4,5) and (4,4) empty
   - Expected output: returned move list size is 2

--- a/docs/bva/MoveGenerator.md
+++ b/docs/bva/MoveGenerator.md
@@ -82,7 +82,7 @@ Scope: Add basic legal move generation for all piece types (pawn, knight, bishop
   - State of the system: white bishop at (4,4), all other squares NonePiece
   - Expected output: returned move list size is 13
 
-- MG-TC5: GenerateLegalMoves_OnRookAtCenter_ReturnsFourteenMoves ( :x: )
+- MG-TC5: GenerateLegalMoves_OnRookAtCenter_ReturnsFourteenMoves ( :white_check_mark: )
   - Method(s) under test: generateLegalMoves(Location)
   - State of the system: white rook at (4,4), all other squares NonePiece
   - Expected output: returned move list size is 14

--- a/docs/bva/MoveGenerator.md
+++ b/docs/bva/MoveGenerator.md
@@ -67,7 +67,7 @@ Scope: Add basic legal move generation for all piece types (pawn, knight, bishop
 
 ### Step 4: Test cases
 
-- MG-TC2: GenerateLegalMoves_OnEmptySquare_ReturnsEmptyList ( :x: )
+- MG-TC2: GenerateLegalMoves_OnEmptySquare_ReturnsEmptyList ( :white_check_mark: )
   - Method(s) under test: generateLegalMoves(Location)
   - State of the system: from (3,3) holds NonePiece
   - Expected output: returned move list size is 0

--- a/docs/bva/MoveGenerator.md
+++ b/docs/bva/MoveGenerator.md
@@ -163,7 +163,7 @@ Scope: Add basic legal move generation for all piece types (pawn, knight, bishop
   - State of the system: white knight at (4,4)
   - Expected output: hasLegalMovesForColor(PieceColor.WHITE) is true
 
-- MG-TC11: HasLegalMovesForColor_OnNoPiecesForColor_ReturnsFalse ( :x: )
+- MG-TC11: HasLegalMovesForColor_OnNoPiecesForColor_ReturnsFalse ( :white_check_mark: )
   - Method(s) under test: hasLegalMovesForColor(PieceColor)
   - State of the system: board has no black pieces
   - Expected output: hasLegalMovesForColor(PieceColor.BLACK) is false

--- a/docs/bva/MoveGenerator.md
+++ b/docs/bva/MoveGenerator.md
@@ -127,7 +127,7 @@ Scope: Add basic legal move generation for all piece types (pawn, knight, bishop
 
 ### Step 4: Test cases
 
-- MG-TC9: GenerateAllLegalMovesForColor_OnSingleWhiteKnight_ReturnsEightMoves ( :x: )
+- MG-TC9: GenerateAllLegalMovesForColor_OnSingleWhiteKnight_ReturnsEightMoves ( :white_check_mark: )
   - Method(s) under test: generateAllLegalMovesForColor(PieceColor)
   - State of the system: only movable white piece is knight at (4,4)
   - Expected output: returned move list size is 8 for PieceColor.WHITE

--- a/docs/bva/MoveGenerator.md
+++ b/docs/bva/MoveGenerator.md
@@ -87,7 +87,7 @@ Scope: Add basic legal move generation for all piece types (pawn, knight, bishop
   - State of the system: white rook at (4,4), all other squares NonePiece
   - Expected output: returned move list size is 14
 
-- MG-TC6: GenerateLegalMoves_OnQueenAtCenter_ReturnsTwentySevenMoves ( :x: )
+- MG-TC6: GenerateLegalMoves_OnQueenAtCenter_ReturnsTwentySevenMoves ( :white_check_mark: )
   - Method(s) under test: generateLegalMoves(Location)
   - State of the system: white queen at (4,4), all other squares NonePiece
   - Expected output: returned move list size is 27

--- a/docs/bva/MoveGenerator.md
+++ b/docs/bva/MoveGenerator.md
@@ -158,7 +158,7 @@ Scope: Add basic legal move generation for all piece types (pawn, knight, bishop
 
 ### Step 4: Test cases
 
-- MG-TC10: HasLegalMovesForColor_OnMovableWhitePiece_ReturnsTrue ( :x: )
+- MG-TC10: HasLegalMovesForColor_OnMovableWhitePiece_ReturnsTrue ( :white_check_mark: )
   - Method(s) under test: hasLegalMovesForColor(PieceColor)
   - State of the system: white knight at (4,4)
   - Expected output: hasLegalMovesForColor(PieceColor.WHITE) is true

--- a/docs/bva/MoveGenerator.md
+++ b/docs/bva/MoveGenerator.md
@@ -195,7 +195,7 @@ Scope: Add basic legal move generation for all piece types (pawn, knight, bishop
 
 ### Step 4: Test cases
 
-- MG-TC12: IsInCheck_WhenRookAttacksKing_ReturnsTrue ( :x: )
+- MG-TC12: IsInCheck_WhenRookAttacksKing_ReturnsTrue ( :white_check_mark: )
   - Method(s) under test: isInCheck(PieceColor)
   - State of the system: white king on same file as black rook with empty squares between
   - Expected output: isInCheck(PieceColor.WHITE) is true

--- a/src/main/java/domain/MoveGenerator.java
+++ b/src/main/java/domain/MoveGenerator.java
@@ -29,6 +29,20 @@ public class MoveGenerator {
         this.enPassantTarget = enPassantTarget;
     }
 
+    public boolean hasLegalMovesForColor(PieceColor color) {
+        for (int rank = 0; rank < BOARD_SIZE; rank++) {
+            for (int file = 0; file < BOARD_SIZE; file++) {
+                Piece piece = board[rank][file];
+                if (piece.getType() != PieceType.NONE && piece.getColor() == color) {
+                    if (!generateLegalMoves(new Location(file, rank)).isEmpty()) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
     public List<Move> generateAllLegalMovesForColor(PieceColor color) {
         List<Move> moves = new ArrayList<>();
         for (int rank = 0; rank < BOARD_SIZE; rank++) {

--- a/src/main/java/domain/MoveGenerator.java
+++ b/src/main/java/domain/MoveGenerator.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import domain.piece.Piece;
+import domain.piece.PieceType;
 
 public class MoveGenerator {
 
@@ -18,6 +19,10 @@ public class MoveGenerator {
     }
 
     public List<Move> generateLegalMoves(Location from) {
+        Piece piece = board[from.getY()][from.getX()];
+        if (piece.getType() == PieceType.NONE) {
+            return new ArrayList<>();
+        }
         return new ArrayList<>();
     }
 }

--- a/src/main/java/domain/MoveGenerator.java
+++ b/src/main/java/domain/MoveGenerator.java
@@ -29,6 +29,19 @@ public class MoveGenerator {
         this.enPassantTarget = enPassantTarget;
     }
 
+    public List<Move> generateAllLegalMovesForColor(PieceColor color) {
+        List<Move> moves = new ArrayList<>();
+        for (int rank = 0; rank < BOARD_SIZE; rank++) {
+            for (int file = 0; file < BOARD_SIZE; file++) {
+                Piece piece = board[rank][file];
+                if (piece.getType() != PieceType.NONE && piece.getColor() == color) {
+                    moves.addAll(generateLegalMoves(new Location(file, rank)));
+                }
+            }
+        }
+        return moves;
+    }
+
     public List<Move> generateLegalMoves(Location from) {
         Piece piece = board[from.getY()][from.getX()];
         if (piece.getType() == PieceType.NONE) {

--- a/src/main/java/domain/MoveGenerator.java
+++ b/src/main/java/domain/MoveGenerator.java
@@ -11,6 +11,8 @@ import domain.piece.PieceType;
 public class MoveGenerator {
 
     private static final int BOARD_SIZE = 8;
+    private static final int[][] ROOK_DIRS = {{-1, 0}, {1, 0}, {0, -1}, {0, 1}};
+    private static final int[][] BISHOP_DIRS = {{-1, -1}, {-1, 1}, {1, -1}, {1, 1}};
     private static final int[][] KNIGHT_OFFSETS = {
         {-2, -1}, {-2, 1}, {-1, -2}, {-1, 2}, {1, -2}, {1, 2}, {2, -1}, {2, 1}
     };
@@ -31,7 +33,34 @@ public class MoveGenerator {
         if (piece.getType() == PieceType.KNIGHT) {
             return generateKnightMoves(from, piece);
         }
+        if (piece.getType() == PieceType.BISHOP) {
+            return generateSlidingMoves(from, piece, BISHOP_DIRS);
+        }
         return new ArrayList<>();
+    }
+
+    private List<Move> generateSlidingMoves(Location from, Piece piece, int[][] directions) {
+        List<Move> moves = new ArrayList<>();
+        int rank = from.getY();
+        int file = from.getX();
+        for (int[] direction : directions) {
+            int currentRank = rank + direction[0];
+            int currentFile = file + direction[1];
+            while (isOnBoard(currentRank, currentFile)) {
+                Piece target = board[currentRank][currentFile];
+                if (target.getType() == PieceType.NONE) {
+                    moves.add(new Move(from, new Location(currentFile, currentRank)));
+                    currentRank += direction[0];
+                    currentFile += direction[1];
+                    continue;
+                }
+                if (target.getColor() != piece.getColor()) {
+                    moves.add(new Move(from, new Location(currentFile, currentRank)));
+                }
+                break;
+            }
+        }
+        return moves;
     }
 
     private List<Move> generateKnightMoves(Location from, Piece knight) {

--- a/src/main/java/domain/MoveGenerator.java
+++ b/src/main/java/domain/MoveGenerator.java
@@ -10,6 +10,11 @@ import domain.piece.PieceType;
 
 public class MoveGenerator {
 
+    private static final int BOARD_SIZE = 8;
+    private static final int[][] KNIGHT_OFFSETS = {
+        {-2, -1}, {-2, 1}, {-1, -2}, {-1, 2}, {1, -2}, {1, 2}, {2, -1}, {2, 1}
+    };
+
     private final Piece[][] board;
     private final Optional<Location> enPassantTarget;
 
@@ -23,6 +28,31 @@ public class MoveGenerator {
         if (piece.getType() == PieceType.NONE) {
             return new ArrayList<>();
         }
+        if (piece.getType() == PieceType.KNIGHT) {
+            return generateKnightMoves(from, piece);
+        }
         return new ArrayList<>();
+    }
+
+    private List<Move> generateKnightMoves(Location from, Piece knight) {
+        List<Move> moves = new ArrayList<>();
+        int rank = from.getY();
+        int file = from.getX();
+        for (int[] offset : KNIGHT_OFFSETS) {
+            int targetRank = rank + offset[0];
+            int targetFile = file + offset[1];
+            if (!isOnBoard(targetRank, targetFile)) {
+                continue;
+            }
+            Piece target = board[targetRank][targetFile];
+            if (target.getType() == PieceType.NONE || target.getColor() != knight.getColor()) {
+                moves.add(new Move(from, new Location(targetFile, targetRank)));
+            }
+        }
+        return moves;
+    }
+
+    private static boolean isOnBoard(int rank, int file) {
+        return rank >= 0 && rank < BOARD_SIZE && file >= 0 && file < BOARD_SIZE;
     }
 }

--- a/src/main/java/domain/MoveGenerator.java
+++ b/src/main/java/domain/MoveGenerator.java
@@ -36,6 +36,9 @@ public class MoveGenerator {
         if (piece.getType() == PieceType.BISHOP) {
             return generateSlidingMoves(from, piece, BISHOP_DIRS);
         }
+        if (piece.getType() == PieceType.ROOK) {
+            return generateSlidingMoves(from, piece, ROOK_DIRS);
+        }
         return new ArrayList<>();
     }
 

--- a/src/main/java/domain/MoveGenerator.java
+++ b/src/main/java/domain/MoveGenerator.java
@@ -45,7 +45,28 @@ public class MoveGenerator {
         if (piece.getType() == PieceType.QUEEN) {
             return generateSlidingMoves(from, piece, EIGHT_DIRECTIONS);
         }
+        if (piece.getType() == PieceType.KING) {
+            return generateKingMoves(from, piece);
+        }
         return new ArrayList<>();
+    }
+
+    private List<Move> generateKingMoves(Location from, Piece king) {
+        List<Move> moves = new ArrayList<>();
+        int rank = from.getY();
+        int file = from.getX();
+        for (int[] offset : EIGHT_DIRECTIONS) {
+            int targetRank = rank + offset[0];
+            int targetFile = file + offset[1];
+            if (!isOnBoard(targetRank, targetFile)) {
+                continue;
+            }
+            Piece target = board[targetRank][targetFile];
+            if (target.getType() == PieceType.NONE || target.getColor() != king.getColor()) {
+                moves.add(new Move(from, new Location(targetFile, targetRank)));
+            }
+        }
+        return moves;
     }
 
     private List<Move> generateSlidingMoves(Location from, Piece piece, int[][] directions) {

--- a/src/main/java/domain/MoveGenerator.java
+++ b/src/main/java/domain/MoveGenerator.java
@@ -1,0 +1,23 @@
+package domain;
+
+import domain.location.Location;
+import domain.move.Move;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import domain.piece.Piece;
+
+public class MoveGenerator {
+
+    private final Piece[][] board;
+    private final Optional<Location> enPassantTarget;
+
+    public MoveGenerator(Piece[][] board, Optional<Location> enPassantTarget) {
+        this.board = board;
+        this.enPassantTarget = enPassantTarget;
+    }
+
+    public List<Move> generateLegalMoves(Location from) {
+        return new ArrayList<>();
+    }
+}

--- a/src/main/java/domain/MoveGenerator.java
+++ b/src/main/java/domain/MoveGenerator.java
@@ -11,6 +11,9 @@ import domain.piece.PieceType;
 public class MoveGenerator {
 
     private static final int BOARD_SIZE = 8;
+    private static final int[][] EIGHT_DIRECTIONS = {
+        {-1, -1}, {-1, 0}, {-1, 1}, {0, -1}, {0, 1}, {1, -1}, {1, 0}, {1, 1}
+    };
     private static final int[][] ROOK_DIRS = {{-1, 0}, {1, 0}, {0, -1}, {0, 1}};
     private static final int[][] BISHOP_DIRS = {{-1, -1}, {-1, 1}, {1, -1}, {1, 1}};
     private static final int[][] KNIGHT_OFFSETS = {
@@ -38,6 +41,9 @@ public class MoveGenerator {
         }
         if (piece.getType() == PieceType.ROOK) {
             return generateSlidingMoves(from, piece, ROOK_DIRS);
+        }
+        if (piece.getType() == PieceType.QUEEN) {
+            return generateSlidingMoves(from, piece, EIGHT_DIRECTIONS);
         }
         return new ArrayList<>();
     }

--- a/src/main/java/domain/MoveGenerator.java
+++ b/src/main/java/domain/MoveGenerator.java
@@ -29,6 +29,14 @@ public class MoveGenerator {
         this.enPassantTarget = enPassantTarget;
     }
 
+    public boolean isInCheck(PieceColor color) {
+        Location kingLocation = findKing(color, board);
+        if (kingLocation == null) {
+            return false;
+        }
+        return isSquareAttackedBy(kingLocation, opponent(color), board);
+    }
+
     public boolean hasLegalMovesForColor(PieceColor color) {
         for (int rank = 0; rank < BOARD_SIZE; rank++) {
             for (int file = 0; file < BOARD_SIZE; file++) {
@@ -170,5 +178,116 @@ public class MoveGenerator {
 
     private static boolean isOnBoard(int rank, int file) {
         return rank >= 0 && rank < BOARD_SIZE && file >= 0 && file < BOARD_SIZE;
+    }
+
+    private static boolean isSquareAttackedBy(
+            Location square, PieceColor attackerColor, Piece[][] board) {
+        return isSliderAttacking(square, attackerColor, board, ROOK_DIRS,
+                PieceType.ROOK, PieceType.QUEEN)
+            || isSliderAttacking(square, attackerColor, board, BISHOP_DIRS,
+                PieceType.BISHOP, PieceType.QUEEN)
+            || isKnightAttacking(square, attackerColor, board)
+            || isPawnAttacking(square, attackerColor, board)
+            || isKingAttacking(square, attackerColor, board);
+    }
+
+    private static boolean isSliderAttacking(
+            Location square,
+            PieceColor attackerColor,
+            Piece[][] board,
+            int[][] directions,
+            PieceType... sliderTypes) {
+        int rank = square.getY();
+        int file = square.getX();
+        for (int[] direction : directions) {
+            int currentRank = rank + direction[0];
+            int currentFile = file + direction[1];
+            while (isOnBoard(currentRank, currentFile)) {
+                Piece piece = board[currentRank][currentFile];
+                if (piece.getType() == PieceType.NONE) {
+                    currentRank += direction[0];
+                    currentFile += direction[1];
+                    continue;
+                }
+                if (piece.getColor() == attackerColor) {
+                    for (PieceType sliderType : sliderTypes) {
+                        if (piece.getType() == sliderType) {
+                            return true;
+                        }
+                    }
+                }
+                break;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isKnightAttacking(
+            Location square, PieceColor attackerColor, Piece[][] board) {
+        int rank = square.getY();
+        int file = square.getX();
+        for (int[] offset : KNIGHT_OFFSETS) {
+            int targetRank = rank + offset[0];
+            int targetFile = file + offset[1];
+            if (!isOnBoard(targetRank, targetFile)) {
+                continue;
+            }
+            Piece piece = board[targetRank][targetFile];
+            if (piece.getType() == PieceType.KNIGHT && piece.getColor() == attackerColor) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isPawnAttacking(
+            Location square, PieceColor attackerColor, Piece[][] board) {
+        int rank = square.getY();
+        int file = square.getX();
+        int pawnRank = rank + (attackerColor == PieceColor.WHITE ? 1 : -1);
+        for (int df : new int[] {-1, 1}) {
+            int pawnFile = file + df;
+            if (isOnBoard(pawnRank, pawnFile)) {
+                Piece piece = board[pawnRank][pawnFile];
+                if (piece.getType() == PieceType.PAWN && piece.getColor() == attackerColor) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static boolean isKingAttacking(
+            Location square, PieceColor attackerColor, Piece[][] board) {
+        int rank = square.getY();
+        int file = square.getX();
+        for (int[] offset : EIGHT_DIRECTIONS) {
+            int targetRank = rank + offset[0];
+            int targetFile = file + offset[1];
+            if (!isOnBoard(targetRank, targetFile)) {
+                continue;
+            }
+            Piece piece = board[targetRank][targetFile];
+            if (piece.getType() == PieceType.KING && piece.getColor() == attackerColor) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static Location findKing(PieceColor color, Piece[][] board) {
+        for (int rank = 0; rank < BOARD_SIZE; rank++) {
+            for (int file = 0; file < BOARD_SIZE; file++) {
+                Piece piece = board[rank][file];
+                if (piece.getType() == PieceType.KING && piece.getColor() == color) {
+                    return new Location(file, rank);
+                }
+            }
+        }
+        return null;
+    }
+
+    private static PieceColor opponent(PieceColor color) {
+        return color == PieceColor.WHITE ? PieceColor.BLACK : PieceColor.WHITE;
     }
 }

--- a/src/main/java/domain/MoveGenerator.java
+++ b/src/main/java/domain/MoveGenerator.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import domain.piece.Piece;
+import domain.piece.PieceColor;
 import domain.piece.PieceType;
 
 public class MoveGenerator {
@@ -48,7 +49,36 @@ public class MoveGenerator {
         if (piece.getType() == PieceType.KING) {
             return generateKingMoves(from, piece);
         }
+        if (piece.getType() == PieceType.PAWN) {
+            return generatePawnMoves(from, piece);
+        }
         return new ArrayList<>();
+    }
+
+    private List<Move> generatePawnMoves(Location from, Piece pawn) {
+        List<Move> moves = new ArrayList<>();
+        int rank = from.getY();
+        int file = from.getX();
+        PieceColor color = pawn.getColor();
+        int direction = (color == PieceColor.WHITE) ? -1 : 1;
+        int startRank = (color == PieceColor.WHITE) ? 6 : 1;
+
+        int oneAhead = rank + direction;
+        if (!isOnBoard(oneAhead, file)) {
+            return moves;
+        }
+        if (board[oneAhead][file].getType() != PieceType.NONE) {
+            return moves;
+        }
+        moves.add(new Move(from, new Location(file, oneAhead)));
+
+        int twoAhead = rank + 2 * direction;
+        if (rank == startRank
+                && isOnBoard(twoAhead, file)
+                && board[twoAhead][file].getType() == PieceType.NONE) {
+            moves.add(new Move(from, new Location(file, twoAhead)));
+        }
+        return moves;
     }
 
     private List<Move> generateKingMoves(Location from, Piece king) {

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -30,6 +30,19 @@ class MoveGeneratorTest {
     }
 
     @Test
+    void IsInCheck_WhenRookAttacksKing_ReturnsTrue() {
+        Piece[][] board = emptyBoard();
+        board[4][4] = new King(PieceColor.WHITE);
+        board[0][4] = new Rook(PieceColor.BLACK);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = true;
+        boolean actual = moveGenerator.isInCheck(PieceColor.WHITE);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
     void HasLegalMovesForColor_OnMovableWhitePiece_ReturnsTrue() {
         Piece[][] board = emptyBoard();
         board[4][4] = new Knight(PieceColor.WHITE);

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -30,6 +30,30 @@ class MoveGeneratorTest {
     }
 
     @Test
+    void HasLegalMovesForColor_OnMovableWhitePiece_ReturnsTrue() {
+        Piece[][] board = emptyBoard();
+        board[4][4] = new Knight(PieceColor.WHITE);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = true;
+        boolean actual = moveGenerator.hasLegalMovesForColor(PieceColor.WHITE);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void HasLegalMovesForColor_OnNoPiecesForColor_ReturnsFalse() {
+        Piece[][] board = emptyBoard();
+        board[4][4] = new Knight(PieceColor.WHITE);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = false;
+        boolean actual = moveGenerator.hasLegalMovesForColor(PieceColor.BLACK);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
     void GenerateAllLegalMovesForColor_OnSingleWhiteKnight_ReturnsEightMoves() {
         Piece[][] board = emptyBoard();
         board[4][4] = new Knight(PieceColor.WHITE);

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -30,6 +30,19 @@ class MoveGeneratorTest {
     }
 
     @Test
+    void IsInCheck_WhenKingNotAttacked_ReturnsFalse() {
+        Piece[][] board = emptyBoard();
+        board[4][4] = new King(PieceColor.WHITE);
+        board[0][0] = new Rook(PieceColor.BLACK);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = false;
+        boolean actual = moveGenerator.isInCheck(PieceColor.WHITE);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
     void IsInCheck_WhenRookAttacksKing_ReturnsTrue() {
         Piece[][] board = emptyBoard();
         board[4][4] = new King(PieceColor.WHITE);

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -25,6 +25,18 @@ class MoveGeneratorTest {
     }
 
     @Test
+    void GenerateLegalMoves_OnKnightAtCenter_ReturnsEightMoves() {
+        Piece[][] board = emptyBoard();
+        board[4][4] = new Knight(PieceColor.WHITE);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        int expected = 8;
+        int actual = moveGenerator.generateLegalMoves(new Location(4, 4)).size();
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
     void GenerateLegalMoves_OnEmptySquare_ReturnsEmptyList() {
         Piece[][] board = emptyBoard();
         MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -4,7 +4,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import domain.location.Location;
+import domain.piece.Bishop;
 import domain.piece.Knight;
+import domain.piece.Rook;
 import domain.piece.NonePiece;
 import domain.piece.Piece;
 import domain.piece.PieceColor;
@@ -22,6 +24,18 @@ class MoveGeneratorTest {
         MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
 
         assertNotNull(moveGenerator.generateLegalMoves(new Location(4, 4)));
+    }
+
+    @Test
+    void GenerateLegalMoves_OnBishopAtCenter_ReturnsThirteenMoves() {
+        Piece[][] board = emptyBoard();
+        board[4][4] = new Bishop(PieceColor.WHITE);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        int expected = 13;
+        int actual = moveGenerator.generateLegalMoves(new Location(4, 4)).size();
+
+        assertEquals(expected, actual);
     }
 
     @Test

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import domain.location.Location;
 import domain.piece.Bishop;
+import domain.piece.King;
 import domain.piece.Knight;
 import domain.piece.Queen;
 import domain.piece.Rook;
@@ -25,6 +26,18 @@ class MoveGeneratorTest {
         MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
 
         assertNotNull(moveGenerator.generateLegalMoves(new Location(4, 4)));
+    }
+
+    @Test
+    void GenerateLegalMoves_OnKingAtCenter_ReturnsEightMoves() {
+        Piece[][] board = emptyBoard();
+        board[4][4] = new King(PieceColor.WHITE);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        int expected = 8;
+        int actual = moveGenerator.generateLegalMoves(new Location(4, 4)).size();
+
+        assertEquals(expected, actual);
     }
 
     @Test

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -1,0 +1,35 @@
+package domain;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import domain.location.Location;
+import domain.piece.Knight;
+import domain.piece.NonePiece;
+import domain.piece.Piece;
+import domain.piece.PieceColor;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class MoveGeneratorTest {
+
+    private static final int BOARD_SIZE = 8;
+
+    @Test
+    void Constructor_WithBoardAndEmptyEnPassant_GenerateLegalMovesUsable() {
+        Piece[][] board = emptyBoard();
+        board[4][4] = new Knight(PieceColor.WHITE);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        assertNotNull(moveGenerator.generateLegalMoves(new Location(4, 4)));
+    }
+
+    private static Piece[][] emptyBoard() {
+        Piece[][] board = new Piece[BOARD_SIZE][BOARD_SIZE];
+        for (int rank = 0; rank < BOARD_SIZE; rank++) {
+            for (int file = 0; file < BOARD_SIZE; file++) {
+                board[rank][file] = new NonePiece();
+            }
+        }
+        return board;
+    }
+}

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -30,6 +30,19 @@ class MoveGeneratorTest {
     }
 
     @Test
+    void GenerateAllLegalMovesForColor_OnSingleWhiteKnight_ReturnsEightMoves() {
+        Piece[][] board = emptyBoard();
+        board[4][4] = new Knight(PieceColor.WHITE);
+        board[0][0] = new King(PieceColor.BLACK);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        int expected = 8;
+        int actual = moveGenerator.generateAllLegalMovesForColor(PieceColor.WHITE).size();
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
     void GenerateLegalMoves_OnWhitePawnAtStart_ReturnsOneAndTwoStepMoves() {
         Piece[][] board = emptyBoard();
         board[6][4] = new Pawn(PieceColor.WHITE);

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -27,6 +27,18 @@ class MoveGeneratorTest {
     }
 
     @Test
+    void GenerateLegalMoves_OnRookAtCenter_ReturnsFourteenMoves() {
+        Piece[][] board = emptyBoard();
+        board[4][4] = new Rook(PieceColor.WHITE);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        int expected = 14;
+        int actual = moveGenerator.generateLegalMoves(new Location(4, 4)).size();
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
     void GenerateLegalMoves_OnBishopAtCenter_ReturnsThirteenMoves() {
         Piece[][] board = emptyBoard();
         board[4][4] = new Bishop(PieceColor.WHITE);

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -11,6 +11,7 @@ import domain.piece.Queen;
 import domain.piece.Rook;
 import domain.piece.NonePiece;
 import domain.piece.Piece;
+import domain.piece.Pawn;
 import domain.piece.PieceColor;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -26,6 +27,18 @@ class MoveGeneratorTest {
         MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
 
         assertNotNull(moveGenerator.generateLegalMoves(new Location(4, 4)));
+    }
+
+    @Test
+    void GenerateLegalMoves_OnWhitePawnAtStart_ReturnsOneAndTwoStepMoves() {
+        Piece[][] board = emptyBoard();
+        board[6][4] = new Pawn(PieceColor.WHITE);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        int expected = 2;
+        int actual = moveGenerator.generateLegalMoves(new Location(4, 6)).size();
+
+        assertEquals(expected, actual);
     }
 
     @Test

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import domain.location.Location;
 import domain.piece.Bishop;
 import domain.piece.Knight;
+import domain.piece.Queen;
 import domain.piece.Rook;
 import domain.piece.NonePiece;
 import domain.piece.Piece;
@@ -24,6 +25,18 @@ class MoveGeneratorTest {
         MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
 
         assertNotNull(moveGenerator.generateLegalMoves(new Location(4, 4)));
+    }
+
+    @Test
+    void GenerateLegalMoves_OnQueenAtCenter_ReturnsTwentySevenMoves() {
+        Piece[][] board = emptyBoard();
+        board[4][4] = new Queen(PieceColor.WHITE);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        int expected = 27;
+        int actual = moveGenerator.generateLegalMoves(new Location(4, 4)).size();
+
+        assertEquals(expected, actual);
     }
 
     @Test

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -1,5 +1,6 @@
 package domain;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import domain.location.Location;
@@ -21,6 +22,17 @@ class MoveGeneratorTest {
         MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
 
         assertNotNull(moveGenerator.generateLegalMoves(new Location(4, 4)));
+    }
+
+    @Test
+    void GenerateLegalMoves_OnEmptySquare_ReturnsEmptyList() {
+        Piece[][] board = emptyBoard();
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        int expected = 0;
+        int actual = moveGenerator.generateLegalMoves(new Location(3, 3)).size();
+
+        assertEquals(expected, actual);
     }
 
     private static Piece[][] emptyBoard() {


### PR DESCRIPTION
## Description

This PR adds legal move generation support in the domain layer, aligned with the chess-master approach, with a strict BVA-first and TDD workflow.

Main goals covered:
- Add MoveGenerator support for all basic piece movement patterns
- Add check-aware filtering so moves that leave the moving side in check are excluded
- Add Board.getLegalMoves delegation to MoveGenerator
- Add and update BVA documentation to match implemented test cases

## Type of Change

- [x] Feature (new functionality)
- [ ] Bug fix
- [x] Documentation update
- [x] Refactor
- [x] Test addition/update

## Related Work

Closes #(issue number) | Related to docs/bva/MoveGenerator.md and docs/bva/Board.md.

## Changes Made

- [x] Added MoveGenerator with legal move generation for knight, bishop, rook, queen, king, and basic pawn forward movement
- [x] Added MoveGenerator APIs for color-wide move queries and check detection
- [x] Added check filtering to remove pseudo-legal moves that expose own king
- [x] Added Board.getLegalMoves(Location) and tests for empty square and center knight cases
- [x] Updated BVA docs and implementation status markers for new test cases

## BVA & Testing

- BVA documented in: `docs/bva/MoveGenerator.md`, `docs/bva/Board.md`
- Test cases implemented:
  - MoveGenerator: MG-TC1 through MG-TC14
  - Board: TC36 and TC37 for `getLegalMoves(Location)`
- All tests passing: [x]

## Design Alignment

- [x] Changes align with `docs/design/chess-full-design.puml`
- [x] No breaking changes to existing methods (new methods added)
- [x] New methods follow the established patterns

## Implementation Notes

- Work was implemented in small vertical slices:
  - BVA update commit first
  - Then one failing test at a time, minimum code to pass, green run, commit
- Check filtering was implemented by:
  - Generating pseudo-legal moves first
  - Simulating each move on a copied board
  - Rejecting moves that leave the moving side in check
- Board legal move retrieval now delegates to MoveGenerator to centralize move logic.

## Checklist

- [x] BVA analysis is documented
- [x] TDD workflow followed (tests before code)
- [x] Code compiles and all tests pass
- [x] No new compiler warnings
- [x] Documentation updated (if applicable)
- [x] Commit messages are clear and follow TDD workflow