### PR TITLE
[FEAT] BoardController Legal Move For Selection

### DIFF
--- a/docs/bva/BoardController.md
+++ b/docs/bva/BoardController.md
@@ -381,17 +381,17 @@ Scope: After the player selects an own-color piece on their turn, expose that pi
 
 ### Step 4: Test cases
 
-- **BC-TC52: GetLegalMovesForSelection_NoSelection_ReturnsEmptyList** ( :x: )
+- **BC-TC52: GetLegalMovesForSelection_NoSelection_ReturnsEmptyList** ( :white_check_mark: )
   - **Method(s) under test**: `getLegalMovesForSelection()`
   - **State of the system**: newly constructed controller; no piece selected
   - **Expected output**: returned list size is `0`
 
-- **BC-TC53: GetLegalMovesForSelection_WithSelection_ReturnsMovesFromBoard** ( :x: )
+- **BC-TC53: GetLegalMovesForSelection_WithSelection_ReturnsMovesFromBoard** ( :white_check_mark: )
   - **Method(s) under test**: `getLegalMovesForSelection()`, `handleSquareClick(Location)`
   - **State of the system**: white turn; white pawn selected at `Location(0, 6)`; board stubs one legal move
   - **Expected output**: returned list equals board's `getLegalMoves` result for selected square
 
-- **BC-TC54: GetLegalMovesForSelection_WithSelection_WhenBoardReturnsEmpty_ReturnsEmptyList** ( :x: )
+- **BC-TC54: GetLegalMovesForSelection_WithSelection_WhenBoardReturnsEmpty_ReturnsEmptyList** ( :white_check_mark: )
   - **Method(s) under test**: `getLegalMovesForSelection()`, `handleSquareClick(Location)`
   - **State of the system**: white turn; own piece selected; board stubs empty legal-move list
   - **Expected output**: returned list size is `0`

--- a/docs/bva/BoardController.md
+++ b/docs/bva/BoardController.md
@@ -347,3 +347,51 @@ Scope addition: derive **current player color** from `board.getCurrentGameState(
   - **Method(s) under test**: `handleSquareClick(Location)`, `getBoardSnapshot()`
   - **State of the system**: `GameState.BLACK_TURN`; empty square
   - **Expected output**: snapshot unchanged cell-wise
+
+---
+
+## Method: `getLegalMovesForSelection(): List<Move>`
+
+Scope: After the player selects an own-color piece on their turn, expose that piece's **legal** moves from `Board.getLegalMoves` for UI highlighting (`BoardView`). When nothing is selected, return an empty list (chess-master delegation; no board call).
+
+### Step 1: Input and output equivalence classes
+
+| Input / state | Equivalence classes |
+| ------------- | ------------------- |
+| `lastSelectedLoc` | `Optional.empty()` vs present |
+| `board.getLegalMoves(from)` | empty collection vs non-empty collection |
+
+| Output | Equivalence classes |
+| ------ | ------------------- |
+| Returned list | empty; non-empty (same as board) |
+
+### Step 2: BVA catalog data types
+
+| Variable / output | Catalog type | Notes |
+| ----------------- | ------------ | ----- |
+| `lastSelectedLoc` | Optional | empty vs present |
+| Board move list | Collections | empty vs one-or-many |
+| Returned list | Collections | mirrors board when selected |
+
+### Step 3: Concrete boundary values
+
+- No selection: fresh controller; `getLegalMovesForSelection()` before any click.
+- With selection: white turn; click white pawn at `Location(0, 6)`; stub `board.getLegalMoves(Location(0, 6))`.
+- Board returns empty: same selection state; stub empty list from `getLegalMoves`.
+
+### Step 4: Test cases
+
+- **BC-TC52: GetLegalMovesForSelection_NoSelection_ReturnsEmptyList** ( :x: )
+  - **Method(s) under test**: `getLegalMovesForSelection()`
+  - **State of the system**: newly constructed controller; no piece selected
+  - **Expected output**: returned list size is `0`
+
+- **BC-TC53: GetLegalMovesForSelection_WithSelection_ReturnsMovesFromBoard** ( :x: )
+  - **Method(s) under test**: `getLegalMovesForSelection()`, `handleSquareClick(Location)`
+  - **State of the system**: white turn; white pawn selected at `Location(0, 6)`; board stubs one legal move
+  - **Expected output**: returned list equals board's `getLegalMoves` result for selected square
+
+- **BC-TC54: GetLegalMovesForSelection_WithSelection_WhenBoardReturnsEmpty_ReturnsEmptyList** ( :x: )
+  - **Method(s) under test**: `getLegalMovesForSelection()`, `handleSquareClick(Location)`
+  - **State of the system**: white turn; own piece selected; board stubs empty legal-move list
+  - **Expected output**: returned list size is `0`

--- a/src/main/java/ui/BoardController.java
+++ b/src/main/java/ui/BoardController.java
@@ -41,7 +41,10 @@ public class BoardController {
   }
 
   public List<Move> getLegalMovesForSelection() {
-    return new ArrayList<>();
+    if (!lastSelectedLoc.isPresent()) {
+      return new ArrayList<>();
+    }
+    return board.getLegalMoves(lastSelectedLoc.get());
   }
 
   public void handleSquareClick(Location loc) {

--- a/src/main/java/ui/BoardController.java
+++ b/src/main/java/ui/BoardController.java
@@ -3,9 +3,12 @@ package ui;
 import domain.Board;
 import domain.gamestate.GameState;
 import domain.location.Location;
+import domain.move.Move;
 import domain.piece.Piece;
 import domain.piece.PieceColor;
 import domain.piece.PieceType;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 public class BoardController {
@@ -35,6 +38,10 @@ public class BoardController {
 
   public Optional<Location> getSelectedLocation() {
     return lastSelectedLoc;
+  }
+
+  public List<Move> getLegalMovesForSelection() {
+    return new ArrayList<>();
   }
 
   public void handleSquareClick(Location loc) {

--- a/src/main/java/ui/BoardController.java
+++ b/src/main/java/ui/BoardController.java
@@ -8,7 +8,6 @@ import domain.piece.Piece;
 import domain.piece.PieceColor;
 import domain.piece.PieceType;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -104,10 +103,6 @@ public class BoardController {
     int x = loc.getX();
     int y = loc.getY();
     return x >= 0 && x < BOARD_SIZE && y >= 0 && y < BOARD_SIZE;
-  }
-
-  public List<Move> getLegalMovesForSelection() {
-    return Collections.emptyList();
   }
 
   public Piece[][] getBoardSnapshot() {

--- a/src/test/java/ui/BoardControllerTest.java
+++ b/src/test/java/ui/BoardControllerTest.java
@@ -7,6 +7,7 @@ import domain.FischerRandomBoardInitializer;
 import domain.StandardBoardInitializer;
 import domain.gamestate.GameState;
 import domain.location.Location;
+import domain.move.Move;
 import domain.piece.Bishop;
 import domain.piece.King;
 import domain.piece.Knight;
@@ -43,6 +44,17 @@ class BoardControllerTest {
 
         Optional<Location> expected = Optional.empty();
         Optional<Location> actual = controller.getSelectedLocation();
+        assertEquals(expected, actual);
+        EasyMock.verify(boardMock);
+    }
+
+    @Test
+    void GetLegalMovesForSelection_NoSelection_ReturnsEmptyList() {
+        Board boardMock = replayNiceBoard();
+        BoardController controller = new BoardController(boardMock);
+
+        int expected = 0;
+        int actual = controller.getLegalMovesForSelection().size();
         assertEquals(expected, actual);
         EasyMock.verify(boardMock);
     }

--- a/src/test/java/ui/BoardControllerTest.java
+++ b/src/test/java/ui/BoardControllerTest.java
@@ -49,6 +49,27 @@ class BoardControllerTest {
     }
 
     @Test
+    void GetLegalMovesForSelection_WithSelection_ReturnsMovesFromBoard() {
+        Piece[][] standardGrid = newStandardStartingGrid();
+        Location selected = new Location(0, 6);
+        Location destination = new Location(0, 5);
+        List<Move> boardMoves = List.of(new Move(selected, destination));
+        Board boardMock = EasyMock.createMock(Board.class);
+        EasyMock.expect(boardMock.getCurrentGameState()).andStubReturn(GameState.WHITE_TURN);
+        EasyMock.expect(boardMock.getPieceAt(6, 0)).andReturn(standardGrid[6][0]);
+        EasyMock.expect(boardMock.getLegalMoves(selected)).andReturn(boardMoves);
+        EasyMock.replay(boardMock);
+
+        BoardController controller = new BoardController(boardMock);
+        controller.handleSquareClick(selected);
+
+        List<Move> expected = boardMoves;
+        List<Move> actual = controller.getLegalMovesForSelection();
+        assertEquals(expected, actual);
+        EasyMock.verify(boardMock);
+    }
+
+    @Test
     void GetLegalMovesForSelection_NoSelection_ReturnsEmptyList() {
         Board boardMock = replayNiceBoard();
         BoardController controller = new BoardController(boardMock);

--- a/src/test/java/ui/BoardControllerTest.java
+++ b/src/test/java/ui/BoardControllerTest.java
@@ -49,6 +49,25 @@ class BoardControllerTest {
     }
 
     @Test
+    void GetLegalMovesForSelection_WithSelection_WhenBoardReturnsEmpty_ReturnsEmptyList() {
+        Piece[][] standardGrid = newStandardStartingGrid();
+        Location selected = new Location(0, 6);
+        Board boardMock = EasyMock.createMock(Board.class);
+        EasyMock.expect(boardMock.getCurrentGameState()).andStubReturn(GameState.WHITE_TURN);
+        EasyMock.expect(boardMock.getPieceAt(6, 0)).andReturn(standardGrid[6][0]);
+        EasyMock.expect(boardMock.getLegalMoves(selected)).andReturn(List.of());
+        EasyMock.replay(boardMock);
+
+        BoardController controller = new BoardController(boardMock);
+        controller.handleSquareClick(selected);
+
+        int expected = 0;
+        int actual = controller.getLegalMovesForSelection().size();
+        assertEquals(expected, actual);
+        EasyMock.verify(boardMock);
+    }
+
+    @Test
     void GetLegalMovesForSelection_WithSelection_ReturnsMovesFromBoard() {
         Piece[][] standardGrid = newStandardStartingGrid();
         Location selected = new Location(0, 6);

--- a/src/test/java/ui/BoardControllerTest.java
+++ b/src/test/java/ui/BoardControllerTest.java
@@ -61,7 +61,7 @@ class BoardControllerTest {
         EasyMock.expect(boardMock.getLegalMoves(selected)).andReturn(List.of());
         EasyMock.replay(boardMock);
 
-        BoardController controller = new BoardController(boardMock);
+        BoardController controller = controllerFor(boardMock);
         controller.handleSquareClick(selected);
 
         int expected = 0;
@@ -82,7 +82,7 @@ class BoardControllerTest {
         EasyMock.expect(boardMock.getLegalMoves(selected)).andReturn(boardMoves);
         EasyMock.replay(boardMock);
 
-        BoardController controller = new BoardController(boardMock);
+        BoardController controller = controllerFor(boardMock);
         controller.handleSquareClick(selected);
 
         List<Move> expected = boardMoves;
@@ -94,7 +94,7 @@ class BoardControllerTest {
     @Test
     void GetLegalMovesForSelection_NoSelection_ReturnsEmptyList() {
         Board boardMock = replayNiceBoard();
-        BoardController controller = new BoardController(boardMock);
+        BoardController controller = controllerFor(boardMock);
 
         int expected = 0;
         int actual = controller.getLegalMovesForSelection().size();


### PR DESCRIPTION
## Description

Adds `BoardController.getLegalMovesForSelection()` so the UI can highlight legal destinations after a player selects one of their pieces. When nothing is selected, the method returns an empty list; when a piece is selected, it delegates to `board.getLegalMoves(lastSelectedLoc.get())`. Matches the chess-master delegation pattern used by `BoardView.drawLegalMoveHighlights`.

This slice covers **legal-move lookup for selection only** — not destination clicks, `makeMove`, or turn switching (follow-up work).

## Type of Change

- [x] Feature (new functionality)
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactor
- [x] Test addition/update

## Related Work

Related to `docs/bva/BoardController.md` — `getLegalMovesForSelection()` section (BC-TC52–54)

Branch: `feature-board-controller-legal-move-selection`

User story (partial): *As a player, I can select one of my pieces and move it to a legal destination on my turn, so that the board updates and the other player becomes active.*

## Changes Made

- [x] Added `getLegalMovesForSelection(): List<Move>` to `BoardController`
- [x] Returns empty list when `lastSelectedLoc` is absent; otherwise calls `board.getLegalMoves`
- [x] Added BC-TC52–54 unit tests in `BoardControllerTest` (EasyMock for `Board.getLegalMoves`)
- [x] Documented and marked BC-TC52–54 in BVA

## BVA & Testing

- BVA documented in: `docs/bva/BoardController.md`
- Test cases implemented: **BC-TC52, BC-TC53, BC-TC54**
  - `GetLegalMovesForSelection_NoSelection_ReturnsEmptyList`
  - `GetLegalMovesForSelection_WithSelection_ReturnsMovesFromBoard`
  - `GetLegalMovesForSelection_WithSelection_WhenBoardReturnsEmpty_ReturnsEmptyList`
- All tests passing: [x] `./gradlew test`

### TDD commits (one TC per commit)

1. `Update BoardController BVA for getLegalMovesForSelection` (BVA only)
2. `GetLegalMovesForSelection_NoSelection_ReturnsEmptyList passes` (test + stub method)
3. `GetLegalMovesForSelection_WithSelection_ReturnsMovesFromBoard passes` (test + delegation to board)
4. `GetLegalMovesForSelection_WithSelection_WhenBoardReturnsEmpty_ReturnsEmptyList passes` (test only)
5. `Update BoardController BVA mark TC52-54 implemented`

## Design Alignment

- [x] Changes align with `docs/design/chess-full-design.puml`
- [x] No breaking changes to existing methods
- [x] New method follows the established chess-master pattern

## Implementation Notes

- **Chess-master parity:** Same implementation as chess-master — guard on `lastSelectedLoc`, then `board.getLegalMoves`.
- **Test strategy:** Controller tests mock `Board`; legal-move generation itself is covered by `Board` / `MoveGenerator` tests.
- **Out of scope:** `handleDestinationClick`, `executeMove`, promotion dialog, and end-game flow remain for a later slice to complete the full user story.

## Checklist

- [x] BVA analysis is documented
- [x] TDD workflow followed (tests before code)
- [x] Code compiles and all tests pass
- [x] No new compiler warnings
- [x] Documentation updated (if applicable)
- [x] Commit messages are clear and follow TDD workflow