### PR TITLE
[FEAT] PromotionDialog

### DIFF
--- a/docs/bva/PromotionDialog.md
+++ b/docs/bva/PromotionDialog.md
@@ -1,0 +1,66 @@
+# BVA Analysis for PromotionDialog
+
+Package: `ui.PromotionDialog`
+
+Scope: `PromotionDialog` is a package-private modal `JDialog` shown when a pawn reaches the back rank. It presents four image buttons (Queen, Rook, Bishop, Knight); clicking one sets `chosenType` and disposes the dialog. `showAndGetChoice()` blocks until a button is clicked and returns the chosen `PieceType`.
+
+Both the constructor (`buildUi()` creates a `JDialog`) and `showAndGetChoice()` (blocks on `dialog.setVisible(true)`) are **untestable** — UI/IO operations that cannot be driven in a headless test environment. There are no automated test cases for this class.
+
+**Null invariant (verified by code inspection):**
+- `chosenType` is initialized to `PieceType.QUEEN` before the dialog opens.
+- Every button's action listener sets `chosenType` to a non-null `PieceType` before calling `dialog.dispose()`.
+- `JDialog.DO_NOTHING_ON_CLOSE` prevents dismissal without a choice.
+- `showAndGetChoice()` therefore always returns a non-null `PieceType`.
+
+---
+
+## Method / behavior: `PromotionDialog(JFrame parent, PieceColor color)`
+
+### Step 1: Input and output equivalence classes
+
+| Concern | Equivalence classes |
+| ------- | ------------------- |
+| Input: `color` | WHITE, BLACK |
+| Output: `chosenType` default | QUEEN (pre-click default) |
+
+### Step 2: BVA catalog data types
+
+| Variable / output | Catalog type | Notes |
+| ----------------- | ------------ | ----- |
+| `color` | Cases | WHITE, BLACK |
+| `chosenType` default | Cases | QUEEN |
+
+### Step 3: Concrete boundary values
+
+- `color`: WHITE, BLACK
+- `chosenType` initial value: QUEEN
+
+### Step 4: Test cases
+
+*Untestable — constructor calls `buildUi()` which creates a `JDialog`; cannot be exercised in a headless test environment.*
+
+---
+
+## Method / behavior: `showAndGetChoice(): PieceType`
+
+### Step 1: Input and output equivalence classes
+
+| Concern | Equivalence classes |
+| ------- | ------------------- |
+| Button clicked | Queen, Rook, Bishop, Knight |
+| Return value | Non-null PieceType matching the clicked button |
+
+### Step 2: BVA catalog data types
+
+| Variable / output | Catalog type | Notes |
+| ----------------- | ------------ | ----- |
+| Button clicked | Cases | QUEEN, ROOK, BISHOP, KNIGHT |
+| Return value | Cases | QUEEN, ROOK, BISHOP, KNIGHT |
+
+### Step 3: Concrete boundary values
+
+- Each of the four buttons sets `chosenType` to the corresponding `PieceType`
+
+### Step 4: Test cases
+
+*Untestable — `dialog.setVisible(true)` blocks the calling thread on user input; cannot be driven in a headless test environment.*

--- a/src/main/java/ui/PromotionDialog.java
+++ b/src/main/java/ui/PromotionDialog.java
@@ -28,8 +28,10 @@ class PromotionDialog {
     private PieceType chosenType = PieceType.QUEEN;
 
     PromotionDialog(JFrame parent, PieceColor color) {
+        // untestable: creates JDialog (Swing/AWT component)
         this.color = color;
         this.dialog = new JDialog(parent, "Promote Pawn", true);
+        buildUi();
     }
 
     PieceType showAndGetChoice() {

--- a/src/main/java/ui/PromotionDialog.java
+++ b/src/main/java/ui/PromotionDialog.java
@@ -44,6 +44,13 @@ class PromotionDialog {
     }
 
     private Image loadImage(PieceType type) {
-        throw new UnsupportedOperationException();
+        // untestable: classpath resource loading, no headless equivalent
+        String prefix = (color == PieceColor.WHITE) ? "white" : "black";
+        String path = "pieces/" + prefix + "_" + type.name().toLowerCase() + ".png";
+        java.net.URL resource = getClass().getClassLoader().getResource(path);
+        if (resource == null) {
+            return null;
+        }
+        return new ImageIcon(resource).getImage();
     }
 }

--- a/src/main/java/ui/PromotionDialog.java
+++ b/src/main/java/ui/PromotionDialog.java
@@ -37,6 +37,22 @@ class PromotionDialog {
     }
 
     private void buildUi() {
+        // untestable: Swing layout construction
+        JPanel panel = new JPanel(new FlowLayout(FlowLayout.CENTER, 10, 10));
+        panel.setBackground(BACKGROUND);
+        panel.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
+        JLabel label = new JLabel("Choose promotion piece:");
+        label.setForeground(TEXT_COLOR);
+        label.setFont(LABEL_FONT);
+        panel.add(label);
+        for (PieceType type : new PieceType[]{
+                PieceType.QUEEN, PieceType.ROOK, PieceType.BISHOP, PieceType.KNIGHT}) {
+            panel.add(buildPromotionButton(type));
+        }
+        dialog.setContentPane(panel);
+        dialog.pack();
+        dialog.setLocationRelativeTo(dialog.getParent());
+        dialog.setDefaultCloseOperation(JDialog.DO_NOTHING_ON_CLOSE);
     }
 
     private JButton buildPromotionButton(PieceType type) {

--- a/src/main/java/ui/PromotionDialog.java
+++ b/src/main/java/ui/PromotionDialog.java
@@ -33,6 +33,8 @@ class PromotionDialog {
     }
 
     PieceType showAndGetChoice() {
+        // untestable: UI/IO modal blocks on user input
+        dialog.setVisible(true);
         return chosenType;
     }
 

--- a/src/main/java/ui/PromotionDialog.java
+++ b/src/main/java/ui/PromotionDialog.java
@@ -1,0 +1,49 @@
+package ui;
+
+import domain.piece.PieceColor;
+import domain.piece.PieceType;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.Font;
+import java.awt.Image;
+import javax.swing.BorderFactory;
+import javax.swing.ImageIcon;
+import javax.swing.JButton;
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+
+class PromotionDialog {
+
+    private static final Color BACKGROUND = new Color(30, 20, 12);
+    private static final Color BUTTON_BG = new Color(181, 136, 99);
+    private static final Color TEXT_COLOR = new Color(240, 217, 181);
+    private static final Font LABEL_FONT = new Font("SansSerif", Font.BOLD, 16);
+    private static final int BUTTON_SIZE = 72;
+
+    private final JDialog dialog;
+    private final PieceColor color;
+    private PieceType chosenType = PieceType.QUEEN;
+
+    PromotionDialog(JFrame parent, PieceColor color) {
+        this.color = color;
+        this.dialog = new JDialog(parent, "Promote Pawn", true);
+    }
+
+    PieceType showAndGetChoice() {
+        return chosenType;
+    }
+
+    private void buildUi() {
+    }
+
+    private JButton buildPromotionButton(PieceType type) {
+        throw new UnsupportedOperationException();
+    }
+
+    private Image loadImage(PieceType type) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/main/java/ui/PromotionDialog.java
+++ b/src/main/java/ui/PromotionDialog.java
@@ -40,7 +40,27 @@ class PromotionDialog {
     }
 
     private JButton buildPromotionButton(PieceType type) {
-        throw new UnsupportedOperationException();
+        // untestable: Swing component construction
+        JButton button = new JButton();
+        button.setPreferredSize(new Dimension(BUTTON_SIZE, BUTTON_SIZE));
+        button.setBackground(BUTTON_BG);
+        button.setFocusPainted(false);
+        button.setBorderPainted(false);
+        button.setOpaque(true);
+        Image img = loadImage(type);
+        if (img != null) {
+            button.setIcon(new ImageIcon(
+                img.getScaledInstance(BUTTON_SIZE, BUTTON_SIZE, Image.SCALE_SMOOTH)));
+        } else {
+            button.setText(type.name().substring(0, 1));
+            button.setForeground(TEXT_COLOR);
+            button.setFont(LABEL_FONT);
+        }
+        button.addActionListener(e -> {
+            chosenType = type;
+            dialog.dispose();
+        });
+        return button;
     }
 
     private Image loadImage(PieceType type) {

--- a/src/main/java/ui/README.md
+++ b/src/main/java/ui/README.md
@@ -1,2 +1,2 @@
-Placeholder for WelcomeView. This file marks the feature-welcome-view branch.
-The WelcomeView class and associated tests will be added in subsequent commits following the TDD workflow.
+Placeholder for PromotionDialog. This file marks the feature-promotion-dialog branch.
+The PromotionDialog class and associated tests will be added in subsequent commits following the TDD workflow.


### PR DESCRIPTION
## Description

Adds `PromotionDialog` to the `ui` package — a modal dialog that fires when a pawn reaches the promotion rank. The dialog presents the four legal promotion choices (Queen, Rook, Bishop, Knight) as image buttons and returns the player's selection via `showAndGetChoice()`. `BoardController` is responsible for detecting that a promotion is pending after a pawn move, calling `promptForPromotionPiece(color)`, and forwarding the chosen `PieceType` into the move (via `move.withPromotionType(choice)`) before calling `board.makeMove(move)`.

The entire class is untestable (UI/IO modal — `showAndGetChoice()` blocks on user input). This follows the same pattern as the reference implementation.

## Type of Change

- [x] Feature (new functionality)
- [ ] Bug fix
- [x] Documentation update
- [ ] Refactor
- [ ] Test addition/update

## Related Work

Related to issue #44 (User Story: One Turn) and issue #55 (User Story: Legal Move Generation)

Related to `docs/bva/PromotionDialog.md`

`Board.makeMove(Move)` with `MoveType.PROMOTION` — the domain method this dialog feeds into — is handled via `move.withPromotionType(choice)` before calling `board.makeMove(move)`.

## Changes Made

- [x] `PromotionDialog` already added to `docs/design/chess-full-design.puml` (design prerequisite met)
- [x] Add `docs/bva/PromotionDialog.md` (BVA doc — notes entire class is untestable)
- [x] Implement `PromotionDialog` class in `src/main/java/ui/`

## BVA & Testing

- BVA documented in: `docs/bva/PromotionDialog.md`
- **No testable TCs** — `showAndGetChoice()` is a blocking modal (UI/IO); the entire public surface is untestable
- All tests passing: [x] (no tests added — nothing to test)

### Planned commits

1. `Add PromotionDialog BVA doc` (BVA doc only)
2. `Implement PromotionDialog (untestable — graphics/UI/IO)`

## Design Alignment

- [x] `PromotionDialog` added to `docs/design/chess-full-design.puml` (line 132–142)
- [x] `showAndGetChoice()` matches puml and reference implementation
- [x] `BoardController` wires `promptForPromotionPiece(color)` → `move.withPromotionType(choice)` → `board.makeMove(move)` (already in puml)
- [x] No breaking changes to existing methods

## Implementation Notes

- **Null banned:** `chosenType` is initialized to `PieceType.QUEEN`; button clicks overwrite it before `dialog.dispose()`. `showAndGetChoice()` always returns a non-null value.
- **Untestable surface:** `showAndGetChoice()` is a blocking modal — `// untestable: UI/IO modal blocks on user input`. No TC, own commit.
- **Scope of this slice:** Dialog only. Detection of the promotion condition in `BoardController` and full move wiring belong in a follow-up `BoardController` slice.
- **Out of scope:** En passant, castling, checkmate/stalemate, and all other special moves.

## Checklist

- [x] BVA analysis is documented
- [x] TDD workflow followed (entire class untestable — noted in BVA doc)
- [x] Code compiles and all tests pass
- [x] No new compiler warnings
- [x] Documentation updated (if applicable)
- [x] Commit messages are clear and follow TDD workflow