### PR TITLE
[FEAT] Add en Passant and Castling to MoveGenerator

### DIFF
--- a/docs/bva/MoveGenerator.md
+++ b/docs/bva/MoveGenerator.md
@@ -239,27 +239,27 @@ Scope: add pseudo-legal generation for en passant and castling using current boa
 
 ### Step 4: Test cases
 
-- MG-TC14: GenerateLegalMoves_OnWhitePawnWithEnPassantTarget_IncludesEnPassantMove ( :x: )
+- MG-TC14: GenerateLegalMoves_OnWhitePawnWithEnPassantTarget_IncludesEnPassantMove ( :white_check_mark: )
   - Method(s) under test: generateLegalMoves(Location)
   - State of the system: white pawn at `(4,3)`, `enPassantTarget = Optional.of(new Location(5,2))`
   - Expected output: returned moves include destination `(5,2)` with `MoveType.EN_PASSANT`
 
-- MG-TC15: GenerateLegalMoves_OnWhitePawnWithoutEnPassantTarget_ExcludesEnPassantMove ( :x: )
+- MG-TC15: GenerateLegalMoves_OnWhitePawnWithoutEnPassantTarget_ExcludesEnPassantMove ( :white_check_mark: )
   - Method(s) under test: generateLegalMoves(Location)
   - State of the system: white pawn at `(4,3)`, `enPassantTarget = Optional.empty()`
   - Expected output: returned moves do not include any `MoveType.EN_PASSANT`
 
-- MG-TC16: GenerateLegalMoves_OnUnmovedKingWithClearKingsidePath_IncludesKingsideCastling ( :x: )
+- MG-TC16: GenerateLegalMoves_OnUnmovedKingWithClearKingsidePath_IncludesKingsideCastling ( :white_check_mark: )
   - Method(s) under test: generateLegalMoves(Location)
   - State of the system: white king `(4,7)` and rook `(7,7)` unmoved; path clear and safe
   - Expected output: returned moves include destination `(6,7)` with `MoveType.CASTLING_KINGSIDE`
 
-- MG-TC17: GenerateLegalMoves_OnMovedKing_ExcludesCastlingMoves ( :x: )
+- MG-TC17: GenerateLegalMoves_OnMovedKing_ExcludesCastlingMoves ( :white_check_mark: )
   - Method(s) under test: generateLegalMoves(Location)
   - State of the system: same as MG-TC16 but king has `hasMoved() == true`
   - Expected output: returned moves include no castling move types
 
-- MG-TC18: GenerateLegalMoves_OnKingsidePathSquareUnderAttack_ExcludesKingsideCastling ( :x: )
+- MG-TC18: GenerateLegalMoves_OnKingsidePathSquareUnderAttack_ExcludesKingsideCastling ( :white_check_mark: )
   - Method(s) under test: generateLegalMoves(Location)
   - State of the system: same as MG-TC16 with black rook attacking square `(5,7)`
   - Expected output: returned moves do not include `MoveType.CASTLING_KINGSIDE`

--- a/docs/bva/MoveGenerator.md
+++ b/docs/bva/MoveGenerator.md
@@ -26,8 +26,8 @@
 
 **En-passant target state — Cases:**
 
-- No en-passant target
-- En-passant target present at a capture square (later slices)
+- No en-passant target (`Optional.empty()`)
+- En-passant target present at capture square (see MG-TC25–26, MG-TC32)
 
 ### Step 4: Test Cases (Each-Choice Strategy)
 
@@ -401,61 +401,84 @@ Scope: aggregates `generateLegalMoves` for every piece of `color`, so check filt
 
 ## Method / behavior: en passant and castling in `generateLegalMoves(Location from)`
 
-Scope: add pseudo-legal generation for en passant and castling using current board state, king/rook `hasMoved` flags, and `enPassantTarget`. Check filtering (above) still applies to returned moves.
+Scope: pseudo-legal **en passant** (via stored `enPassantTarget`) and **castling** (king/rook `hasMoved`, clear path, king path not attacked). Exercised through `generateLegalMoves`; check filtering above still applies to returned moves.
 
 ### Step 1: Equivalence Classes
 
-- **Input: en-passant target** — no target vs target on adjacent capture square
-- **Input: king/rook movement state** — unmoved king and rook vs moved king or moved rook
-- **Input: castling path** — squares clear and safe vs blocked or attacked
-- **Output: move list contents** — includes or excludes special-move types
+- **Input: en-passant target** — absent vs present on valid capture square vs present on wrong rank
+- **Input: castling side** — kingside vs queenside unmoved rook
+- **Input: king/rook movement state** — both unmoved vs king moved vs rook moved
+- **Input: castling path safety** — transit squares clear and unattacked vs square under attack
+- **Output: move list contents** — special `MoveType` present vs absent for a given destination
 
 ### Step 2: Data Types (from BVA Catalog)
 
 | Equivalence class | Catalog data type | Parameters |
 | --- | --- | --- |
-| Input: en-passant target | Cases | no target, target at capture square |
-| Input: king/rook movement state | Cases | unmoved pair, king moved |
-| Input: castling path safety | Cases | clear and safe, square under attack |
-| Output: move list contents | Collections | includes `EN_PASSANT` / `CASTLING_KINGSIDE` vs excludes them |
+| Input: en-passant target | Cases | no target, valid target at `(5, 2)`, invalid target at `(5, 4)` |
+| Input: castling side | Cases | kingside, queenside |
+| Input: king/rook movement state | Cases | both unmoved, king moved, rook moved |
+| Input: castling path safety | Cases | safe path, attacked transit square `(5, 7)` |
+| Output: move list contents | Collections | includes / excludes `EN_PASSANT`, `CASTLING_KINGSIDE`, `CASTLING_QUEENSIDE` |
 
 ### Step 3: Boundary Values (from BVA Catalog)
 
 **En-passant target — Cases:**
 
-- No en-passant target
-- En-passant target at `(5, 2)` for white pawn at `(4, 3)`
+- No target — `Optional.empty()` for pawn at `(4, 3)`
+- Valid target — `(5, 2)` adjacent to white pawn at `(4, 3)` on rank `2`
+- Invalid target — `(5, 4)` (wrong rank; not `rank + direction`)
+
+**Castling side — Cases:**
+
+- Kingside — white king `(4, 7)`, rook `(7, 7)` unmoved; destination `(6, 7)`
+- Queenside — white king `(4, 7)`, rook `(0, 7)` unmoved; destination `(2, 7)`
 
 **King/rook movement — Cases:**
 
-- White king `(4, 7)` and rook `(7, 7)` both unmoved
-- Same layout with `king.changeToMoved()`
+- Both unmoved — castling allowed when path safe
+- King moved — `king.changeToMoved()`; no castling types
+- Kingside rook moved — `rook.changeToMoved()` at `(7, 7)`; kingside excluded
 
-**Castling path — Cases:**
+**Castling path safety — Cases:**
 
-- Squares `(5, 7)` and `(6, 7)` empty; king path not attacked
-- Black rook attacks `(5, 7)` on otherwise valid kingside layout
+- Clear path — squares between king and rook empty; no attack on king path
+- Attacked transit — black rook at `(5, 0)` attacks `(5, 7)` on kingside layout
 
 ### Step 4: Test Cases (Each-Choice Strategy)
 
+`addEnPassantMoves` and `addCastlingMoves` are private; exercised indirectly through `generateLegalMoves`.
+
 - **MG-TC25: GenerateLegalMoves_OnWhitePawnWithEnPassantTarget_IncludesEnPassantMove** ( :white_check_mark: )
-  - **Method(s) under test**: `generateLegalMoves(Location)`
-  - **State of the system**: white pawn at `(4, 3)`; en-passant target at `(5, 2)`
+  - **Method(s) under test**: `generateLegalMoves(Location)` (via `addEnPassantMoves`)
+  - **State of the system**: white pawn at `(4, 3)`; `enPassantTarget` at `(5, 2)`
   - **Expected output**: returned moves include destination `(5, 2)` with `MoveType.EN_PASSANT`
 - **MG-TC26: GenerateLegalMoves_OnWhitePawnWithoutEnPassantTarget_ExcludesEnPassantMove** ( :white_check_mark: )
-  - **Method(s) under test**: `generateLegalMoves(Location)`
-  - **State of the system**: white pawn at `(4, 3)`; no en-passant target
-  - **Expected output**: returned moves include no `MoveType.EN_PASSANT`
+  - **Method(s) under test**: `generateLegalMoves(Location)` (via `addEnPassantMoves`)
+  - **State of the system**: white pawn at `(4, 3)`; `Optional.empty()` en-passant target
+  - **Expected output**: no returned move has `MoveType.EN_PASSANT`
 - **MG-TC27: GenerateLegalMoves_OnUnmovedKingWithClearKingsidePath_IncludesKingsideCastling** ( :white_check_mark: )
-  - **Method(s) under test**: `generateLegalMoves(Location)`
+  - **Method(s) under test**: `generateLegalMoves(Location)` (via `addCastlingMoves`)
   - **State of the system**: white king `(4, 7)` and rook `(7, 7)` unmoved; path clear and safe
   - **Expected output**: returned moves include destination `(6, 7)` with `MoveType.CASTLING_KINGSIDE`
 - **MG-TC28: GenerateLegalMoves_OnMovedKing_ExcludesCastlingMoves** ( :white_check_mark: )
-  - **Method(s) under test**: `generateLegalMoves(Location)`
+  - **Method(s) under test**: `generateLegalMoves(Location)` (via `addCastlingMoves`)
   - **State of the system**: same as MG-TC27 but king has `hasMoved() == true`
-  - **Expected output**: returned moves include no castling move types
+  - **Expected output**: no returned move has `MoveType.CASTLING_KINGSIDE` or `MoveType.CASTLING_QUEENSIDE`
 - **MG-TC29: GenerateLegalMoves_OnKingsidePathSquareUnderAttack_ExcludesKingsideCastling** ( :white_check_mark: )
-  - **Method(s) under test**: `generateLegalMoves(Location)`
-  - **State of the system**: same as MG-TC27 with black rook attacking square `(5, 7)`
-  - **Expected output**: returned moves do not include `MoveType.CASTLING_KINGSIDE`
+  - **Method(s) under test**: `generateLegalMoves(Location)` (via `addCastlingMoves`)
+  - **State of the system**: same as MG-TC27 with black rook at `(5, 0)` attacking transit square `(5, 7)`
+  - **Expected output**: no returned move has `MoveType.CASTLING_KINGSIDE`
+- **MG-TC30: GenerateLegalMoves_OnUnmovedKingWithClearQueensidePath_IncludesQueensideCastling** ( :x: )
+  - **Method(s) under test**: `generateLegalMoves(Location)` (via `addCastlingMoves`)
+  - **State of the system**: white king `(4, 7)` and rook `(0, 7)` unmoved; squares `(1, 7)`, `(2, 7)`, `(3, 7)` empty; path safe
+  - **Expected output**: returned moves include destination `(2, 7)` with `MoveType.CASTLING_QUEENSIDE`
+- **MG-TC31: GenerateLegalMoves_OnMovedKingsideRook_ExcludesKingsideCastling** ( :x: )
+  - **Method(s) under test**: `generateLegalMoves(Location)` (via `addCastlingMoves`)
+  - **State of the system**: white king `(4, 7)` unmoved; rook `(7, 7)` with `hasMoved() == true`
+  - **Expected output**: no returned move has `MoveType.CASTLING_KINGSIDE`
+- **MG-TC32: GenerateLegalMoves_OnEnPassantTargetWrongRank_ExcludesEnPassantMove** ( :x: )
+  - **Method(s) under test**: `generateLegalMoves(Location)` (via `addEnPassantMoves`)
+  - **State of the system**: white pawn at `(4, 3)`; `enPassantTarget` at `(5, 4)` (not on capture rank `2`)
+  - **Expected output**: no returned move has `MoveType.EN_PASSANT`
 

--- a/docs/bva/MoveGenerator.md
+++ b/docs/bva/MoveGenerator.md
@@ -204,3 +204,62 @@ Scope: Add basic legal move generation for all piece types (pawn, knight, bishop
   - Method(s) under test: isInCheck(PieceColor)
   - State of the system: white king present and no black piece attacks it
   - Expected output: isInCheck(PieceColor.WHITE) is false
+
+---
+
+## Method / behavior: en passant and castling in `generateLegalMoves(Location from)`
+
+Scope: add pseudo-legal generation for en passant and castling using current board state, king/rook `hasMoved` flags, and `enPassantTarget`.
+
+### Step 1: Inputs and outputs
+
+| Input / state | Equivalence classes |
+| ------------- | ------------------- |
+| `enPassantTarget` | Optional empty vs present on adjacent capture square |
+| King/rook movement state | Cases - unmoved king+rook vs moved king or moved rook |
+| Castling path | Cases - squares clear and safe vs blocked or attacked |
+| Output | Collections - includes special move vs excludes it |
+
+### Step 2: Catalog data types
+
+| Variable / output | Catalog data type |
+| ----------------- | ----------------- |
+| `enPassantTarget` | Optional |
+| Piece movement flags | Cases |
+| Path occupancy and attack checks | Cases |
+| Returned move list | Collections |
+
+### Step 3: Concrete boundary values
+
+- White en passant: white pawn at `(4,3)`, `enPassantTarget = (5,2)`.
+- No en passant target: same pawn placement, `enPassantTarget = Optional.empty()`.
+- Kingside castling allowed: white king `(4,7)` and rook `(7,7)` both unmoved, squares `(5,7)` and `(6,7)` empty, none of `(4,7)`, `(5,7)`, `(6,7)` attacked.
+- Castling blocked by moved king: same board but `king.changeToMoved()`.
+- Castling blocked by attacked transit square: same board plus black rook attacking `(5,7)`.
+
+### Step 4: Test cases
+
+- MG-TC14: GenerateLegalMoves_OnWhitePawnWithEnPassantTarget_IncludesEnPassantMove ( :x: )
+  - Method(s) under test: generateLegalMoves(Location)
+  - State of the system: white pawn at `(4,3)`, `enPassantTarget = Optional.of(new Location(5,2))`
+  - Expected output: returned moves include destination `(5,2)` with `MoveType.EN_PASSANT`
+
+- MG-TC15: GenerateLegalMoves_OnWhitePawnWithoutEnPassantTarget_ExcludesEnPassantMove ( :x: )
+  - Method(s) under test: generateLegalMoves(Location)
+  - State of the system: white pawn at `(4,3)`, `enPassantTarget = Optional.empty()`
+  - Expected output: returned moves do not include any `MoveType.EN_PASSANT`
+
+- MG-TC16: GenerateLegalMoves_OnUnmovedKingWithClearKingsidePath_IncludesKingsideCastling ( :x: )
+  - Method(s) under test: generateLegalMoves(Location)
+  - State of the system: white king `(4,7)` and rook `(7,7)` unmoved; path clear and safe
+  - Expected output: returned moves include destination `(6,7)` with `MoveType.CASTLING_KINGSIDE`
+
+- MG-TC17: GenerateLegalMoves_OnMovedKing_ExcludesCastlingMoves ( :x: )
+  - Method(s) under test: generateLegalMoves(Location)
+  - State of the system: same as MG-TC16 but king has `hasMoved() == true`
+  - Expected output: returned moves include no castling move types
+
+- MG-TC18: GenerateLegalMoves_OnKingsidePathSquareUnderAttack_ExcludesKingsideCastling ( :x: )
+  - Method(s) under test: generateLegalMoves(Location)
+  - State of the system: same as MG-TC16 with black rook attacking square `(5,7)`
+  - Expected output: returned moves do not include `MoveType.CASTLING_KINGSIDE`

--- a/docs/bva/MoveGenerator.md
+++ b/docs/bva/MoveGenerator.md
@@ -469,7 +469,7 @@ Scope: pseudo-legal **en passant** (via stored `enPassantTarget`) and **castling
   - **Method(s) under test**: `generateLegalMoves(Location)` (via `addCastlingMoves`)
   - **State of the system**: same as MG-TC27 with black rook at `(5, 0)` attacking transit square `(5, 7)`
   - **Expected output**: no returned move has `MoveType.CASTLING_KINGSIDE`
-- **MG-TC30: GenerateLegalMoves_OnUnmovedKingWithClearQueensidePath_IncludesQueensideCastling** ( :x: )
+- **MG-TC30: GenerateLegalMoves_OnUnmovedKingWithClearQueensidePath_IncludesQueensideCastling** ( :white_check_mark: )
   - **Method(s) under test**: `generateLegalMoves(Location)` (via `addCastlingMoves`)
   - **State of the system**: white king `(4, 7)` and rook `(0, 7)` unmoved; squares `(1, 7)`, `(2, 7)`, `(3, 7)` empty; path safe
   - **Expected output**: returned moves include destination `(2, 7)` with `MoveType.CASTLING_QUEENSIDE`

--- a/docs/bva/MoveGenerator.md
+++ b/docs/bva/MoveGenerator.md
@@ -477,7 +477,7 @@ Scope: pseudo-legal **en passant** (via stored `enPassantTarget`) and **castling
   - **Method(s) under test**: `generateLegalMoves(Location)` (via `addCastlingMoves`)
   - **State of the system**: white king `(4, 7)` unmoved; rook `(7, 7)` with `hasMoved() == true`
   - **Expected output**: no returned move has `MoveType.CASTLING_KINGSIDE`
-- **MG-TC32: GenerateLegalMoves_OnEnPassantTargetWrongRank_ExcludesEnPassantMove** ( :x: )
+- **MG-TC32: GenerateLegalMoves_OnEnPassantTargetWrongRank_ExcludesEnPassantMove** ( :white_check_mark: )
   - **Method(s) under test**: `generateLegalMoves(Location)` (via `addEnPassantMoves`)
   - **State of the system**: white pawn at `(4, 3)`; `enPassantTarget` at `(5, 4)` (not on capture rank `2`)
   - **Expected output**: no returned move has `MoveType.EN_PASSANT`

--- a/docs/bva/MoveGenerator.md
+++ b/docs/bva/MoveGenerator.md
@@ -473,7 +473,7 @@ Scope: pseudo-legal **en passant** (via stored `enPassantTarget`) and **castling
   - **Method(s) under test**: `generateLegalMoves(Location)` (via `addCastlingMoves`)
   - **State of the system**: white king `(4, 7)` and rook `(0, 7)` unmoved; squares `(1, 7)`, `(2, 7)`, `(3, 7)` empty; path safe
   - **Expected output**: returned moves include destination `(2, 7)` with `MoveType.CASTLING_QUEENSIDE`
-- **MG-TC31: GenerateLegalMoves_OnMovedKingsideRook_ExcludesKingsideCastling** ( :x: )
+- **MG-TC31: GenerateLegalMoves_OnMovedKingsideRook_ExcludesKingsideCastling** ( :white_check_mark: )
   - **Method(s) under test**: `generateLegalMoves(Location)` (via `addCastlingMoves`)
   - **State of the system**: white king `(4, 7)` unmoved; rook `(7, 7)` with `hasMoved() == true`
   - **Expected output**: no returned move has `MoveType.CASTLING_KINGSIDE`

--- a/docs/bva/MoveGenerator.md
+++ b/docs/bva/MoveGenerator.md
@@ -11,7 +11,7 @@ Scope: Add basic legal move generation for all piece types (pawn, knight, bishop
 | Input / state   | Equivalence classes                                           |
 | --------------- | ------------------------------------------------------------- |
 | board           | Collections - 8x8 board with Piece objects                    |
-| enPassantTarget | Optional - empty or present                                   |
+| enPassantTarget | Cases - no target vs target set at capture square             |
 | Output          | Cases - generator stores references for later move generation |
 
 ### Step 2: Catalog data types
@@ -19,19 +19,24 @@ Scope: Add basic legal move generation for all piece types (pawn, knight, bishop
 | Variable / output   | Catalog data type |
 | ------------------- | ----------------- |
 | board               | Collections       |
-| enPassantTarget     | Optional          |
+| enPassantTarget     | Cases             |
 | generator readiness | Cases             |
 
 ### Step 3: Concrete boundary values
 
 - board: 8x8 array filled with NonePiece except test-specific piece placements.
-- enPassantTarget: Optional.empty() for basic move tests.
+- enPassantTarget: no target for basic move tests.
+
+**enPassantTarget — Cases:**
+
+- No en-passant target
+- En-passant target present at a capture square
 
 ### Step 4: Test cases
 
 - MG-TC1: Constructor_WithBoardAndEmptyEnPassant_GenerateLegalMovesUsable ( :white_check_mark: )
   - Method(s) under test: MoveGenerator(Piece[][], Optional<Location>), generateLegalMoves(Location)
-  - State of the system: 8x8 board, white knight at (4,4), enPassantTarget is Optional.empty()
+  - State of the system: 8x8 board, white knight at (4,4), no en-passant target
   - Expected output: generateLegalMoves(new Location(4,4)) returns a non-null list
 
 ---
@@ -215,7 +220,7 @@ Scope: add pseudo-legal generation for en passant and castling using current boa
 
 | Input / state | Equivalence classes |
 | ------------- | ------------------- |
-| `enPassantTarget` | Optional empty vs present on adjacent capture square |
+| `enPassantTarget` | Cases - no target vs target on adjacent capture square |
 | King/rook movement state | Cases - unmoved king+rook vs moved king or moved rook |
 | Castling path | Cases - squares clear and safe vs blocked or attacked |
 | Output | Collections - includes special move vs excludes it |
@@ -224,15 +229,20 @@ Scope: add pseudo-legal generation for en passant and castling using current boa
 
 | Variable / output | Catalog data type |
 | ----------------- | ----------------- |
-| `enPassantTarget` | Optional |
+| `enPassantTarget` | Cases |
 | Piece movement flags | Cases |
 | Path occupancy and attack checks | Cases |
 | Returned move list | Collections |
 
 ### Step 3: Concrete boundary values
 
-- White en passant: white pawn at `(4,3)`, `enPassantTarget = (5,2)`.
-- No en passant target: same pawn placement, `enPassantTarget = Optional.empty()`.
+**enPassantTarget — Cases:**
+
+- No en-passant target
+- En-passant target present (e.g. `(5,2)` for white pawn en passant)
+
+- White en passant: white pawn at `(4,3)`, en-passant target at `(5,2)`.
+- No en passant: same pawn placement, no en-passant target.
 - Kingside castling allowed: white king `(4,7)` and rook `(7,7)` both unmoved, squares `(5,7)` and `(6,7)` empty, none of `(4,7)`, `(5,7)`, `(6,7)` attacked.
 - Castling blocked by moved king: same board but `king.changeToMoved()`.
 - Castling blocked by attacked transit square: same board plus black rook attacking `(5,7)`.
@@ -241,12 +251,12 @@ Scope: add pseudo-legal generation for en passant and castling using current boa
 
 - MG-TC14: GenerateLegalMoves_OnWhitePawnWithEnPassantTarget_IncludesEnPassantMove ( :white_check_mark: )
   - Method(s) under test: generateLegalMoves(Location)
-  - State of the system: white pawn at `(4,3)`, `enPassantTarget = Optional.of(new Location(5,2))`
+  - State of the system: white pawn at `(4,3)`, en-passant target at `(5,2)`
   - Expected output: returned moves include destination `(5,2)` with `MoveType.EN_PASSANT`
 
 - MG-TC15: GenerateLegalMoves_OnWhitePawnWithoutEnPassantTarget_ExcludesEnPassantMove ( :white_check_mark: )
   - Method(s) under test: generateLegalMoves(Location)
-  - State of the system: white pawn at `(4,3)`, `enPassantTarget = Optional.empty()`
+  - State of the system: white pawn at `(4,3)`, no en-passant target
   - Expected output: returned moves do not include any `MoveType.EN_PASSANT`
 
 - MG-TC16: GenerateLegalMoves_OnUnmovedKingWithClearKingsidePath_IncludesKingsideCastling ( :white_check_mark: )

--- a/src/main/java/domain/MoveGenerator.java
+++ b/src/main/java/domain/MoveGenerator.java
@@ -2,6 +2,7 @@ package domain;
 
 import domain.location.Location;
 import domain.move.Move;
+import domain.move.MoveType;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -113,7 +114,22 @@ public class MoveGenerator {
                 && board[twoAhead][file].getType() == PieceType.NONE) {
             moves.add(new Move(from, new Location(file, twoAhead)));
         }
+        addEnPassantMoves(moves, from, rank, file, direction);
         return moves;
+    }
+
+    private void addEnPassantMoves(
+            List<Move> moves, Location from, int rank, int file, int direction) {
+        if (!enPassantTarget.isPresent()) {
+            return;
+        }
+        Location target = enPassantTarget.get();
+        if (target.getY() != rank + direction) {
+            return;
+        }
+        if (target.getX() == file - 1 || target.getX() == file + 1) {
+            moves.add(new Move(from, target, MoveType.EN_PASSANT));
+        }
     }
 
     private List<Move> generateKingMoves(Location from, Piece king) {

--- a/src/main/java/domain/MoveGenerator.java
+++ b/src/main/java/domain/MoveGenerator.java
@@ -13,6 +13,10 @@ import domain.piece.PieceType;
 public class MoveGenerator {
 
     private static final int BOARD_SIZE = 8;
+    private static final int KINGSIDE_KING_DEST_FILE = 6;
+    private static final int QUEENSIDE_KING_DEST_FILE = 2;
+    private static final int KINGSIDE_ROOK_DEST_FILE = 5;
+    private static final int QUEENSIDE_ROOK_DEST_FILE = 3;
     private static final int[][] EIGHT_DIRECTIONS = {
         {-1, -1}, {-1, 0}, {-1, 1}, {0, -1}, {0, 1}, {1, -1}, {1, 0}, {1, 1}
     };
@@ -147,7 +151,84 @@ public class MoveGenerator {
                 moves.add(new Move(from, new Location(targetFile, targetRank)));
             }
         }
+        addCastlingMoves(moves, from, king);
         return moves;
+    }
+
+    private void addCastlingMoves(List<Move> moves, Location from, Piece king) {
+        if (king.hasMoved() || isInCheck(king.getColor())) {
+            return;
+        }
+        int rank = from.getY();
+        int file = from.getX();
+        PieceColor color = king.getColor();
+        int kingsideRook = findUnmovedRookFileIn(board, rank, file, true, color);
+        if (kingsideRook >= 0
+                && canCastle(rank, file, kingsideRook, KINGSIDE_KING_DEST_FILE,
+                KINGSIDE_ROOK_DEST_FILE, color)) {
+            moves.add(new Move(from, new Location(KINGSIDE_KING_DEST_FILE, rank),
+                    MoveType.CASTLING_KINGSIDE));
+        }
+        int queensideRook = findUnmovedRookFileIn(board, rank, file, false, color);
+        if (queensideRook >= 0
+                && canCastle(rank, file, queensideRook, QUEENSIDE_KING_DEST_FILE,
+                QUEENSIDE_ROOK_DEST_FILE, color)) {
+            moves.add(new Move(from, new Location(QUEENSIDE_KING_DEST_FILE, rank),
+                    MoveType.CASTLING_QUEENSIDE));
+        }
+    }
+
+    private boolean canCastle(
+            int rank, int kingFile, int rookFile, int kingDestFile, int rookDestFile, PieceColor color) {
+        return isPathClearForCastling(rank, kingFile, rookFile, kingDestFile, rookDestFile)
+                && isKingPathSafe(rank, kingFile, kingDestFile, color);
+    }
+
+    private boolean isPathClearForCastling(
+            int rank, int kingFile, int rookFile, int kingDestFile, int rookDestFile) {
+        int minFile = Math.min(Math.min(kingFile, rookFile), Math.min(kingDestFile, rookDestFile));
+        int maxFile = Math.max(Math.max(kingFile, rookFile), Math.max(kingDestFile, rookDestFile));
+        for (int f = minFile; f <= maxFile; f++) {
+            if (f == kingFile || f == rookFile) {
+                continue;
+            }
+            if (board[rank][f].getType() != PieceType.NONE) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean isKingPathSafe(int rank, int kingFile, int kingDestFile, PieceColor color) {
+        int minFile = Math.min(kingFile, kingDestFile);
+        int maxFile = Math.max(kingFile, kingDestFile);
+        PieceColor attacker = opponent(color);
+        for (int f = minFile; f <= maxFile; f++) {
+            if (isSquareAttackedBy(new Location(f, rank), attacker, board)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static int findUnmovedRookFileIn(
+            Piece[][] board, int rank, int kingFile, boolean kingside, PieceColor color) {
+        if (kingside) {
+            for (int f = BOARD_SIZE - 1; f > kingFile; f--) {
+                Piece p = board[rank][f];
+                if (p.getType() == PieceType.ROOK && p.getColor() == color && !p.hasMoved()) {
+                    return f;
+                }
+            }
+        } else {
+            for (int f = 0; f < kingFile; f++) {
+                Piece p = board[rank][f];
+                if (p.getType() == PieceType.ROOK && p.getColor() == color && !p.hasMoved()) {
+                    return f;
+                }
+            }
+        }
+        return -1;
     }
 
     private List<Move> generateSlidingMoves(Location from, Piece piece, int[][] directions) {

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -389,6 +389,23 @@ class MoveGeneratorTest {
     }
 
     @Test
+    void GenerateLegalMoves_OnUnmovedKingWithClearQueensidePath_IncludesQueensideCastling() {
+        Piece[][] board = emptyBoard();
+        board[7][4] = new King(PieceColor.WHITE);
+        board[7][0] = new Rook(PieceColor.WHITE);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = true;
+        boolean actual = hasMoveToWithType(
+                moveGenerator.generateLegalMoves(new Location(4, 7)),
+                2,
+                7,
+                MoveType.CASTLING_QUEENSIDE);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
     void GenerateLegalMoves_OnKingsidePathSquareUnderAttack_ExcludesKingsideCastling() {
         Piece[][] board = emptyBoard();
         board[7][4] = new King(PieceColor.WHITE);

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import domain.location.Location;
+import domain.move.Move;
+import domain.move.MoveType;
 import domain.piece.Bishop;
 import domain.piece.King;
 import domain.piece.Knight;
@@ -173,6 +175,35 @@ class MoveGeneratorTest {
         int actual = moveGenerator.generateLegalMoves(new Location(3, 3)).size();
 
         assertEquals(expected, actual);
+    }
+
+    @Test
+    void GenerateLegalMoves_OnWhitePawnWithEnPassantTarget_IncludesEnPassantMove() {
+        Piece[][] board = emptyBoard();
+        board[3][4] = new Pawn(PieceColor.WHITE);
+        MoveGenerator moveGenerator =
+                new MoveGenerator(board, Optional.of(new Location(5, 2)));
+
+        boolean expected = true;
+        boolean actual = hasMoveToWithType(
+                moveGenerator.generateLegalMoves(new Location(4, 3)),
+                5,
+                2,
+                MoveType.EN_PASSANT);
+
+        assertEquals(expected, actual);
+    }
+
+    private static boolean hasMoveToWithType(
+            java.util.List<Move> moves, int file, int rank, MoveType type) {
+        for (Move move : moves) {
+            if (move.getTo().getX() == file
+                    && move.getTo().getY() == rank
+                    && move.getType() == type) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static Piece[][] emptyBoard() {

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -194,12 +194,35 @@ class MoveGeneratorTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void GenerateLegalMoves_OnWhitePawnWithoutEnPassantTarget_ExcludesEnPassantMove() {
+        Piece[][] board = emptyBoard();
+        board[3][4] = new Pawn(PieceColor.WHITE);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = false;
+        boolean actual = hasMoveType(
+                moveGenerator.generateLegalMoves(new Location(4, 3)),
+                MoveType.EN_PASSANT);
+
+        assertEquals(expected, actual);
+    }
+
     private static boolean hasMoveToWithType(
             java.util.List<Move> moves, int file, int rank, MoveType type) {
         for (Move move : moves) {
             if (move.getTo().getX() == file
                     && move.getTo().getY() == rank
                     && move.getType() == type) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean hasMoveType(java.util.List<Move> moves, MoveType type) {
+        for (Move move : moves) {
+            if (move.getType() == type) {
                 return true;
             }
         }

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -241,6 +241,22 @@ class MoveGeneratorTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void GenerateLegalMoves_OnKingsidePathSquareUnderAttack_ExcludesKingsideCastling() {
+        Piece[][] board = emptyBoard();
+        board[7][4] = new King(PieceColor.WHITE);
+        board[7][7] = new Rook(PieceColor.WHITE);
+        board[0][5] = new Rook(PieceColor.BLACK);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = false;
+        boolean actual = hasMoveType(
+                moveGenerator.generateLegalMoves(new Location(4, 7)),
+                MoveType.CASTLING_KINGSIDE);
+
+        assertEquals(expected, actual);
+    }
+
     private static boolean hasMoveToWithType(
             java.util.List<Move> moves, int file, int rank, MoveType type) {
         for (Move move : moves) {

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -356,6 +356,21 @@ class MoveGeneratorTest {
     }
 
     @Test
+    void GenerateLegalMoves_OnEnPassantTargetWrongRank_ExcludesEnPassantMove() {
+        Piece[][] board = emptyBoard();
+        board[3][4] = new Pawn(PieceColor.WHITE);
+        MoveGenerator moveGenerator =
+                new MoveGenerator(board, Optional.of(new Location(5, 4)));
+
+        boolean expected = false;
+        boolean actual = hasMoveType(
+                moveGenerator.generateLegalMoves(new Location(4, 3)),
+                MoveType.EN_PASSANT);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
     void GenerateLegalMoves_OnUnmovedKingWithClearKingsidePath_IncludesKingsideCastling() {
         Piece[][] board = emptyBoard();
         board[7][4] = new King(PieceColor.WHITE);

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -208,6 +208,23 @@ class MoveGeneratorTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void GenerateLegalMoves_OnUnmovedKingWithClearKingsidePath_IncludesKingsideCastling() {
+        Piece[][] board = emptyBoard();
+        board[7][4] = new King(PieceColor.WHITE);
+        board[7][7] = new Rook(PieceColor.WHITE);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = true;
+        boolean actual = hasMoveToWithType(
+                moveGenerator.generateLegalMoves(new Location(4, 7)),
+                6,
+                7,
+                MoveType.CASTLING_KINGSIDE);
+
+        assertEquals(expected, actual);
+    }
+
     private static boolean hasMoveToWithType(
             java.util.List<Move> moves, int file, int rank, MoveType type) {
         for (Move move : moves) {

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -225,6 +225,22 @@ class MoveGeneratorTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void GenerateLegalMoves_OnMovedKing_ExcludesCastlingMoves() {
+        Piece[][] board = emptyBoard();
+        board[7][4] = new King(PieceColor.WHITE);
+        board[7][4].changeToMoved();
+        board[7][7] = new Rook(PieceColor.WHITE);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = false;
+        boolean actual = hasMoveType(
+                moveGenerator.generateLegalMoves(new Location(4, 7)),
+                MoveType.CASTLING_KINGSIDE);
+
+        assertEquals(expected, actual);
+    }
+
     private static boolean hasMoveToWithType(
             java.util.List<Move> moves, int file, int rank, MoveType type) {
         for (Move move : moves) {

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -406,6 +406,22 @@ class MoveGeneratorTest {
     }
 
     @Test
+    void GenerateLegalMoves_OnMovedKingsideRook_ExcludesKingsideCastling() {
+        Piece[][] board = emptyBoard();
+        board[7][4] = new King(PieceColor.WHITE);
+        board[7][7] = new Rook(PieceColor.WHITE);
+        board[7][7].changeToMoved();
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = false;
+        boolean actual = hasMoveType(
+                moveGenerator.generateLegalMoves(new Location(4, 7)),
+                MoveType.CASTLING_KINGSIDE);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
     void GenerateLegalMoves_OnKingsidePathSquareUnderAttack_ExcludesKingsideCastling() {
         Piece[][] board = emptyBoard();
         board[7][4] = new King(PieceColor.WHITE);


### PR DESCRIPTION
## Description

Adds en passant and castling move generation to `MoveGenerator` so players can perform these special moves when conditions are met.

This PR extends `generateLegalMoves(Location)` with:
- **En passant** generation from `enPassantTarget` for adjacent pawn captures.
- **Castling** generation for kingside/queenside when the king/rook are unmoved, path squares are clear, the king is not currently in check, and the king’s path is not attacked.

The implementation follows the chess-master approach for special-move generation and castling safety checks.

## Type of Change

- [x] Feature (new functionality)
- [ ] Bug fix
- [x] Documentation update
- [ ] Refactor
- [x] Test addition/update

## Related Work

Related to `docs/bva/MoveGenerator.md` (MG-TC14–18)

Branch: `feature-enpassant-to-move-generator`

User story: *As a player, I can perform en passant and castling when the conditions are met.*

## Changes Made

- [x] Added en passant generation to pawn moves using `enPassantTarget`
- [x] Added castling generation in king moves (kingside + queenside checks)
- [x] Added castling helper logic:
  - `addCastlingMoves(...)`
  - `canCastle(...)`
  - `isPathClearForCastling(...)`
  - `isKingPathSafe(...)`
  - `findUnmovedRookFileIn(...)`
- [x] Added unit tests for MG-TC14–18
- [x] Updated BVA and marked MG-TC14–18 implemented

## BVA & Testing

- BVA documented in: `docs/bva/MoveGenerator.md`
- Test cases implemented:
  - **MG-TC14** `GenerateLegalMoves_OnWhitePawnWithEnPassantTarget_IncludesEnPassantMove`
  - **MG-TC15** `GenerateLegalMoves_OnWhitePawnWithoutEnPassantTarget_ExcludesEnPassantMove`
  - **MG-TC16** `GenerateLegalMoves_OnUnmovedKingWithClearKingsidePath_IncludesKingsideCastling`
  - **MG-TC17** `GenerateLegalMoves_OnMovedKing_ExcludesCastlingMoves`
  - **MG-TC18** `GenerateLegalMoves_OnKingsidePathSquareUnderAttack_ExcludesKingsideCastling`
- All tests passing: [x] `./gradlew test`

### TDD commits (one TC per commit)

1. `Update MoveGenerator BVA for en passant and castling` (BVA only)
2. `GenerateLegalMoves_OnWhitePawnWithEnPassantTarget_IncludesEnPassantMove passes`
3. `GenerateLegalMoves_OnWhitePawnWithoutEnPassantTarget_ExcludesEnPassantMove passes`
4. `GenerateLegalMoves_OnUnmovedKingWithClearKingsidePath_IncludesKingsideCastling passes`
5. `GenerateLegalMoves_OnMovedKing_ExcludesCastlingMoves passes`
6. `GenerateLegalMoves_OnKingsidePathSquareUnderAttack_ExcludesKingsideCastling passes`
7. `Update MoveGenerator BVA mark TC14-18 implemented`

## Design Alignment

- [x] Changes align with `docs/design/chess-full-design.puml`
- [x] No breaking changes to existing methods
- [x] New methods follow established MoveGenerator patterns

## Implementation Notes

- This PR focuses on **special move generation** in `MoveGenerator`.
- Existing check-filtering behavior is preserved.
- Board-level execution/application of special moves in `Board.makeMove` is outside this PR scope.

## Checklist

- [x] BVA analysis is documented
- [x] TDD workflow followed (tests before code)
- [x] Code compiles and all tests pass
- [x] No new compiler warnings
- [x] Documentation updated (if applicable)
- [x] Commit messages are clear and follow TDD workflow