### PR TITLE
[FIX] WelcomeController Game Launch Wiring

### DIFF
--- a/docs/bva/WelcomeController.md
+++ b/docs/bva/WelcomeController.md
@@ -186,17 +186,17 @@ Scope: After name validation, create `BoardController(player1Name, player2Name, 
 
 ### Step 4: Test cases
 
-- **TC9: StartGame_NonEmptyNames_StartedBoardControllerNotNull** ( :x: )
+- **TC9: StartGame_NonEmptyNames_StartedBoardControllerNotNull** ( :white_check_mark: )
   - **Method(s) under test**: `startGame()`
   - **State of the system**: valid player names; `startGame()` called after `show()`
   - **Expected output**: `getStartedBoardController()` is not `null`
 
-- **TC10: StartGame_NonEmptyNames_MainViewIsVisible** ( :x: )
+- **TC10: StartGame_NonEmptyNames_MainViewIsVisible** ( :white_check_mark: )
   - **Method(s) under test**: `startGame()`
   - **State of the system**: valid player names; game started
   - **Expected output**: `getStartedBoardController().getMainView().isVisible()` is `true`
 
-- **TC11: StartGame_NonEmptyNames_CurrentPlayerLabelShowsPlayer1Name** ( :x: )
+- **TC11: StartGame_NonEmptyNames_CurrentPlayerLabelShowsPlayer1Name** ( :white_check_mark: )
   - **Method(s) under test**: `startGame()`
   - **State of the system**: valid player names; standard new game (`WHITE_TURN`)
   - **Expected output**: game stats current-player label text is `player1Name`

--- a/docs/bva/WelcomeController.md
+++ b/docs/bva/WelcomeController.md
@@ -155,3 +155,48 @@
   - **Method(s) under test**: `selectedInitializer()`
   - **State of the system**: chess960 selected; `selectedInitializer()` called
   - **Expected output**: returned value is an instance of `FischerRandomBoardInitializer`
+
+---
+
+## Method / behavior: `startGame()` — BoardController launch wiring (chess-master alignment)
+
+Scope: After name validation, create `BoardController(player1Name, player2Name, board)` and call `boardController.show()` so the game UI (including turn labels) is owned by `BoardController`, not constructed directly in `WelcomeController`.
+
+### Step 1: Equivalence Classes
+
+| Input / state | Equivalence classes |
+| ------------- | ------------------- |
+| Player names | both non-empty (valid start) |
+| Board mode | standard or chess960 via `selectedInitializer()` |
+| Output | `BoardController` created and `show()` launches visible `MainView` with player-one label on white turn |
+
+### Step 2: Data Types (from BVA Catalog)
+
+| Variable / output | Catalog data type |
+| ----------------- | ----------------- |
+| `player1Name`, `player2Name` | Strings |
+| Started controller reference | Pointers |
+| Main view visibility | Boolean |
+| Current player label text | Strings |
+
+### Step 3: Concrete boundary values
+
+- Valid start: `player1Name = "Alice"`, `player2Name = "Bob"`.
+- Fresh board from standard initializer; initial turn `WHITE_TURN`.
+
+### Step 4: Test cases
+
+- **TC9: StartGame_NonEmptyNames_StartedBoardControllerNotNull** ( :x: )
+  - **Method(s) under test**: `startGame()`
+  - **State of the system**: valid player names; `startGame()` called after `show()`
+  - **Expected output**: `getStartedBoardController()` is not `null`
+
+- **TC10: StartGame_NonEmptyNames_MainViewIsVisible** ( :x: )
+  - **Method(s) under test**: `startGame()`
+  - **State of the system**: valid player names; game started
+  - **Expected output**: `getStartedBoardController().getMainView().isVisible()` is `true`
+
+- **TC11: StartGame_NonEmptyNames_CurrentPlayerLabelShowsPlayer1Name** ( :x: )
+  - **Method(s) under test**: `startGame()`
+  - **State of the system**: valid player names; standard new game (`WHITE_TURN`)
+  - **Expected output**: game stats current-player label text is `player1Name`

--- a/docs/bva/WelcomeController.md
+++ b/docs/bva/WelcomeController.md
@@ -9,18 +9,20 @@
 
 ### Step 2: Data Types (from BVA Catalog)
 
-| Equivalence class                       | Catalog data type | Parameters                          |
-| --------------------------------------- | ----------------- | ----------------------------------- |
-| Output: WelcomeView initial visibility  | Boolean           | true (visible), false (not visible) |
-| Output: start-game action wired         | Boolean           | true (wired), false (not wired)     |
+| Equivalence class                      | Catalog data type | Parameters                          |
+| -------------------------------------- | ----------------- | ----------------------------------- |
+| Output: WelcomeView initial visibility | Boolean           | true (visible), false (not visible) |
+| Output: start-game action wired        | Boolean           | true (wired), false (not wired)     |
 
 ### Step 3: Boundary Values (from BVA Catalog)
 
 **WelcomeView initial visibility — Boolean:**
+
 - `false` (0)
 - `true` (1) — CAN'T SET: `show()` has not been called
 
 **start-game action wired — Boolean:**
+
 - `false` (0) — CAN'T SET: the constructor always wires the action
 - `true` (1)
 
@@ -53,6 +55,7 @@
 ### Step 3: Boundary Values (from BVA Catalog)
 
 **WelcomeView visibility — Boolean:**
+
 - `false` (0) — CAN'T SET: `show()` always makes the view visible
 - `true` (1)
 
@@ -86,18 +89,22 @@
 ### Step 3: Boundary Values (from BVA Catalog)
 
 **player1Name — String:**
+
 - `""` (empty string)
 - A non-empty string (e.g., `"Alice"`)
 
 **player2Name — String:**
+
 - `""` (empty string)
 - A non-empty string (e.g., `"Bob"`)
 
 **WelcomeView disposed — Boolean:**
+
 - `false` (0) — at least one name is empty; validation rejects the start
 - `true` (1) — both names are non-empty; game proceeds
 
 **error message — Boolean:**
+
 - `false` (0) — both names non-empty; no error shown
 - `true` (1) — at least one name is empty; error message displayed
 
@@ -129,18 +136,20 @@
 
 ### Step 2: Data Types (from BVA Catalog)
 
-| Equivalence class             | Catalog data type | Parameters                                                                    |
-| ----------------------------- | ----------------- | ----------------------------------------------------------------------------- |
-| Input: chess960 mode selected | Boolean           | true (chess960 selected), false (standard selected)                           |
-| Output: BoardInitializer type | Cases             | StandardBoardInitializer, FischerRandomBoardInitializer                       |
+| Equivalence class             | Catalog data type | Parameters                                              |
+| ----------------------------- | ----------------- | ------------------------------------------------------- |
+| Input: chess960 mode selected | Boolean           | true (chess960 selected), false (standard selected)     |
+| Output: BoardInitializer type | Cases             | StandardBoardInitializer, FischerRandomBoardInitializer |
 
 ### Step 3: Boundary Values (from BVA Catalog)
 
 **chess960 mode selected — Boolean:**
+
 - `false` (0) — standard radio button selected (default)
 - `true` (1) — chess960 radio button selected
 
 **BoardInitializer type — Cases:**
+
 - `StandardBoardInitializer`
 - `FischerRandomBoardInitializer`
 
@@ -158,26 +167,26 @@
 
 ---
 
-## Method / behavior: `startGame()` — BoardController launch wiring (chess-master alignment)
+## Method / behavior: `startGame()` — BoardController launch wiring
 
 Scope: After name validation, create `BoardController(player1Name, player2Name, board)` and call `boardController.show()` so the game UI (including turn labels) is owned by `BoardController`, not constructed directly in `WelcomeController`.
 
 ### Step 1: Equivalence Classes
 
-| Input / state | Equivalence classes |
-| ------------- | ------------------- |
-| Player names | both non-empty (valid start) |
-| Board mode | standard or chess960 via `selectedInitializer()` |
-| Output | `BoardController` created and `show()` launches visible `MainView` with player-one label on white turn |
+| Input / state | Equivalence classes                                                                                    |
+| ------------- | ------------------------------------------------------------------------------------------------------ |
+| Player names  | both non-empty (valid start)                                                                           |
+| Board mode    | standard or chess960 via `selectedInitializer()`                                                       |
+| Output        | `BoardController` created and `show()` launches visible `MainView` with player-one label on white turn |
 
 ### Step 2: Data Types (from BVA Catalog)
 
-| Variable / output | Catalog data type |
-| ----------------- | ----------------- |
-| `player1Name`, `player2Name` | Strings |
-| Started controller reference | Pointers |
-| Main view visibility | Boolean |
-| Current player label text | Strings |
+| Variable / output            | Catalog data type |
+| ---------------------------- | ----------------- |
+| `player1Name`, `player2Name` | Strings           |
+| Started controller reference | Pointers          |
+| Main view visibility         | Boolean           |
+| Current player label text    | Strings           |
 
 ### Step 3: Concrete boundary values
 

--- a/docs/design/chess-full-design.puml
+++ b/docs/design/chess-full-design.puml
@@ -91,11 +91,15 @@ package ui {
 
     +class BoardController {
         -{static}{final} BOARD_SIZE: int
+        -player1Name: String
+        -player2Name: String
         -board: Board
+        -mainView: MainView
         -boardView: BoardView
         -lastSelectedLoc: Optional<Location>
 
-        +BoardController(board: Board)
+        +BoardController(player1Name: String, player2Name: String, board: Board)
+        +show(): void
         +setBoardView(boardView: BoardView): void
         ~getBoardView(): BoardView
         ~getMainView(): MainView

--- a/src/main/java/ui/BoardController.java
+++ b/src/main/java/ui/BoardController.java
@@ -33,6 +33,17 @@ public class BoardController {
   public void show() {
     mainView = new MainView(player1Name, player2Name, this);
     mainView.setVisible(true);
+    updateCurrentPlayerLabel();
+  }
+
+  private void updateCurrentPlayerLabel() {
+    if (mainView == null) {
+      return;
+    }
+    String text = board.getCurrentGameState() == GameState.WHITE_TURN
+        ? player1Name
+        : player2Name;
+    mainView.getGameStatsView().updateCurrentPlayerLabel(text);
   }
 
   MainView getMainView() {

--- a/src/main/java/ui/BoardController.java
+++ b/src/main/java/ui/BoardController.java
@@ -26,10 +26,6 @@ public class BoardController {
     lastSelectedLoc = Optional.empty();
   }
 
-  public BoardController(Board board) {
-    this("", "", board);
-  }
-
   public void show() {
     mainView = new MainView(player1Name, player2Name, this);
     mainView.setVisible(true);

--- a/src/main/java/ui/BoardController.java
+++ b/src/main/java/ui/BoardController.java
@@ -15,6 +15,7 @@ public class BoardController {
   private final String player1Name;
   private final String player2Name;
   private final Board board;
+  private MainView mainView;
   private BoardView boardView;
   private Optional<Location> lastSelectedLoc;
 
@@ -27,6 +28,15 @@ public class BoardController {
 
   public BoardController(Board board) {
     this("", "", board);
+  }
+
+  public void show() {
+    mainView = new MainView(player1Name, player2Name, this);
+    mainView.setVisible(true);
+  }
+
+  MainView getMainView() {
+    return mainView;
   }
 
   public void setBoardView(BoardView boardView) {

--- a/src/main/java/ui/BoardController.java
+++ b/src/main/java/ui/BoardController.java
@@ -12,13 +12,21 @@ public class BoardController {
 
   private static final int BOARD_SIZE = 8;
 
+  private final String player1Name;
+  private final String player2Name;
   private final Board board;
   private BoardView boardView;
   private Optional<Location> lastSelectedLoc;
 
-  public BoardController(Board board) {
+  public BoardController(String player1Name, String player2Name, Board board) {
+    this.player1Name = player1Name;
+    this.player2Name = player2Name;
     this.board = board;
     lastSelectedLoc = Optional.empty();
+  }
+
+  public BoardController(Board board) {
+    this("", "", board);
   }
 
   public void setBoardView(BoardView boardView) {

--- a/src/main/java/ui/BoardController.java
+++ b/src/main/java/ui/BoardController.java
@@ -33,9 +33,6 @@ public class BoardController {
   }
 
   private void updateCurrentPlayerLabel() {
-    if (mainView == null) {
-      return;
-    }
     String text = board.getCurrentGameState() == GameState.WHITE_TURN
         ? player1Name
         : player2Name;

--- a/src/main/java/ui/WelcomeController.java
+++ b/src/main/java/ui/WelcomeController.java
@@ -9,6 +9,7 @@ import java.util.Random;
 public class WelcomeController {
 
     private final WelcomeView welcomeView;
+    private BoardController startedBoardController;
 
     public WelcomeController() {
         welcomeView = new WelcomeView();
@@ -26,9 +27,10 @@ public class WelcomeController {
             welcomeView.showError("Player names cannot be empty.");
             return;
         }
-        BoardController boardController = new BoardController(new Board(selectedInitializer()));
+        startedBoardController =
+                new BoardController(player1Name, player2Name, new Board(selectedInitializer()));
         closeWelcomeView();
-        new MainView(player1Name, player2Name, boardController).setVisible(true);
+        new MainView(player1Name, player2Name, startedBoardController).setVisible(true);
     }
 
     private void closeWelcomeView() {
@@ -44,5 +46,9 @@ public class WelcomeController {
 
     WelcomeView getWelcomeView() {
         return welcomeView;
+    }
+
+    BoardController getStartedBoardController() {
+        return startedBoardController;
     }
 }

--- a/src/main/java/ui/WelcomeController.java
+++ b/src/main/java/ui/WelcomeController.java
@@ -9,33 +9,29 @@ import java.util.Random;
 public class WelcomeController {
 
     private final WelcomeView welcomeView;
-    private BoardController startedBoardController;
 
     public WelcomeController() {
         welcomeView = new WelcomeView();
         welcomeView.setStartGameAction(this::startGame);
     }
 
+    WelcomeView getWelcomeView() {
+        return welcomeView;
+    }
+
     public void show() {
         welcomeView.setVisible(true);
     }
 
-    void startGame() {
+    private void startGame() {
         String player1Name = welcomeView.getPlayer1Name();
         String player2Name = welcomeView.getPlayer2Name();
         if (player1Name.isEmpty() || player2Name.isEmpty()) {
-            welcomeView.showError("Player names cannot be empty.");
+            welcomeView.showError("Player name cannot be empty");
             return;
         }
-        startedBoardController =
-                new BoardController(player1Name, player2Name, new Board(selectedInitializer()));
         closeWelcomeView();
-        startedBoardController.show();
-    }
-
-    private void closeWelcomeView() {
-        welcomeView.setVisible(false);
-        welcomeView.dispose();
+        new BoardController(player1Name, player2Name, new Board(selectedInitializer())).show();
     }
 
     BoardInitializer selectedInitializer() {
@@ -44,11 +40,8 @@ public class WelcomeController {
             : new StandardBoardInitializer();
     }
 
-    WelcomeView getWelcomeView() {
-        return welcomeView;
-    }
-
-    BoardController getStartedBoardController() {
-        return startedBoardController;
+    private void closeWelcomeView() {
+        welcomeView.setVisible(false);
+        welcomeView.dispose();
     }
 }

--- a/src/main/java/ui/WelcomeController.java
+++ b/src/main/java/ui/WelcomeController.java
@@ -30,7 +30,7 @@ public class WelcomeController {
         startedBoardController =
                 new BoardController(player1Name, player2Name, new Board(selectedInitializer()));
         closeWelcomeView();
-        new MainView(player1Name, player2Name, startedBoardController).setVisible(true);
+        startedBoardController.show();
     }
 
     private void closeWelcomeView() {

--- a/src/test/java/ui/BoardControllerTest.java
+++ b/src/test/java/ui/BoardControllerTest.java
@@ -25,10 +25,13 @@ import org.junit.jupiter.api.Test;
 
 class BoardControllerTest {
 
+    private static final String TEST_PLAYER_ONE = "Alice";
+    private static final String TEST_PLAYER_TWO = "Bob";
+
     @Test
     void Constructor_FreshInstance_LastSelectedUnset() {
         Board boardMock = replayNiceBoard();
-        BoardController controller = new BoardController(boardMock);
+        BoardController controller = controllerFor(boardMock);
 
         boolean expected = false;
         boolean actual = controller.hasSelection();
@@ -39,7 +42,7 @@ class BoardControllerTest {
     @Test
     void GetSelectedLocation_FreshInstance_ReturnsEmpty() {
         Board boardMock = replayNiceBoard();
-        BoardController controller = new BoardController(boardMock);
+        BoardController controller = controllerFor(boardMock);
 
         Optional<Location> expected = Optional.empty();
         Optional<Location> actual = controller.getSelectedLocation();
@@ -54,7 +57,7 @@ class BoardControllerTest {
         EasyMock.expect(boardMock.getSnapshot()).andReturn(standardGrid);
         EasyMock.replay(boardMock);
 
-        BoardController controller = new BoardController(boardMock);
+        BoardController controller = controllerFor(boardMock);
         Piece[][] snapshot = controller.getBoardSnapshot();
 
         boolean expected = true;
@@ -70,7 +73,7 @@ class BoardControllerTest {
         EasyMock.expect(boardMock.getSnapshot()).andReturn(standardGrid);
         EasyMock.replay(boardMock);
 
-        BoardController controller = new BoardController(boardMock);
+        BoardController controller = controllerFor(boardMock);
         Piece[][] snapshot = controller.getBoardSnapshot();
 
         boolean expected = true;
@@ -86,7 +89,7 @@ class BoardControllerTest {
         EasyMock.expect(boardMock.getSnapshot()).andReturn(expectedGrid);
         EasyMock.replay(boardMock);
 
-        BoardController controller = new BoardController(boardMock);
+        BoardController controller = controllerFor(boardMock);
         Piece[][] snapshot = controller.getBoardSnapshot();
 
         boolean expected = true;
@@ -102,7 +105,7 @@ class BoardControllerTest {
         EasyMock.expect(boardMock.getSnapshot()).andReturn(standardGrid);
         EasyMock.replay(boardMock);
 
-        BoardController controller = new BoardController(boardMock);
+        BoardController controller = controllerFor(boardMock);
         Piece[][] snapshot = controller.getBoardSnapshot();
 
         int expected = 16;
@@ -118,7 +121,7 @@ class BoardControllerTest {
         EasyMock.expect(boardMock.getSnapshot()).andReturn(standardGrid);
         EasyMock.replay(boardMock);
 
-        BoardController controller = new BoardController(boardMock);
+        BoardController controller = controllerFor(boardMock);
         Piece[][] snapshot = controller.getBoardSnapshot();
 
         int expected = 16;
@@ -133,7 +136,7 @@ class BoardControllerTest {
         EasyMock.expect(boardMock.getCurrentGameState()).andReturn(GameState.WHITE_TURN);
         EasyMock.replay(boardMock);
 
-        BoardController controller = new BoardController(boardMock);
+        BoardController controller = controllerFor(boardMock);
 
         GameState expectedState = GameState.WHITE_TURN;
         GameState actualState = controller.getCurrentGameState();
@@ -148,7 +151,7 @@ class BoardControllerTest {
         EasyMock.expect(boardMock.getSnapshot()).andReturn(standardGrid);
         EasyMock.replay(boardMock);
 
-        BoardController controller = new BoardController(boardMock);
+        BoardController controller = controllerFor(boardMock);
 
         boolean expected = true;
         boolean actual = everyOccupiedPieceHasNotMoved(controller.getBoardSnapshot());
@@ -165,7 +168,7 @@ class BoardControllerTest {
         EasyMock.expect(boardMock.getSnapshot()).andReturn(snapshot2);
         EasyMock.replay(boardMock);
 
-        BoardController controller = new BoardController(boardMock);
+        BoardController controller = controllerFor(boardMock);
         Piece[][] actual1 = controller.getBoardSnapshot();
         Piece[][] actual2 = controller.getBoardSnapshot();
 
@@ -179,7 +182,7 @@ class BoardControllerTest {
     void GetBoardSnapshot_Chess960_BishopsOnOppositeColorSquares_WhiteBackRank() {
         Piece[][] chess960Grid = newChess960FixedStartingGrid();
         Board boardMock = stubSnapshot(chess960Grid);
-        BoardController controller = new BoardController(boardMock);
+        BoardController controller = controllerFor(boardMock);
         Piece[][] snapshot = controller.getBoardSnapshot();
 
         boolean expected = true;
@@ -192,7 +195,7 @@ class BoardControllerTest {
     void GetBoardSnapshot_Chess960_BishopsOnOppositeColorSquares_BlackBackRank() {
         Piece[][] chess960Grid = newChess960FixedStartingGrid();
         Board boardMock = stubSnapshot(chess960Grid);
-        BoardController controller = new BoardController(boardMock);
+        BoardController controller = controllerFor(boardMock);
         Piece[][] snapshot = controller.getBoardSnapshot();
 
         boolean expected = true;
@@ -205,7 +208,7 @@ class BoardControllerTest {
     void GetBoardSnapshot_Chess960_KingStrictlyBetweenRooksOnBackRank_WhiteBackRank() {
         Piece[][] chess960Grid = newChess960FixedStartingGrid();
         Board boardMock = stubSnapshot(chess960Grid);
-        BoardController controller = new BoardController(boardMock);
+        BoardController controller = controllerFor(boardMock);
         Piece[][] snapshot = controller.getBoardSnapshot();
 
         boolean expected = true;
@@ -218,7 +221,7 @@ class BoardControllerTest {
     void GetBoardSnapshot_Chess960_KingStrictlyBetweenRooksOnBackRank_BlackBackRank() {
         Piece[][] chess960Grid = newChess960FixedStartingGrid();
         Board boardMock = stubSnapshot(chess960Grid);
-        BoardController controller = new BoardController(boardMock);
+        BoardController controller = controllerFor(boardMock);
         Piece[][] snapshot = controller.getBoardSnapshot();
 
         boolean expected = true;
@@ -231,7 +234,7 @@ class BoardControllerTest {
     void GetBoardSnapshot_Chess960_BackRanksMirrorPieceTypes_BackRankTypesMirror() {
         Piece[][] chess960Grid = newChess960FixedStartingGrid();
         Board boardMock = stubSnapshot(chess960Grid);
-        BoardController controller = new BoardController(boardMock);
+        BoardController controller = controllerFor(boardMock);
         Piece[][] snapshot = controller.getBoardSnapshot();
 
         boolean expected = true;
@@ -244,7 +247,7 @@ class BoardControllerTest {
     void GetBoardSnapshot_Chess960_BackRanksMirrorPieceTypes_StandardPawnRows() {
         Piece[][] chess960Grid = newChess960FixedStartingGrid();
         Board boardMock = stubSnapshot(chess960Grid);
-        BoardController controller = new BoardController(boardMock);
+        BoardController controller = controllerFor(boardMock);
         Piece[][] snapshot = controller.getBoardSnapshot();
 
         boolean expected = true;
@@ -257,7 +260,7 @@ class BoardControllerTest {
     void GetBoardSnapshot_Chess960_OneQueenTwoKnightsOnBackRank_WhiteBackRank() {
         Piece[][] chess960Grid = newChess960FixedStartingGrid();
         Board boardMock = stubSnapshot(chess960Grid);
-        BoardController controller = new BoardController(boardMock);
+        BoardController controller = controllerFor(boardMock);
         Piece[][] snapshot = controller.getBoardSnapshot();
 
         boolean expected = true;
@@ -270,7 +273,7 @@ class BoardControllerTest {
     void GetBoardSnapshot_Chess960_OneQueenTwoKnightsOnBackRank_BlackBackRank() {
         Piece[][] chess960Grid = newChess960FixedStartingGrid();
         Board boardMock = stubSnapshot(chess960Grid);
-        BoardController controller = new BoardController(boardMock);
+        BoardController controller = controllerFor(boardMock);
         Piece[][] snapshot = controller.getBoardSnapshot();
 
         boolean expected = true;
@@ -283,7 +286,7 @@ class BoardControllerTest {
     void GetBoardSnapshot_Chess960_SeedOne_BishopsOppositeColorSquares_WhiteBackRank() {
         Piece[][] seedGrid = newChess960SeedOneGrid();
         Board boardMock = stubSnapshot(seedGrid);
-        BoardController controller = new BoardController(boardMock);
+        BoardController controller = controllerFor(boardMock);
         Piece[][] snapshot = controller.getBoardSnapshot();
 
         boolean expected = true;
@@ -296,7 +299,7 @@ class BoardControllerTest {
     void GetBoardSnapshot_Chess960_SeedOne_BishopsOppositeColorSquares_BlackBackRank() {
         Piece[][] seedGrid = newChess960SeedOneGrid();
         Board boardMock = stubSnapshot(seedGrid);
-        BoardController controller = new BoardController(boardMock);
+        BoardController controller = controllerFor(boardMock);
         Piece[][] snapshot = controller.getBoardSnapshot();
 
         boolean expected = true;
@@ -309,7 +312,7 @@ class BoardControllerTest {
     void GetBoardSnapshot_Chess960_SeedOne_KingStrictlyBetweenRooks_WhiteBackRank() {
         Piece[][] seedGrid = newChess960SeedOneGrid();
         Board boardMock = stubSnapshot(seedGrid);
-        BoardController controller = new BoardController(boardMock);
+        BoardController controller = controllerFor(boardMock);
         Piece[][] snapshot = controller.getBoardSnapshot();
 
         boolean expected = true;
@@ -322,7 +325,7 @@ class BoardControllerTest {
     void GetBoardSnapshot_Chess960_SeedOne_KingStrictlyBetweenRooks_BlackBackRank() {
         Piece[][] seedGrid = newChess960SeedOneGrid();
         Board boardMock = stubSnapshot(seedGrid);
-        BoardController controller = new BoardController(boardMock);
+        BoardController controller = controllerFor(boardMock);
         Piece[][] snapshot = controller.getBoardSnapshot();
 
         boolean expected = true;
@@ -335,7 +338,7 @@ class BoardControllerTest {
     void GetBoardSnapshot_Chess960_SeedOne_BackRanksMirrorPieceTypes() {
         Piece[][] seedGrid = newChess960SeedOneGrid();
         Board boardMock = stubSnapshot(seedGrid);
-        BoardController controller = new BoardController(boardMock);
+        BoardController controller = controllerFor(boardMock);
         Piece[][] snapshot = controller.getBoardSnapshot();
 
         boolean expected = true;
@@ -348,7 +351,7 @@ class BoardControllerTest {
     void GetBoardSnapshot_Chess960_SeedOne_StandardPawnRows() {
         Piece[][] seedGrid = newChess960SeedOneGrid();
         Board boardMock = stubSnapshot(seedGrid);
-        BoardController controller = new BoardController(boardMock);
+        BoardController controller = controllerFor(boardMock);
         Piece[][] snapshot = controller.getBoardSnapshot();
 
         boolean expected = true;
@@ -361,7 +364,7 @@ class BoardControllerTest {
     void GetBoardSnapshot_Chess960_SeedOne_OneQueenTwoKnightsOnBackRank_WhiteBackRank() {
         Piece[][] seedGrid = newChess960SeedOneGrid();
         Board boardMock = stubSnapshot(seedGrid);
-        BoardController controller = new BoardController(boardMock);
+        BoardController controller = controllerFor(boardMock);
         Piece[][] snapshot = controller.getBoardSnapshot();
 
         boolean expected = true;
@@ -374,7 +377,7 @@ class BoardControllerTest {
     void GetBoardSnapshot_Chess960_SeedOne_OneQueenTwoKnightsOnBackRank_BlackBackRank() {
         Piece[][] seedGrid = newChess960SeedOneGrid();
         Board boardMock = stubSnapshot(seedGrid);
-        BoardController controller = new BoardController(boardMock);
+        BoardController controller = controllerFor(boardMock);
         Piece[][] snapshot = controller.getBoardSnapshot();
 
         boolean expected = true;
@@ -387,7 +390,7 @@ class BoardControllerTest {
     void HandleSquareClick_BeforeFirstMove_OnWhitePiece_HasSelection() {
         Piece[][] standardGrid = newStandardStartingGrid();
         Board boardMock = boardForWhitePieceClick(standardGrid, 6, 0);
-        BoardController controller = new BoardController(boardMock);
+        BoardController controller = controllerFor(boardMock);
         Location clicked = new Location(0, 6);
 
         controller.handleSquareClick(clicked);
@@ -402,7 +405,7 @@ class BoardControllerTest {
     void HandleSquareClick_BeforeFirstMove_OnWhitePiece_SelectedLocationMatches() {
         Piece[][] standardGrid = newStandardStartingGrid();
         Board boardMock = boardForWhitePieceClick(standardGrid, 6, 0);
-        BoardController controller = new BoardController(boardMock);
+        BoardController controller = controllerFor(boardMock);
         Location clicked = new Location(0, 6);
 
         controller.handleSquareClick(clicked);
@@ -417,7 +420,7 @@ class BoardControllerTest {
     void HandleSquareClick_BeforeFirstMove_OnWhitePiece_BoardUnchanged() {
         Piece[][] standardGrid = newStandardStartingGrid();
         Board boardMock = boardForWhitePieceClickWithSnapshot(standardGrid, 6, 0);
-        BoardController controller = new BoardController(boardMock);
+        BoardController controller = controllerFor(boardMock);
         Location clicked = new Location(0, 6);
 
         controller.handleSquareClick(clicked);
@@ -432,7 +435,7 @@ class BoardControllerTest {
     void HandleSquareClick_BeforeFirstMove_OnBlackPiece_NoSelectionAfterClick() {
         Piece[][] standardGrid = newStandardStartingGrid();
         Board boardMock = boardForSquareClick(standardGrid, 1, 0);
-        BoardController controller = new BoardController(boardMock);
+        BoardController controller = controllerFor(boardMock);
 
         controller.handleSquareClick(new Location(0, 1));
 
@@ -446,7 +449,7 @@ class BoardControllerTest {
     void HandleSquareClick_BeforeFirstMove_OnBlackPiece_TurnRemainsWhite() {
         Piece[][] standardGrid = newStandardStartingGrid();
         Board boardMock = boardForSquareClick(standardGrid, 1, 0);
-        BoardController controller = new BoardController(boardMock);
+        BoardController controller = controllerFor(boardMock);
 
         controller.handleSquareClick(new Location(0, 1));
 
@@ -460,7 +463,7 @@ class BoardControllerTest {
     void HandleSquareClick_BeforeFirstMove_OnBlackPiece_BoardUnchanged() {
         Piece[][] standardGrid = newStandardStartingGrid();
         Board boardMock = boardForSquareClick(standardGrid, 1, 0);
-        BoardController controller = new BoardController(boardMock);
+        BoardController controller = controllerFor(boardMock);
 
         controller.handleSquareClick(new Location(0, 1));
 
@@ -474,7 +477,7 @@ class BoardControllerTest {
     void HandleSquareClick_BeforeFirstMove_OnEmptySquare_NoSelectionAfterClick() {
         Piece[][] standardGrid = newStandardStartingGrid();
         Board boardMock = boardForSquareClick(standardGrid, 3, 3);
-        BoardController controller = new BoardController(boardMock);
+        BoardController controller = controllerFor(boardMock);
 
         controller.handleSquareClick(new Location(3, 3));
 
@@ -488,7 +491,7 @@ class BoardControllerTest {
     void HandleSquareClick_BeforeFirstMove_OnEmptySquare_TurnRemainsWhite() {
         Piece[][] standardGrid = newStandardStartingGrid();
         Board boardMock = boardForSquareClick(standardGrid, 3, 3);
-        BoardController controller = new BoardController(boardMock);
+        BoardController controller = controllerFor(boardMock);
 
         controller.handleSquareClick(new Location(3, 3));
 
@@ -502,7 +505,7 @@ class BoardControllerTest {
     void HandleSquareClick_BeforeFirstMove_OnEmptySquare_BoardUnchanged() {
         Piece[][] standardGrid = newStandardStartingGrid();
         Board boardMock = boardForSquareClick(standardGrid, 3, 3);
-        BoardController controller = new BoardController(boardMock);
+        BoardController controller = controllerFor(boardMock);
 
         controller.handleSquareClick(new Location(3, 3));
 
@@ -515,7 +518,7 @@ class BoardControllerTest {
     @Test
     void HandleSquareClick_InvalidLocation_NoSelectionAfterClick() {
         Board boardMock = replayNiceBoard();
-        BoardController controller = new BoardController(boardMock);
+        BoardController controller = controllerFor(boardMock);
 
         controller.handleSquareClick(new Location(-1, 0));
 
@@ -532,7 +535,7 @@ class BoardControllerTest {
         EasyMock.expect(boardMock.getCurrentGameState()).andReturn(GameState.WHITE_TURN);
         EasyMock.replay(boardMock);
 
-        BoardController controller = new BoardController(boardMock);
+        BoardController controller = controllerFor(boardMock);
         controller.handleSquareClick(new Location(-1, 0));
 
         GameState expected = GameState.WHITE_TURN;
@@ -548,7 +551,7 @@ class BoardControllerTest {
         EasyMock.expect(boardMock.getSnapshot()).andReturn(standardGrid);
         EasyMock.replay(boardMock);
 
-        BoardController controller = new BoardController(boardMock);
+        BoardController controller = controllerFor(boardMock);
         controller.handleSquareClick(new Location(-1, 0));
 
         boolean expected = true;
@@ -561,7 +564,7 @@ class BoardControllerTest {
     void HandleSquareClick_OnBlackTurn_OnBlackPiece_HasSelection() {
         Piece[][] standardGrid = newStandardStartingGrid();
         Board boardMock = boardForBlackPieceClick(standardGrid, 1, 0);
-        BoardController controller = new BoardController(boardMock);
+        BoardController controller = controllerFor(boardMock);
         Location clicked = new Location(0, 1);
 
         controller.handleSquareClick(clicked);
@@ -576,7 +579,7 @@ class BoardControllerTest {
     void HandleSquareClick_OnBlackTurn_OnBlackPiece_SelectedLocationMatches() {
         Piece[][] standardGrid = newStandardStartingGrid();
         Board boardMock = boardForBlackPieceClick(standardGrid, 1, 0);
-        BoardController controller = new BoardController(boardMock);
+        BoardController controller = controllerFor(boardMock);
         Location clicked = new Location(0, 1);
 
         controller.handleSquareClick(clicked);
@@ -591,7 +594,7 @@ class BoardControllerTest {
     void HandleSquareClick_OnBlackTurn_OnBlackPiece_BoardUnchanged() {
         Piece[][] standardGrid = newStandardStartingGrid();
         Board boardMock = boardForBlackPieceClickWithSnapshot(standardGrid, 1, 0);
-        BoardController controller = new BoardController(boardMock);
+        BoardController controller = controllerFor(boardMock);
         Location clicked = new Location(0, 1);
 
         controller.handleSquareClick(clicked);
@@ -606,7 +609,7 @@ class BoardControllerTest {
     void HandleSquareClick_OnBlackTurn_OnWhitePiece_NoSelectionAfterClick() {
         Piece[][] standardGrid = newStandardStartingGrid();
         Board boardMock = boardForSquareClickOnBlackTurn(standardGrid, 6, 0);
-        BoardController controller = new BoardController(boardMock);
+        BoardController controller = controllerFor(boardMock);
 
         controller.handleSquareClick(new Location(0, 6));
 
@@ -620,7 +623,7 @@ class BoardControllerTest {
     void HandleSquareClick_OnBlackTurn_OnWhitePiece_TurnRemainsBlack() {
         Piece[][] standardGrid = newStandardStartingGrid();
         Board boardMock = boardForSquareClickOnBlackTurn(standardGrid, 6, 0);
-        BoardController controller = new BoardController(boardMock);
+        BoardController controller = controllerFor(boardMock);
 
         controller.handleSquareClick(new Location(0, 6));
 
@@ -634,7 +637,7 @@ class BoardControllerTest {
     void HandleSquareClick_OnBlackTurn_OnWhitePiece_BoardUnchanged() {
         Piece[][] standardGrid = newStandardStartingGrid();
         Board boardMock = boardForSquareClickOnBlackTurn(standardGrid, 6, 0);
-        BoardController controller = new BoardController(boardMock);
+        BoardController controller = controllerFor(boardMock);
 
         controller.handleSquareClick(new Location(0, 6));
 
@@ -648,7 +651,7 @@ class BoardControllerTest {
     void HandleSquareClick_OnBlackTurn_OnEmptySquare_NoSelectionAfterClick() {
         Piece[][] standardGrid = newStandardStartingGrid();
         Board boardMock = boardForSquareClickOnBlackTurn(standardGrid, 3, 3);
-        BoardController controller = new BoardController(boardMock);
+        BoardController controller = controllerFor(boardMock);
 
         controller.handleSquareClick(new Location(3, 3));
 
@@ -662,7 +665,7 @@ class BoardControllerTest {
     void HandleSquareClick_OnBlackTurn_OnEmptySquare_TurnRemainsBlack() {
         Piece[][] standardGrid = newStandardStartingGrid();
         Board boardMock = boardForSquareClickOnBlackTurn(standardGrid, 3, 3);
-        BoardController controller = new BoardController(boardMock);
+        BoardController controller = controllerFor(boardMock);
 
         controller.handleSquareClick(new Location(3, 3));
 
@@ -676,7 +679,7 @@ class BoardControllerTest {
     void HandleSquareClick_OnBlackTurn_OnEmptySquare_BoardUnchanged() {
         Piece[][] standardGrid = newStandardStartingGrid();
         Board boardMock = boardForSquareClickOnBlackTurn(standardGrid, 3, 3);
-        BoardController controller = new BoardController(boardMock);
+        BoardController controller = controllerFor(boardMock);
 
         controller.handleSquareClick(new Location(3, 3));
 
@@ -690,7 +693,7 @@ class BoardControllerTest {
     void HandleSquareClick_Chess960Start_FirstWhiteSelectionSamePolicy() {
         Piece[][] chess960Grid = newChess960FixedStartingGrid();
         Board boardMock = stubSnapshot(chess960Grid);
-        BoardController controller = new BoardController(boardMock);
+        BoardController controller = controllerFor(boardMock);
 
         Piece[][] snapshot = controller.getBoardSnapshot();
 
@@ -704,7 +707,7 @@ class BoardControllerTest {
     void HandleSquareClick_Chess960Start_FirstWhiteSelection_SelectsAndKeepsTurn() {
         Piece[][] chess960Grid = newChess960FixedStartingGrid();
         Board boardMock = boardForWhitePieceClick(chess960Grid, 6, 0);
-        BoardController controller = new BoardController(boardMock);
+        BoardController controller = controllerFor(boardMock);
         Location clicked = new Location(0, 6);
 
         controller.handleSquareClick(clicked);
@@ -719,7 +722,7 @@ class BoardControllerTest {
     void HandleSquareClick_Chess960Start_FirstWhiteSelection_SelectedLocationMatches() {
         Piece[][] chess960Grid = newChess960FixedStartingGrid();
         Board boardMock = boardForWhitePieceClick(chess960Grid, 6, 0);
-        BoardController controller = new BoardController(boardMock);
+        BoardController controller = controllerFor(boardMock);
         Location clicked = new Location(0, 6);
 
         controller.handleSquareClick(clicked);
@@ -734,7 +737,7 @@ class BoardControllerTest {
     void HandleSquareClick_Chess960Start_FirstWhiteSelection_TurnRemainsWhite() {
         Piece[][] chess960Grid = newChess960FixedStartingGrid();
         Board boardMock = boardForWhitePieceClick(chess960Grid, 6, 0);
-        BoardController controller = new BoardController(boardMock);
+        BoardController controller = controllerFor(boardMock);
         Location clicked = new Location(0, 6);
 
         controller.handleSquareClick(clicked);
@@ -770,6 +773,10 @@ class BoardControllerTest {
         EasyMock.expect(boardMock.getSnapshot()).andReturn(snapshot);
         EasyMock.replay(boardMock);
         return boardMock;
+    }
+
+    private static BoardController controllerFor(Board board) {
+        return new BoardController(TEST_PLAYER_ONE, TEST_PLAYER_TWO, board);
     }
 
     private static Board replayNiceBoard() {

--- a/src/test/java/ui/MainViewTest.java
+++ b/src/test/java/ui/MainViewTest.java
@@ -19,7 +19,7 @@ class MainViewTest {
   @Test
   void Constructor_OnAliceAndBob_BoardControllerExposesSnapshot() {
     Board boardMock = stubSnapshot(eightByEightGrid());
-    MainView view = new MainView("Alice", "Bob", new BoardController(boardMock));
+    MainView view = new MainView("Alice", "Bob", new BoardController("Alice", "Bob", boardMock));
 
     int expected = BOARD_SIZE;
     int actual = view.getBoardController().getBoardSnapshot().length;
@@ -30,7 +30,7 @@ class MainViewTest {
   @Test
   void Constructor_OnAliceAndBob_WiresStatsBoardAndLayout() {
     Board boardMock = replayNiceBoard();
-    MainView view = new MainView("Alice", "Bob", new BoardController(boardMock));
+    MainView view = new MainView("Alice", "Bob", new BoardController("Alice", "Bob", boardMock));
 
     boolean wired =
         view.getGameStatsView() instanceof GameStatsView
@@ -51,7 +51,7 @@ class MainViewTest {
     Board boardMock = EasyMock.createNiceMock(Board.class);
     EasyMock.expect(boardMock.getCurrentGameState()).andReturn(GameState.WHITE_TURN);
     EasyMock.replay(boardMock);
-    MainView view = new MainView("Alice", "Bob", new BoardController(boardMock));
+    MainView view = new MainView("Alice", "Bob", new BoardController("Alice", "Bob", boardMock));
 
     GameState expectedState = GameState.WHITE_TURN;
     GameState actualState = view.getBoardController().getCurrentGameState();

--- a/src/test/java/ui/WelcomeControllerTest.java
+++ b/src/test/java/ui/WelcomeControllerTest.java
@@ -1,5 +1,6 @@
 package ui;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -89,6 +90,20 @@ class WelcomeControllerTest {
         controller.startGame();
 
         assertNotNull(controller.getStartedBoardController());
+    }
+
+    @Test
+    void StartGame_NonEmptyNames_MainViewIsVisible() {
+        WelcomeController controller = new WelcomeController();
+        controller.show();
+        controller.getWelcomeView().setPlayer1Name("Alice");
+        controller.getWelcomeView().setPlayer2Name("Bob");
+
+        controller.startGame();
+
+        boolean expected = true;
+        boolean actual = controller.getStartedBoardController().getMainView().isVisible();
+        assertEquals(expected, actual);
     }
 
 }

--- a/src/test/java/ui/WelcomeControllerTest.java
+++ b/src/test/java/ui/WelcomeControllerTest.java
@@ -3,6 +3,7 @@ package ui;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import domain.FischerRandomBoardInitializer;
 import domain.StandardBoardInitializer;
@@ -76,6 +77,18 @@ class WelcomeControllerTest {
         controller.getWelcomeView().setPlayer2Name("Bob");
         controller.getWelcomeView().clickStartGame();
         assertFalse(controller.getWelcomeView().isDisplayable());
+    }
+
+    @Test
+    void StartGame_NonEmptyNames_StartedBoardControllerNotNull() {
+        WelcomeController controller = new WelcomeController();
+        controller.show();
+        controller.getWelcomeView().setPlayer1Name("Alice");
+        controller.getWelcomeView().setPlayer2Name("Bob");
+
+        controller.startGame();
+
+        assertNotNull(controller.getStartedBoardController());
     }
 
 }

--- a/src/test/java/ui/WelcomeControllerTest.java
+++ b/src/test/java/ui/WelcomeControllerTest.java
@@ -10,9 +10,19 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import domain.FischerRandomBoardInitializer;
 import domain.StandardBoardInitializer;
 import java.awt.Window;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 class WelcomeControllerTest {
+
+    @AfterEach
+    void disposeOpenMainViews() {
+        for (Window window : Window.getWindows()) {
+            if (window instanceof MainView) {
+                ((MainView) window).dispose();
+            }
+        }
+    }
 
     @Test
     void Constructor_FreshInstance_WelcomeViewNotVisible() {

--- a/src/test/java/ui/WelcomeControllerTest.java
+++ b/src/test/java/ui/WelcomeControllerTest.java
@@ -6,8 +6,10 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import domain.FischerRandomBoardInitializer;
 import domain.StandardBoardInitializer;
+import java.awt.Window;
 import org.junit.jupiter.api.Test;
 
 class WelcomeControllerTest {
@@ -31,7 +33,7 @@ class WelcomeControllerTest {
         controller.show();
         controller.getWelcomeView().setPlayer1Name("Alice");
         controller.getWelcomeView().setPlayer2Name("Bob");
-        controller.startGame();
+        controller.getWelcomeView().clickStartGame();
         assertFalse(controller.getWelcomeView().isDisplayable());
     }
 
@@ -41,7 +43,7 @@ class WelcomeControllerTest {
         controller.show();
         controller.getWelcomeView().setPlayer1Name("");
         controller.getWelcomeView().setPlayer2Name("Bob");
-        controller.startGame();
+        controller.getWelcomeView().clickStartGame();
         assertTrue(controller.getWelcomeView().isDisplayable());
         assertNotEquals("", controller.getWelcomeView().getErrorText());
     }
@@ -52,7 +54,7 @@ class WelcomeControllerTest {
         controller.show();
         controller.getWelcomeView().setPlayer1Name("Alice");
         controller.getWelcomeView().setPlayer2Name("");
-        controller.startGame();
+        controller.getWelcomeView().clickStartGame();
         assertTrue(controller.getWelcomeView().isDisplayable());
         assertNotEquals("", controller.getWelcomeView().getErrorText());
     }
@@ -87,9 +89,9 @@ class WelcomeControllerTest {
         controller.getWelcomeView().setPlayer1Name("Alice");
         controller.getWelcomeView().setPlayer2Name("Bob");
 
-        controller.startGame();
+        controller.getWelcomeView().clickStartGame();
 
-        assertNotNull(controller.getStartedBoardController());
+        assertNotNull(findVisibleMainView());
     }
 
     @Test
@@ -99,10 +101,10 @@ class WelcomeControllerTest {
         controller.getWelcomeView().setPlayer1Name("Alice");
         controller.getWelcomeView().setPlayer2Name("Bob");
 
-        controller.startGame();
+        controller.getWelcomeView().clickStartGame();
 
         boolean expected = true;
-        boolean actual = controller.getStartedBoardController().getMainView().isVisible();
+        boolean actual = findVisibleMainView().isVisible();
         assertEquals(expected, actual);
     }
 
@@ -113,14 +115,24 @@ class WelcomeControllerTest {
         controller.getWelcomeView().setPlayer1Name("Alice");
         controller.getWelcomeView().setPlayer2Name("Bob");
 
-        controller.startGame();
+        controller.getWelcomeView().clickStartGame();
 
         String expected = "Alice";
-        String actual = controller.getStartedBoardController()
-                .getMainView()
+        String actual = findVisibleMainView()
                 .getGameStatsView()
                 .getCurrentPlayerLabelText();
         assertEquals(expected, actual);
     }
 
+    private static MainView findVisibleMainView() {
+        for (Window window : Window.getWindows()) {
+            if (window instanceof MainView) {
+                MainView mainView = (MainView) window;
+                if (mainView.isVisible()) {
+                    return mainView;
+                }
+            }
+        }
+        return null;
+    }
 }

--- a/src/test/java/ui/WelcomeControllerTest.java
+++ b/src/test/java/ui/WelcomeControllerTest.java
@@ -106,4 +106,21 @@ class WelcomeControllerTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void StartGame_NonEmptyNames_CurrentPlayerLabelShowsPlayer1Name() {
+        WelcomeController controller = new WelcomeController();
+        controller.show();
+        controller.getWelcomeView().setPlayer1Name("Alice");
+        controller.getWelcomeView().setPlayer2Name("Bob");
+
+        controller.startGame();
+
+        String expected = "Alice";
+        String actual = controller.getStartedBoardController()
+                .getMainView()
+                .getGameStatsView()
+                .getCurrentPlayerLabelText();
+        assertEquals(expected, actual);
+    }
+
 }

--- a/src/test/java/ui/WelcomeControllerTest.java
+++ b/src/test/java/ui/WelcomeControllerTest.java
@@ -103,8 +103,11 @@ class WelcomeControllerTest {
 
         controller.getWelcomeView().clickStartGame();
 
+        MainView mainView = findVisibleMainView();
+        assertNotNull(mainView);
+
         boolean expected = true;
-        boolean actual = findVisibleMainView().isVisible();
+        boolean actual = mainView.isVisible();
         assertEquals(expected, actual);
     }
 
@@ -117,10 +120,11 @@ class WelcomeControllerTest {
 
         controller.getWelcomeView().clickStartGame();
 
+        MainView mainView = findVisibleMainView();
+        assertNotNull(mainView);
+
         String expected = "Alice";
-        String actual = findVisibleMainView()
-                .getGameStatsView()
-                .getCurrentPlayerLabelText();
+        String actual = mainView.getGameStatsView().getCurrentPlayerLabelText();
         assertEquals(expected, actual);
     }
 


### PR DESCRIPTION
## Description

Fixes `WelcomeController` so starting a game follows the story pattern: validate player names, close the welcome screen, create `BoardController(player1Name, player2Name, board)`, and call `boardController.show()` instead of constructing `MainView` directly in `WelcomeController`.

Also removes the legacy `BoardController(Board)` constructor.

Supports the user story: *As a player, I can select one of my pieces and move it to a legal destination on my turn, so that the board updates and the other player becomes active* — by wiring the game UI through `BoardController` with player names for correct turn display.

## Type of Change

- [x] Bug fix
- [x] Feature (new functionality)
- [ ] Documentation update
- [x] Refactor
- [x] Test addition/update

## Related Work

Related to `docs/bva/WelcomeController.md` — BoardController launch wiring (WC-TC9–11)

Branch: `fix-welcome-controller`

## Changes Made

- [x] `WelcomeController.startGame()` delegates to `BoardController(...).show()`
- [x] `BoardController(String, String, Board)` only; removed `BoardController(Board)`
- [x] `BoardController.show()` creates `MainView`, shows it, and updates current-player label
- [x] Error message aligned: `"Player name cannot be empty"`
- [x] Tests updated: `BoardControllerTest` uses `controllerFor(board)`; `WelcomeControllerTest` uses `clickStartGame()` and finds `MainView` via `Window.getWindows()`
- [x] Design diagram updated for 3-arg constructor and `show()`

## BVA & Testing

- BVA documented in: `docs/bva/WelcomeController.md`
- Test cases implemented: **WC-TC9, WC-TC10, WC-TC11** (plus existing WC-TC1–8 unchanged)
  - `StartGame_NonEmptyNames_StartedBoardControllerNotNull`
  - `StartGame_NonEmptyNames_MainViewIsVisible`
  - `StartGame_NonEmptyNames_CurrentPlayerLabelShowsPlayer1Name`
- All tests passing: [x] `./gradlew test`

### TDD commits (one TC per commit)

1. `Update WelcomeController BVA for BoardController launch wiring` (BVA only)
2. `StartGame_NonEmptyNames_StartedBoardControllerNotNull passes`
3. `StartGame_NonEmptyNames_MainViewIsVisible passes`
4. `StartGame_NonEmptyNames_CurrentPlayerLabelShowsPlayer1Name passes`
5. `Update WelcomeController BVA mark TC9-11 implemented`
6. `Remove BoardController single-argument constructor`

## Design Alignment

- [x] Changes align with `docs/design/chess-full-design.puml`
- [x] No breaking changes to existing public APIs used by other slices (tests updated for constructor)

## Implementation Notes

BoardController(player1Name, player2Name, new Board(selectedInitializer())).show()`.
- **`selectedInitializer()`** remains package-private so existing BVA tests TC7/TC8 can call it directly.
- **Out of scope for this PR:** destination-click / `makeMove` in `BoardController` (separate feature branches).

## Checklist

- [x] BVA analysis is documented
- [x] TDD workflow followed (tests before code)
- [x] Code compiles and all tests pass
- [x] No new compiler warnings
- [x] Documentation updated (if applicable)
- [x] Commit messages are clear and follow TDD workflow