### PR TITLE
[FIX] BoardController: Enforce Alternating Turns

### DIFF
--- a/docs/bva/BoardController.md
+++ b/docs/bva/BoardController.md
@@ -303,47 +303,47 @@ Scope addition: derive **current player color** from `board.getCurrentGameState(
 
 ### Step 4: Test cases — `BLACK_TURN` source selection
 
-- **BC-TC43: HandleSquareClick_OnBlackTurn_OnBlackPiece_HasSelection** ( :x: )
+- **BC-TC43: HandleSquareClick_OnBlackTurn_OnBlackPiece_HasSelection** ( :white_check_mark: )
   - **Method(s) under test**: `handleSquareClick(Location)`, `hasSelection()`
   - **State of the system**: `GameState.BLACK_TURN`; click black piece at `Location(0, 1)`
   - **Expected output**: `hasSelection()` is `true`
 
-- **BC-TC44: HandleSquareClick_OnBlackTurn_OnBlackPiece_SelectedLocationMatches** ( :x: )
+- **BC-TC44: HandleSquareClick_OnBlackTurn_OnBlackPiece_SelectedLocationMatches** ( :white_check_mark: )
   - **Method(s) under test**: `handleSquareClick(Location)`, `getSelectedLocation()`
   - **State of the system**: `GameState.BLACK_TURN`; click `Location(0, 1)`
   - **Expected output**: `getSelectedLocation()` present with same coordinates
 
-- **BC-TC45: HandleSquareClick_OnBlackTurn_OnBlackPiece_BoardUnchanged** ( :x: )
+- **BC-TC45: HandleSquareClick_OnBlackTurn_OnBlackPiece_BoardUnchanged** ( :white_check_mark: )
   - **Method(s) under test**: `handleSquareClick(Location)`, `getBoardSnapshot()`
   - **State of the system**: `GameState.BLACK_TURN`; click black piece
   - **Expected output**: snapshot unchanged cell-wise
 
-- **BC-TC46: HandleSquareClick_OnBlackTurn_OnWhitePiece_NoSelectionAfterClick** ( :x: )
+- **BC-TC46: HandleSquareClick_OnBlackTurn_OnWhitePiece_NoSelectionAfterClick** ( :white_check_mark: )
   - **Method(s) under test**: `handleSquareClick(Location)`, `hasSelection()`
   - **State of the system**: `GameState.BLACK_TURN`; click white piece at `Location(0, 6)`
   - **Expected output**: `hasSelection()` is `false`
 
-- **BC-TC47: HandleSquareClick_OnBlackTurn_OnWhitePiece_TurnRemainsBlack** ( :x: )
+- **BC-TC47: HandleSquareClick_OnBlackTurn_OnWhitePiece_TurnRemainsBlack** ( :white_check_mark: )
   - **Method(s) under test**: `handleSquareClick(Location)`, `getCurrentGameState()`
   - **State of the system**: `GameState.BLACK_TURN`; click white piece
   - **Expected output**: `GameState.BLACK_TURN`
 
-- **BC-TC48: HandleSquareClick_OnBlackTurn_OnWhitePiece_BoardUnchanged** ( :x: )
+- **BC-TC48: HandleSquareClick_OnBlackTurn_OnWhitePiece_BoardUnchanged** ( :white_check_mark: )
   - **Method(s) under test**: `handleSquareClick(Location)`, `getBoardSnapshot()`
   - **State of the system**: `GameState.BLACK_TURN`; click white piece
   - **Expected output**: snapshot unchanged cell-wise
 
-- **BC-TC49: HandleSquareClick_OnBlackTurn_OnEmptySquare_NoSelectionAfterClick** ( :x: )
+- **BC-TC49: HandleSquareClick_OnBlackTurn_OnEmptySquare_NoSelectionAfterClick** ( :white_check_mark: )
   - **Method(s) under test**: `handleSquareClick(Location)`, `hasSelection()`
   - **State of the system**: `GameState.BLACK_TURN`; empty square `Location(3, 3)`
   - **Expected output**: `hasSelection()` is `false`
 
-- **BC-TC50: HandleSquareClick_OnBlackTurn_OnEmptySquare_TurnRemainsBlack** ( :x: )
+- **BC-TC50: HandleSquareClick_OnBlackTurn_OnEmptySquare_TurnRemainsBlack** ( :white_check_mark: )
   - **Method(s) under test**: `handleSquareClick(Location)`, `getCurrentGameState()`
   - **State of the system**: `GameState.BLACK_TURN`; empty square
   - **Expected output**: `GameState.BLACK_TURN`
 
-- **BC-TC51: HandleSquareClick_OnBlackTurn_OnEmptySquare_BoardUnchanged** ( :x: )
+- **BC-TC51: HandleSquareClick_OnBlackTurn_OnEmptySquare_BoardUnchanged** ( :white_check_mark: )
   - **Method(s) under test**: `handleSquareClick(Location)`, `getBoardSnapshot()`
   - **State of the system**: `GameState.BLACK_TURN`; empty square
   - **Expected output**: snapshot unchanged cell-wise

--- a/docs/bva/BoardController.md
+++ b/docs/bva/BoardController.md
@@ -184,7 +184,7 @@ _(BC-TC1, BC-TC2 cover fresh instance; selection-after-click covered under `hand
 
 | Effect            | Classes                                              |
 | ----------------- | ---------------------------------------------------- |
-| Selection / guard | White may select; black or empty must not change board |
+| Selection / guard | Active player may select own-color pieces only; opponent or empty must not change board |
 
 ### Step 4: Test cases
 
@@ -267,3 +267,83 @@ _(BC-TC1, BC-TC2 cover fresh instance; selection-after-click covered under `hand
   - **Method(s) under test**: `handleSquareClick(Location)`, `getCurrentGameState()`
   - **State of the system**: Chess960 fixed start; white piece click
   - **Expected output**: `GameState.WHITE_TURN`
+
+---
+
+## Method / behavior: `handleSquareClick` — alternating turn enforcement
+
+Scope addition: derive **current player color** from `board.getCurrentGameState()` (`WHITE_TURN` → white pieces only; `BLACK_TURN` → black pieces only). Wrong-color and empty squares must not change selection or turn. Terminal states (`WHITE_WIN`, `BLACK_WIN`, `DRAW`) ignore clicks.
+
+### Step 1: Input and output equivalence classes
+
+| Input | Equivalence classes |
+| ----- | ------------------- |
+| `board.getCurrentGameState()` | `WHITE_TURN`; `BLACK_TURN`; terminal (win/draw) |
+| Square at `loc` | `NonePiece`; own-color piece; opponent-color piece |
+
+| Effect | Classes |
+| ------ | ------- |
+| Source selection | Own-color piece on active turn → selection set |
+| Rejection | Empty, opponent piece, or terminal state → no selection |
+
+### Step 2: BVA catalog data types
+
+| Variable | Catalog type | Notes |
+| -------- | ------------ | ----- |
+| `currentGameState` | Cases | WHITE_TURN vs BLACK_TURN vs terminal |
+| Piece at square | Cases | NONE vs own color vs opponent color |
+| `lastSelectedLoc` | Optional | empty vs present |
+
+### Step 3: Concrete boundary values
+
+- Turn: `WHITE_TURN` (existing BC-TC27–35) vs **`BLACK_TURN`** (new)
+- Black turn own piece: standard grid rank `1` file `0` (black pawn)
+- Black turn opponent: standard grid rank `6` file `0` (white pawn)
+- Black turn empty: rank `3` file `3`
+
+### Step 4: Test cases — `BLACK_TURN` source selection
+
+- **BC-TC43: HandleSquareClick_OnBlackTurn_OnBlackPiece_HasSelection** ( :x: )
+  - **Method(s) under test**: `handleSquareClick(Location)`, `hasSelection()`
+  - **State of the system**: `GameState.BLACK_TURN`; click black piece at `Location(0, 1)`
+  - **Expected output**: `hasSelection()` is `true`
+
+- **BC-TC44: HandleSquareClick_OnBlackTurn_OnBlackPiece_SelectedLocationMatches** ( :x: )
+  - **Method(s) under test**: `handleSquareClick(Location)`, `getSelectedLocation()`
+  - **State of the system**: `GameState.BLACK_TURN`; click `Location(0, 1)`
+  - **Expected output**: `getSelectedLocation()` present with same coordinates
+
+- **BC-TC45: HandleSquareClick_OnBlackTurn_OnBlackPiece_BoardUnchanged** ( :x: )
+  - **Method(s) under test**: `handleSquareClick(Location)`, `getBoardSnapshot()`
+  - **State of the system**: `GameState.BLACK_TURN`; click black piece
+  - **Expected output**: snapshot unchanged cell-wise
+
+- **BC-TC46: HandleSquareClick_OnBlackTurn_OnWhitePiece_NoSelectionAfterClick** ( :x: )
+  - **Method(s) under test**: `handleSquareClick(Location)`, `hasSelection()`
+  - **State of the system**: `GameState.BLACK_TURN`; click white piece at `Location(0, 6)`
+  - **Expected output**: `hasSelection()` is `false`
+
+- **BC-TC47: HandleSquareClick_OnBlackTurn_OnWhitePiece_TurnRemainsBlack** ( :x: )
+  - **Method(s) under test**: `handleSquareClick(Location)`, `getCurrentGameState()`
+  - **State of the system**: `GameState.BLACK_TURN`; click white piece
+  - **Expected output**: `GameState.BLACK_TURN`
+
+- **BC-TC48: HandleSquareClick_OnBlackTurn_OnWhitePiece_BoardUnchanged** ( :x: )
+  - **Method(s) under test**: `handleSquareClick(Location)`, `getBoardSnapshot()`
+  - **State of the system**: `GameState.BLACK_TURN`; click white piece
+  - **Expected output**: snapshot unchanged cell-wise
+
+- **BC-TC49: HandleSquareClick_OnBlackTurn_OnEmptySquare_NoSelectionAfterClick** ( :x: )
+  - **Method(s) under test**: `handleSquareClick(Location)`, `hasSelection()`
+  - **State of the system**: `GameState.BLACK_TURN`; empty square `Location(3, 3)`
+  - **Expected output**: `hasSelection()` is `false`
+
+- **BC-TC50: HandleSquareClick_OnBlackTurn_OnEmptySquare_TurnRemainsBlack** ( :x: )
+  - **Method(s) under test**: `handleSquareClick(Location)`, `getCurrentGameState()`
+  - **State of the system**: `GameState.BLACK_TURN`; empty square
+  - **Expected output**: `GameState.BLACK_TURN`
+
+- **BC-TC51: HandleSquareClick_OnBlackTurn_OnEmptySquare_BoardUnchanged** ( :x: )
+  - **Method(s) under test**: `handleSquareClick(Location)`, `getBoardSnapshot()`
+  - **State of the system**: `GameState.BLACK_TURN`; empty square
+  - **Expected output**: snapshot unchanged cell-wise

--- a/src/main/java/ui/BoardController.java
+++ b/src/main/java/ui/BoardController.java
@@ -41,13 +41,20 @@ public class BoardController {
     if (!isInBounds(loc)) {
       return;
     }
+    GameState state = board.getCurrentGameState();
+    if (state != GameState.WHITE_TURN && state != GameState.BLACK_TURN) {
+      return;
+    }
+    PieceColor currentColor =
+        (state == GameState.WHITE_TURN) ? PieceColor.WHITE : PieceColor.BLACK;
+    handleSourceClick(loc, currentColor);
+  }
+
+  private void handleSourceClick(Location loc, PieceColor currentColor) {
     int file = loc.getX();
     int rank = loc.getY();
     Piece at = board.getPieceAt(rank, file);
-    if (at.getType() == PieceType.NONE || board.getCurrentGameState() != GameState.WHITE_TURN) {
-      return;
-    }
-    if (at.getColor() != PieceColor.WHITE) {
+    if (at.getType() == PieceType.NONE || at.getColor() != currentColor) {
       return;
     }
     lastSelectedLoc = Optional.of(loc);

--- a/src/test/java/ui/BoardControllerTest.java
+++ b/src/test/java/ui/BoardControllerTest.java
@@ -558,6 +558,21 @@ class BoardControllerTest {
     }
 
     @Test
+    void HandleSquareClick_OnBlackTurn_OnBlackPiece_HasSelection() {
+        Piece[][] standardGrid = newStandardStartingGrid();
+        Board boardMock = boardForBlackPieceClick(standardGrid, 1, 0);
+        BoardController controller = new BoardController(boardMock);
+        Location clicked = new Location(0, 1);
+
+        controller.handleSquareClick(clicked);
+
+        boolean expected = true;
+        boolean actual = controller.hasSelection();
+        assertEquals(expected, actual);
+        EasyMock.verify(boardMock);
+    }
+
+    @Test
     void HandleSquareClick_Chess960Start_FirstWhiteSelectionSamePolicy() {
         Piece[][] chess960Grid = newChess960FixedStartingGrid();
         Board boardMock = stubSnapshot(chess960Grid);
@@ -614,6 +629,33 @@ class BoardControllerTest {
         GameState actual = controller.getCurrentGameState();
         assertEquals(expected, actual);
         EasyMock.verify(boardMock);
+    }
+
+    private static Board boardForBlackPieceClick(Piece[][] snapshot, int rank, int file) {
+        Board boardMock = EasyMock.createMock(Board.class);
+        EasyMock.expect(boardMock.getCurrentGameState()).andStubReturn(GameState.BLACK_TURN);
+        EasyMock.expect(boardMock.getPieceAt(rank, file)).andReturn(snapshot[rank][file]);
+        EasyMock.replay(boardMock);
+        return boardMock;
+    }
+
+    private static Board boardForSquareClickOnBlackTurn(Piece[][] snapshot, int rank, int file) {
+        Board boardMock = EasyMock.createMock(Board.class);
+        EasyMock.expect(boardMock.getCurrentGameState()).andStubReturn(GameState.BLACK_TURN);
+        EasyMock.expect(boardMock.getPieceAt(rank, file)).andReturn(snapshot[rank][file]);
+        EasyMock.expect(boardMock.getSnapshot()).andStubReturn(snapshot);
+        EasyMock.replay(boardMock);
+        return boardMock;
+    }
+
+    private static Board boardForBlackPieceClickWithSnapshot(
+            Piece[][] snapshot, int rank, int file) {
+        Board boardMock = EasyMock.createMock(Board.class);
+        EasyMock.expect(boardMock.getCurrentGameState()).andStubReturn(GameState.BLACK_TURN);
+        EasyMock.expect(boardMock.getPieceAt(rank, file)).andReturn(snapshot[rank][file]);
+        EasyMock.expect(boardMock.getSnapshot()).andReturn(snapshot);
+        EasyMock.replay(boardMock);
+        return boardMock;
     }
 
     private static Board replayNiceBoard() {

--- a/src/test/java/ui/BoardControllerTest.java
+++ b/src/test/java/ui/BoardControllerTest.java
@@ -588,6 +588,21 @@ class BoardControllerTest {
     }
 
     @Test
+    void HandleSquareClick_OnBlackTurn_OnBlackPiece_BoardUnchanged() {
+        Piece[][] standardGrid = newStandardStartingGrid();
+        Board boardMock = boardForBlackPieceClickWithSnapshot(standardGrid, 1, 0);
+        BoardController controller = new BoardController(boardMock);
+        Location clicked = new Location(0, 1);
+
+        controller.handleSquareClick(clicked);
+
+        boolean expected = true;
+        boolean actual = cellWiseSameTypeAndColor(standardGrid, controller.getBoardSnapshot());
+        assertEquals(expected, actual);
+        EasyMock.verify(boardMock);
+    }
+
+    @Test
     void HandleSquareClick_Chess960Start_FirstWhiteSelectionSamePolicy() {
         Piece[][] chess960Grid = newChess960FixedStartingGrid();
         Board boardMock = stubSnapshot(chess960Grid);

--- a/src/test/java/ui/BoardControllerTest.java
+++ b/src/test/java/ui/BoardControllerTest.java
@@ -617,6 +617,76 @@ class BoardControllerTest {
     }
 
     @Test
+    void HandleSquareClick_OnBlackTurn_OnWhitePiece_TurnRemainsBlack() {
+        Piece[][] standardGrid = newStandardStartingGrid();
+        Board boardMock = boardForSquareClickOnBlackTurn(standardGrid, 6, 0);
+        BoardController controller = new BoardController(boardMock);
+
+        controller.handleSquareClick(new Location(0, 6));
+
+        GameState expected = GameState.BLACK_TURN;
+        GameState actual = controller.getCurrentGameState();
+        assertEquals(expected, actual);
+        EasyMock.verify(boardMock);
+    }
+
+    @Test
+    void HandleSquareClick_OnBlackTurn_OnWhitePiece_BoardUnchanged() {
+        Piece[][] standardGrid = newStandardStartingGrid();
+        Board boardMock = boardForSquareClickOnBlackTurn(standardGrid, 6, 0);
+        BoardController controller = new BoardController(boardMock);
+
+        controller.handleSquareClick(new Location(0, 6));
+
+        boolean expected = true;
+        boolean actual = cellWiseSameTypeAndColor(standardGrid, controller.getBoardSnapshot());
+        assertEquals(expected, actual);
+        EasyMock.verify(boardMock);
+    }
+
+    @Test
+    void HandleSquareClick_OnBlackTurn_OnEmptySquare_NoSelectionAfterClick() {
+        Piece[][] standardGrid = newStandardStartingGrid();
+        Board boardMock = boardForSquareClickOnBlackTurn(standardGrid, 3, 3);
+        BoardController controller = new BoardController(boardMock);
+
+        controller.handleSquareClick(new Location(3, 3));
+
+        boolean expected = false;
+        boolean actual = controller.hasSelection();
+        assertEquals(expected, actual);
+        EasyMock.verify(boardMock);
+    }
+
+    @Test
+    void HandleSquareClick_OnBlackTurn_OnEmptySquare_TurnRemainsBlack() {
+        Piece[][] standardGrid = newStandardStartingGrid();
+        Board boardMock = boardForSquareClickOnBlackTurn(standardGrid, 3, 3);
+        BoardController controller = new BoardController(boardMock);
+
+        controller.handleSquareClick(new Location(3, 3));
+
+        GameState expected = GameState.BLACK_TURN;
+        GameState actual = controller.getCurrentGameState();
+        assertEquals(expected, actual);
+        EasyMock.verify(boardMock);
+    }
+
+    @Test
+    void HandleSquareClick_OnBlackTurn_OnEmptySquare_BoardUnchanged() {
+        Piece[][] standardGrid = newStandardStartingGrid();
+        Board boardMock = boardForSquareClickOnBlackTurn(standardGrid, 3, 3);
+        BoardController controller = new BoardController(boardMock);
+
+        controller.handleSquareClick(new Location(3, 3));
+
+        boolean expected = true;
+        boolean actual = cellWiseSameTypeAndColor(standardGrid, controller.getBoardSnapshot());
+        assertEquals(expected, actual);
+        EasyMock.verify(boardMock);
+    }
+
+    @Test
     void HandleSquareClick_Chess960Start_FirstWhiteSelectionSamePolicy() {
         Piece[][] chess960Grid = newChess960FixedStartingGrid();
         Board boardMock = stubSnapshot(chess960Grid);

--- a/src/test/java/ui/BoardControllerTest.java
+++ b/src/test/java/ui/BoardControllerTest.java
@@ -573,6 +573,21 @@ class BoardControllerTest {
     }
 
     @Test
+    void HandleSquareClick_OnBlackTurn_OnBlackPiece_SelectedLocationMatches() {
+        Piece[][] standardGrid = newStandardStartingGrid();
+        Board boardMock = boardForBlackPieceClick(standardGrid, 1, 0);
+        BoardController controller = new BoardController(boardMock);
+        Location clicked = new Location(0, 1);
+
+        controller.handleSquareClick(clicked);
+
+        boolean expected = true;
+        boolean actual = selectedLocationMatches(controller.getSelectedLocation(), clicked);
+        assertEquals(expected, actual);
+        EasyMock.verify(boardMock);
+    }
+
+    @Test
     void HandleSquareClick_Chess960Start_FirstWhiteSelectionSamePolicy() {
         Piece[][] chess960Grid = newChess960FixedStartingGrid();
         Board boardMock = stubSnapshot(chess960Grid);

--- a/src/test/java/ui/BoardControllerTest.java
+++ b/src/test/java/ui/BoardControllerTest.java
@@ -603,6 +603,20 @@ class BoardControllerTest {
     }
 
     @Test
+    void HandleSquareClick_OnBlackTurn_OnWhitePiece_NoSelectionAfterClick() {
+        Piece[][] standardGrid = newStandardStartingGrid();
+        Board boardMock = boardForSquareClickOnBlackTurn(standardGrid, 6, 0);
+        BoardController controller = new BoardController(boardMock);
+
+        controller.handleSquareClick(new Location(0, 6));
+
+        boolean expected = false;
+        boolean actual = controller.hasSelection();
+        assertEquals(expected, actual);
+        EasyMock.verify(boardMock);
+    }
+
+    @Test
     void HandleSquareClick_Chess960Start_FirstWhiteSelectionSamePolicy() {
         Piece[][] chess960Grid = newChess960FixedStartingGrid();
         Board boardMock = stubSnapshot(chess960Grid);


### PR DESCRIPTION
## Description

Updates `BoardController.handleSquareClick` to enforce alternating turns. The active player is derived from `board.getCurrentGameState()` (`WHITE_TURN` → white pieces only; `BLACK_TURN` → black pieces only). Opponent pieces and empty squares are rejected without changing selection or turn.

## Type of Change

- [ ] Feature (new functionality)
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactor
- [x] Test addition/update

## Related Work

Related to `docs/bva/BoardController.md`

## Changes Made

- [x] Derive `currentColor` from `GameState` instead of hardcoding white-only selection
- [x] Ignore clicks when game state is not `WHITE_TURN` or `BLACK_TURN`
- [x] Extract `handleSourceClick` — select only own-color, non-empty squares
- [x] Add BC-TC43–51 tests for black-turn source selection (own piece, opponent, empty)

## BVA & Testing

- BVA documented in: `docs/bva/BoardController.md`
- Test cases implemented: BC-TC43–BC-TC51 (black-turn `handleSquareClick` boundaries); BC-TC1–42 unchanged
- All tests passing: [x] (`./gradlew test`, `./gradlew check`)

## Design Alignment

- [x] Changes align with `docs/design/chess-full-design.puml` and chess-master `BoardController` source-selection policy
- [x] No breaking changes to public methods
- [x] Follows established EasyMock test patterns

## Implementation Notes

- Scope is **source selection only** — destination clicks, legal moves, and `board.makeMove` are deferred to a later branch.
- TC47–51 landed in one commit with TC47 because related test additions were staged together; all TCs are implemented and marked in BVA.

## Checklist

- [x] BVA analysis is documented
- [x] TDD workflow followed (tests before code)
- [x] Code compiles and all tests pass
- [x] No new compiler warnings
- [x] Documentation updated (if applicable)
- [x] Commit messages are clear and follow TDD workflow

## Test plan

- [ ] `./gradlew test --tests ui.BoardControllerTest`
- [ ] `./gradlew check`
- [ ] Manual: on black's turn, clicking a black piece selects it; clicking white or empty does nothing