### PR TITLE
[FEAT] Board Make Move

### DIFF
--- a/docs/bva/Board.md
+++ b/docs/bva/Board.md
@@ -558,7 +558,7 @@ Scope: apply a **normal** move to internal board state and toggle turn. Win, dra
   - **State of the system**: white pawn moves from `(4,6)` to `(4,5)`
   - **Expected output**: after move, `getPieceAt(6, 4)` returns type `NONE`
 
-- **TC52: MakeMove_AfterWhiteMove_GameStateIsBlackTurn** ( :x: )
+- **TC52: MakeMove_AfterWhiteMove_GameStateIsBlackTurn** ( :white_check_mark: )
   - **Method(s) under test**: `makeMove(Move)`, `getCurrentGameState()`
   - **State of the system**: white pawn normal move on empty board; game state is `WHITE_TURN`
   - **Expected output**: after move, `getCurrentGameState()` returns `BLACK_TURN`

--- a/docs/bva/Board.md
+++ b/docs/bva/Board.md
@@ -511,3 +511,61 @@ Note: `WHITE_WIN`, `BLACK_WIN`, and `DRAW` are reachable only through game-logic
   - **Expected output**: the two returned `Piece` references are not the same object, but have equal type and color
 
 ---
+
+## Method: `makeMove(Move move)`
+
+Scope: apply a **normal** move to internal board state and toggle turn. Win, draw, en passant, castling, and promotion are deferred to later slices.
+
+### Step 1: Equivalence Classes
+
+- **Input: move** — `Move` with from/to locations and `MoveType.NORMAL`
+- **Input: board state before move** — piece at source square; destination empty or capturable
+- **Input: current game state** — `WHITE_TURN` or `BLACK_TURN`
+- **Output: piece at destination** — moved piece type and color match the piece that was at source
+- **Output: piece at source** — `NonePiece` after move
+- **Output: game state after move** — toggled to the opposite turn
+
+### Step 2: Data Types (from BVA Catalog)
+
+| Equivalence class | Catalog data type | Parameters |
+| --- | --- | --- |
+| Input: move from/to | Pairs of variables | file/rank in [0, 7] |
+| Input: move type | Cases | NORMAL |
+| Input: game state before | Cases | WHITE_TURN, BLACK_TURN |
+| Output: destination piece type | Cases | PAWN, etc. |
+| Output: source piece type | Cases | NONE |
+| Output: game state after | Cases | BLACK_TURN, WHITE_TURN |
+
+### Step 3: Boundary Values (from BVA Catalog)
+
+**move — Pairs of variables:**
+- White pawn `(4,6)` → `(4,5)` on empty board
+- Black pawn `(4,1)` → `(4,2)` on empty board
+
+**game state — Cases:**
+- `WHITE_TURN` before move → `BLACK_TURN` after
+- `BLACK_TURN` before move → `WHITE_TURN` after
+
+### Step 4: Test Cases
+
+- **TC50: MakeMove_OnNormalMove_PieceAtDestination** ( :x: )
+  - **Method(s) under test**: `makeMove(Move)`, `getPieceAt(int, int)`
+  - **State of the system**: white pawn at `(4,6)`, empty `(4,5)`, `WHITE_TURN`
+  - **Expected output**: after move, `getPieceAt(5, 4)` returns type `PAWN` and color `WHITE`
+
+- **TC51: MakeMove_OnNormalMove_SourceSquareIsEmpty** ( :x: )
+  - **Method(s) under test**: `makeMove(Move)`, `getPieceAt(int, int)`
+  - **State of the system**: white pawn moves from `(4,6)` to `(4,5)`
+  - **Expected output**: after move, `getPieceAt(6, 4)` returns type `NONE`
+
+- **TC52: MakeMove_AfterWhiteMove_GameStateIsBlackTurn** ( :x: )
+  - **Method(s) under test**: `makeMove(Move)`, `getCurrentGameState()`
+  - **State of the system**: white pawn normal move on empty board; game state is `WHITE_TURN`
+  - **Expected output**: after move, `getCurrentGameState()` returns `BLACK_TURN`
+
+- **TC53: MakeMove_AfterBlackMove_GameStateIsWhiteTurn** ( :x: )
+  - **Method(s) under test**: `makeMove(Move)`, `getCurrentGameState()`
+  - **State of the system**: black pawn normal move on empty board; game state is `BLACK_TURN` (via prior `switchTurn()`)
+  - **Expected output**: after move, `getCurrentGameState()` returns `WHITE_TURN`
+
+---

--- a/docs/bva/Board.md
+++ b/docs/bva/Board.md
@@ -553,7 +553,7 @@ Scope: apply a **normal** move to internal board state and toggle turn. Win, dra
   - **State of the system**: white pawn at `(4,6)`, empty `(4,5)`, `WHITE_TURN`
   - **Expected output**: after move, `getPieceAt(5, 4)` returns type `PAWN` and color `WHITE`
 
-- **TC51: MakeMove_OnNormalMove_SourceSquareIsEmpty** ( :x: )
+- **TC51: MakeMove_OnNormalMove_SourceSquareIsEmpty** ( :white_check_mark: )
   - **Method(s) under test**: `makeMove(Move)`, `getPieceAt(int, int)`
   - **State of the system**: white pawn moves from `(4,6)` to `(4,5)`
   - **Expected output**: after move, `getPieceAt(6, 4)` returns type `NONE`

--- a/docs/bva/Board.md
+++ b/docs/bva/Board.md
@@ -563,7 +563,7 @@ Scope: apply a **normal** move to internal board state and toggle turn. Win, dra
   - **State of the system**: white pawn normal move on empty board; game state is `WHITE_TURN`
   - **Expected output**: after move, `getCurrentGameState()` returns `BLACK_TURN`
 
-- **TC53: MakeMove_AfterBlackMove_GameStateIsWhiteTurn** ( :x: )
+- **TC53: MakeMove_AfterBlackMove_GameStateIsWhiteTurn** ( :white_check_mark: )
   - **Method(s) under test**: `makeMove(Move)`, `getCurrentGameState()`
   - **State of the system**: black pawn normal move on empty board; game state is `BLACK_TURN` (via prior `switchTurn()`)
   - **Expected output**: after move, `getCurrentGameState()` returns `WHITE_TURN`

--- a/docs/bva/Board.md
+++ b/docs/bva/Board.md
@@ -548,7 +548,7 @@ Scope: apply a **normal** move to internal board state and toggle turn. Win, dra
 
 ### Step 4: Test Cases
 
-- **TC50: MakeMove_OnNormalMove_PieceAtDestination** ( :x: )
+- **TC50: MakeMove_OnNormalMove_PieceAtDestination** ( :white_check_mark: )
   - **Method(s) under test**: `makeMove(Move)`, `getPieceAt(int, int)`
   - **State of the system**: white pawn at `(4,6)`, empty `(4,5)`, `WHITE_TURN`
   - **Expected output**: after move, `getPieceAt(5, 4)` returns type `PAWN` and color `WHITE`

--- a/src/main/java/domain/Board.java
+++ b/src/main/java/domain/Board.java
@@ -80,6 +80,7 @@ public class Board {
 
     public void makeMove(Move move) {
         applyMoveToInternalState(move);
+        switchTurn();
     }
 
     private void applyMoveToInternalState(Move move) {

--- a/src/main/java/domain/Board.java
+++ b/src/main/java/domain/Board.java
@@ -1,6 +1,8 @@
 package domain;
 
 import domain.gamestate.GameState;
+import domain.location.Location;
+import domain.move.Move;
 import domain.piece.Bishop;
 import domain.piece.King;
 import domain.piece.Knight;
@@ -74,5 +76,19 @@ public class Board {
             }
         }
         return snapshot;
+    }
+
+    public void makeMove(Move move) {
+        applyMoveToInternalState(move);
+    }
+
+    private void applyMoveToInternalState(Move move) {
+        int fromRank = move.getFrom().getY();
+        int fromFile = move.getFrom().getX();
+        int toRank = move.getTo().getY();
+        int toFile = move.getTo().getX();
+        pieces[toRank][toFile] = pieces[fromRank][fromFile];
+        pieces[fromRank][fromFile] = new NonePiece();
+        pieces[toRank][toFile].changeToMoved();
     }
 }

--- a/src/test/java/domain/BoardTest.java
+++ b/src/test/java/domain/BoardTest.java
@@ -239,6 +239,24 @@ class BoardTest {
     }
 
     @Test
+    void MakeMove_AfterWhiteMove_GameStateIsBlackTurn() {
+        Piece[][] layout = new Piece[8][8];
+        for (Piece[] row : layout) {
+            Arrays.fill(row, new NonePiece());
+        }
+        layout[6][4] = new Pawn(PieceColor.WHITE);
+        Board board = new Board(layout);
+        Move move = new Move(new Location(4, 6), new Location(4, 5));
+
+        board.makeMove(move);
+
+        GameState expected = GameState.BLACK_TURN;
+        GameState actual = board.getCurrentGameState();
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
     void MakeMove_OnNormalMove_SourceSquareIsEmpty() {
         Piece[][] layout = new Piece[8][8];
         for (Piece[] row : layout) {

--- a/src/test/java/domain/BoardTest.java
+++ b/src/test/java/domain/BoardTest.java
@@ -239,6 +239,25 @@ class BoardTest {
     }
 
     @Test
+    void MakeMove_AfterBlackMove_GameStateIsWhiteTurn() {
+        Piece[][] layout = new Piece[8][8];
+        for (Piece[] row : layout) {
+            Arrays.fill(row, new NonePiece());
+        }
+        layout[1][4] = new Pawn(PieceColor.BLACK);
+        Board board = new Board(layout);
+        board.switchTurn();
+        Move move = new Move(new Location(4, 1), new Location(4, 2));
+
+        board.makeMove(move);
+
+        GameState expected = GameState.WHITE_TURN;
+        GameState actual = board.getCurrentGameState();
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
     void MakeMove_AfterWhiteMove_GameStateIsBlackTurn() {
         Piece[][] layout = new Piece[8][8];
         for (Piece[] row : layout) {

--- a/src/test/java/domain/BoardTest.java
+++ b/src/test/java/domain/BoardTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 import domain.gamestate.GameState;
+import domain.location.Location;
+import domain.move.Move;
 import domain.piece.Bishop;
 import domain.piece.King;
 import domain.piece.Knight;
@@ -234,6 +236,24 @@ class BoardTest {
         layout[7][7] = new Rook(PieceColor.WHITE);
         Board board = new Board(layout);
         assertEquals(PieceColor.WHITE, board.getPieceAt(7, 7).getColor());
+    }
+
+    @Test
+    void MakeMove_OnNormalMove_PieceAtDestination() {
+        Piece[][] layout = new Piece[8][8];
+        for (Piece[] row : layout) {
+            Arrays.fill(row, new NonePiece());
+        }
+        layout[6][4] = new Pawn(PieceColor.WHITE);
+        Board board = new Board(layout);
+        Move move = new Move(new Location(4, 6), new Location(4, 5));
+
+        board.makeMove(move);
+
+        PieceType expected = PieceType.PAWN;
+        PieceType actual = board.getPieceAt(5, 4).getType();
+
+        assertEquals(expected, actual);
     }
 
     @Test

--- a/src/test/java/domain/BoardTest.java
+++ b/src/test/java/domain/BoardTest.java
@@ -239,6 +239,24 @@ class BoardTest {
     }
 
     @Test
+    void MakeMove_OnNormalMove_SourceSquareIsEmpty() {
+        Piece[][] layout = new Piece[8][8];
+        for (Piece[] row : layout) {
+            Arrays.fill(row, new NonePiece());
+        }
+        layout[6][4] = new Pawn(PieceColor.WHITE);
+        Board board = new Board(layout);
+        Move move = new Move(new Location(4, 6), new Location(4, 5));
+
+        board.makeMove(move);
+
+        PieceType expected = PieceType.NONE;
+        PieceType actual = board.getPieceAt(6, 4).getType();
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
     void MakeMove_OnNormalMove_PieceAtDestination() {
         Piece[][] layout = new Piece[8][8];
         for (Piece[] row : layout) {


### PR DESCRIPTION
## Description

Adds `Board.makeMove(Move move)` to apply **normal** moves to the internal board and toggle the active turn. This slice follows chess-master’s `applyMoveToInternalState` + turn update pattern, but limits scope to relocation and `switchTurn()` — win, draw, en passant, castling, and promotion are deferred.

## Type of Change

- [x] Feature (new functionality)
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactor
- [x] Test addition/update

## Related Work

Related to `docs/bva/Board.md` (TC50–TC53)  
Reference: chess-master `Board.makeMove` / `applyMoveToInternalState` (normal-move default case)

## Changes Made

- [x] Added `Board.makeMove(Move)` — applies move, then calls `switchTurn()`
- [x] Added private `applyMoveToInternalState(Move)` for `MoveType.NORMAL` (relocate piece, clear source, `changeToMoved()`)
- [x] Added BVA analysis for `makeMove` in `docs/bva/Board.md`
- [x] Added four `BoardTest` cases (TC50–TC53) via TDD, one commit per passing TC

## BVA & Testing

- BVA documented in: `docs/bva/Board.md`
- Test cases implemented:
  - **TC50:** `MakeMove_OnNormalMove_PieceAtDestination`
  - **TC51:** `MakeMove_OnNormalMove_SourceSquareIsEmpty`
  - **TC52:** `MakeMove_AfterWhiteMove_GameStateIsBlackTurn`
  - **TC53:** `MakeMove_AfterBlackMove_GameStateIsWhiteTurn`
- All tests passing: [x] (`./gradlew test` and `./gradlew check`)

## Design Alignment

- [x] Changes align with `docs/design/chess-full-design.puml` (Board `makeMove` entry point; full game-state logic lands in a later slice)
- [x] No breaking changes to existing methods
- [x] New methods follow the established patterns (BVA → failing test → minimal code → green commit)

## Implementation Notes

- **Turn management:** uses existing `switchTurn()` after each move (toggle only).
- **Deferred from chess-master:** `updateGameState` (checkmate/stalemate/win/draw), `updateEnPassantTarget`, `halfMoveClock`, en passant, castling, promotion, and capture-specific BVA.
- **Normal moves only:** `applyMoveToInternalState` handles the default relocation path; special `MoveType` cases will be added in follow-up slices.
- TDD commits: BVA → TC50 → TC51 → TC52 → TC53.

## Checklist

- [x] BVA analysis is documented
- [x] TDD workflow followed (tests before code)
- [x] Code compiles and all tests pass
- [x] No new compiler warnings
- [x] Documentation updated (if applicable)
- [x] Commit messages are clear and follow TDD workflow