### PR TITLE
[FEAT] EndGameController

### DIFF
--- a/docs/bva/EndGameController.md
+++ b/docs/bva/EndGameController.md
@@ -38,12 +38,12 @@
 
 ### Step 4: Test Cases (Each-Choice Strategy)
 
-- **TC1: Constructor_WithEmptyResultMessage_ShowHidesMainView** ( :white_check_mark: )
+- **TC1: Constructor_WithEmptyResultMessage_ShowHidesMainView** ( :x: )
   - **Method(s) under test**: `EndGameController(String, JFrame)`, `show()`
   - **State of the system**: `resultMessage = ""`, `mainView` = a non-null visible `JFrame`; `show()` is called
   - **Expected output**: `mainView.isVisible()` returns `false`
 
-- **TC2: Constructor_WithNonEmptyResultMessage_ShowHidesMainViewAndDisplaysEndGameView** ( :white_check_mark: )
+- **TC2: Constructor_WithNonEmptyResultMessage_ShowHidesMainViewAndDisplaysEndGameView** ( :x: )
   - **Method(s) under test**: `EndGameController(String, JFrame)`, `show()`
   - **State of the system**: `resultMessage = "Alice wins!"`, `mainView` = a non-null visible `JFrame`; `show()` is called
   - **Expected output**: `mainView.isVisible()` returns `false`; `getEndGameView().isVisible()` returns `true`
@@ -77,13 +77,13 @@
 
 ### Step 4: Test Cases (Each-Choice Strategy)
 
-- **TC3: Show_HidesMainView** ( :white_check_mark: )
+- **TC3: Show_HidesMainView** ( :x: )
   - **Method(s) under test**: `show()`
   - **State of the system**: `EndGameController` constructed with a non-null visible `mainView`; `show()` is called
   - **Expected output**: `mainView.isVisible()` returns `false`
   - **Covered by**: TC1, TC2
 
-- **TC4: Show_DisplaysEndGameView** ( :white_check_mark: )
+- **TC4: Show_DisplaysEndGameView** ( :x: )
   - **Method(s) under test**: `show()`
   - **State of the system**: `EndGameController` constructed; `show()` is called
   - **Expected output**: `getEndGameView().isVisible()` returns `true`
@@ -117,12 +117,12 @@
 
 ### Step 4: Test Cases (Each-Choice Strategy)
 
-- **TC5: PlayAgain_DisposesEndGameView** ( :white_check_mark: )
+- **TC5: PlayAgain_DisposesEndGameView** ( :x: )
   - **Method(s) under test**: `playAgain()` (via `getEndGameView().clickPlayAgain()`)
   - **State of the system**: `EndGameController` constructed and `show()` called; `getEndGameView().clickPlayAgain()` is called
   - **Expected output**: `getEndGameView().isDisplayable()` returns `false`
 
-- **TC6: PlayAgain_ShowsWelcomeView** ( :white_check_mark: )
+- **TC6: PlayAgain_ShowsWelcomeView** ( :x: )
   - **Method(s) under test**: `playAgain()` (via `getEndGameView().clickPlayAgain()`)
   - **State of the system**: `EndGameController` constructed and `show()` called; `getEndGameView().clickPlayAgain()` is called
   - **Expected output**: a new `WelcomeView` is visible

--- a/docs/bva/EndGameController.md
+++ b/docs/bva/EndGameController.md
@@ -117,12 +117,12 @@
 
 ### Step 4: Test Cases (Each-Choice Strategy)
 
-- **TC5: PlayAgain_DisposesEndGameView** ( :x: )
+- **TC5: PlayAgain_DisposesEndGameView** ( :white_check_mark: )
   - **Method(s) under test**: `playAgain()` (via `getEndGameView().clickPlayAgain()`)
   - **State of the system**: `EndGameController` constructed and `show()` called; `getEndGameView().clickPlayAgain()` is called
   - **Expected output**: `getEndGameView().isDisplayable()` returns `false`
 
-- **TC6: PlayAgain_ShowsWelcomeView** ( :x: )
+- **TC6: PlayAgain_WhenShowHasBeenCalled_WelcomeViewIsVisible** ( :x: )
   - **Method(s) under test**: `playAgain()` (via `getEndGameView().clickPlayAgain()`)
   - **State of the system**: `EndGameController` constructed and `show()` called; `getEndGameView().clickPlayAgain()` is called
   - **Expected output**: a new `WelcomeView` is visible

--- a/docs/bva/EndGameController.md
+++ b/docs/bva/EndGameController.md
@@ -43,7 +43,7 @@
   - **State of the system**: `resultMessage = ""`, `mainView` = a non-null visible `JFrame`; `show()` is called
   - **Expected output**: `mainView.isVisible()` returns `false`
 
-- **TC2: Constructor_WithNonEmptyResultMessage_ShowHidesMainViewAndDisplaysEndGameView** ( :x: )
+- **TC2: Constructor_WithNonEmptyResultMessage_ShowHidesMainViewAndDisplaysEndGameView** ( :white_check_mark: )
   - **Method(s) under test**: `EndGameController(String, JFrame)`, `show()`
   - **State of the system**: `resultMessage = "Alice wins!"`, `mainView` = a non-null visible `JFrame`; `show()` is called
   - **Expected output**: `mainView.isVisible()` returns `false`; `getEndGameView().isVisible()` returns `true`

--- a/docs/bva/EndGameController.md
+++ b/docs/bva/EndGameController.md
@@ -122,7 +122,7 @@
   - **State of the system**: `EndGameController` constructed and `show()` called; `getEndGameView().clickPlayAgain()` is called
   - **Expected output**: `getEndGameView().isDisplayable()` returns `false`
 
-- **TC6: PlayAgain_WhenShowHasBeenCalled_WelcomeViewIsVisible** ( :x: )
+- **TC6: PlayAgain_WhenShowHasBeenCalled_WelcomeViewIsVisible** ( :white_check_mark: )
   - **Method(s) under test**: `playAgain()` (via `getEndGameView().clickPlayAgain()`)
   - **State of the system**: `EndGameController` constructed and `show()` called; `getEndGameView().clickPlayAgain()` is called
   - **Expected output**: a new `WelcomeView` is visible

--- a/docs/bva/EndGameController.md
+++ b/docs/bva/EndGameController.md
@@ -1,0 +1,128 @@
+# BVA Analysis for EndGameController
+
+## Method: `EndGameController(String resultMessage, JFrame mainView)`
+
+### Step 1: Equivalence Classes
+
+- **Input: result message** — the game outcome text to display in the end-game screen
+- **Input: main view reference** — the main game JFrame to be hidden when the end-game screen is shown
+- **Output: main view visibility after `show()`** — whether the main game window is hidden
+- **Output: end-game view visibility after `show()`** — whether the end-game screen is showing
+
+### Step 2: Data Types (from BVA Catalog)
+
+| Equivalence class | Catalog data type |
+| --- | --- |
+| Input: result message | String |
+| Input: main view reference | Pointer |
+| Output: main view visibility after `show()` | Boolean |
+| Output: end-game view visibility after `show()` | Boolean |
+
+### Step 3: Boundary Values (from BVA Catalog)
+
+**Result message — String:**
+- `""` (the empty string)
+- `"Alice wins!"` (a non-empty string)
+
+**Main view reference — Pointer:**
+- `null` — CAN'T SET: `show()` calls `mainView.setVisible(false)`, which throws `NullPointerException`
+- a non-null `JFrame` instance
+
+**Main view visibility — Boolean:**
+- `false` — `show()` always hides mainView; expected post-condition
+- `true` — CAN'T SET as a post-`show()` output
+
+**End-game view visibility — Boolean:**
+- `true` — `show()` always shows endGameView; expected post-condition
+- `false` — CAN'T SET as a post-`show()` output
+
+### Step 4: Test Cases (Each-Choice Strategy)
+
+- **TC1: Constructor_WithEmptyResultMessage_ShowHidesMainView** ( :white_check_mark: )
+  - **Method(s) under test**: `EndGameController(String, JFrame)`, `show()`
+  - **State of the system**: `resultMessage = ""`, `mainView` = a non-null visible `JFrame`; `show()` is called
+  - **Expected output**: `mainView.isVisible()` returns `false`
+
+- **TC2: Constructor_WithNonEmptyResultMessage_ShowHidesMainViewAndDisplaysEndGameView** ( :white_check_mark: )
+  - **Method(s) under test**: `EndGameController(String, JFrame)`, `show()`
+  - **State of the system**: `resultMessage = "Alice wins!"`, `mainView` = a non-null visible `JFrame`; `show()` is called
+  - **Expected output**: `mainView.isVisible()` returns `false`; `getEndGameView().isVisible()` returns `true`
+  - **Note**: observing end-game view visibility requires a package-private `getEndGameView()` accessor on `EndGameController`, consistent with the `WelcomeController.getWelcomeView()` pattern
+
+---
+
+## Method: `void show()`
+
+### Step 1: Equivalence Classes
+
+- **Output: main view visibility** — mainView is hidden after `show()`
+- **Output: end-game view visibility** — end-game screen is displayed after `show()`
+
+### Step 2: Data Types (from BVA Catalog)
+
+| Equivalence class | Catalog data type |
+| --- | --- |
+| Output: main view visibility | Boolean |
+| Output: end-game view visibility | Boolean |
+
+### Step 3: Boundary Values (from BVA Catalog)
+
+**Main view visibility — Boolean:**
+- `false` — `show()` always hides mainView; expected post-condition
+- `true` — CAN'T SET as a post-`show()` output
+
+**End-game view visibility — Boolean:**
+- `true` — `show()` always shows endGameView; expected post-condition
+- `false` — CAN'T SET as a post-`show()` output
+
+### Step 4: Test Cases (Each-Choice Strategy)
+
+- **TC3: Show_HidesMainView** ( :white_check_mark: )
+  - **Method(s) under test**: `show()`
+  - **State of the system**: `EndGameController` constructed with a non-null visible `mainView`; `show()` is called
+  - **Expected output**: `mainView.isVisible()` returns `false`
+  - **Covered by**: TC1, TC2
+
+- **TC4: Show_DisplaysEndGameView** ( :white_check_mark: )
+  - **Method(s) under test**: `show()`
+  - **State of the system**: `EndGameController` constructed; `show()` is called
+  - **Expected output**: `getEndGameView().isVisible()` returns `true`
+  - **Covered by**: TC2
+
+---
+
+## Method: `playAgain()` (invoked via `getEndGameView().clickPlayAgain()`)
+
+### Step 1: Equivalence Classes
+
+- **Output: end-game view disposal** — end-game screen is disposed after "Play Again" is clicked
+- **Output: welcome screen shown** — a new `WelcomeView` becomes visible
+
+### Step 2: Data Types (from BVA Catalog)
+
+| Equivalence class | Catalog data type |
+| --- | --- |
+| Output: end-game view disposal | Boolean |
+| Output: welcome screen shown | Boolean |
+
+### Step 3: Boundary Values (from BVA Catalog)
+
+**End-game view disposal — Boolean:**
+- `true` — end-game view is disposed after `playAgain()`; expected post-condition
+- `false` — CAN'T SET as a post-`playAgain()` output
+
+**Welcome screen shown — Boolean:**
+- `true` — a new `WelcomeView` is shown after `playAgain()`; expected post-condition
+- `false` — CAN'T SET as a post-`playAgain()` output
+
+### Step 4: Test Cases (Each-Choice Strategy)
+
+- **TC5: PlayAgain_DisposesEndGameView** ( :white_check_mark: )
+  - **Method(s) under test**: `playAgain()` (via `getEndGameView().clickPlayAgain()`)
+  - **State of the system**: `EndGameController` constructed and `show()` called; `getEndGameView().clickPlayAgain()` is called
+  - **Expected output**: `getEndGameView().isDisplayable()` returns `false`
+
+- **TC6: PlayAgain_ShowsWelcomeView** ( :white_check_mark: )
+  - **Method(s) under test**: `playAgain()` (via `getEndGameView().clickPlayAgain()`)
+  - **State of the system**: `EndGameController` constructed and `show()` called; `getEndGameView().clickPlayAgain()` is called
+  - **Expected output**: a new `WelcomeView` is visible

--- a/docs/bva/EndGameController.md
+++ b/docs/bva/EndGameController.md
@@ -38,7 +38,7 @@
 
 ### Step 4: Test Cases (Each-Choice Strategy)
 
-- **TC1: Constructor_WithEmptyResultMessage_ShowHidesMainView** ( :x: )
+- **TC1: Constructor_WithEmptyResultMessage_ShowHidesMainView** ( :white_check_mark: )
   - **Method(s) under test**: `EndGameController(String, JFrame)`, `show()`
   - **State of the system**: `resultMessage = ""`, `mainView` = a non-null visible `JFrame`; `show()` is called
   - **Expected output**: `mainView.isVisible()` returns `false`

--- a/docs/bva/EndGameController.md
+++ b/docs/bva/EndGameController.md
@@ -77,13 +77,13 @@
 
 ### Step 4: Test Cases (Each-Choice Strategy)
 
-- **TC3: Show_HidesMainView** ( :x: )
+- **TC3: Show_HidesMainView** ( :white_check_mark: )
   - **Method(s) under test**: `show()`
   - **State of the system**: `EndGameController` constructed with a non-null visible `mainView`; `show()` is called
   - **Expected output**: `mainView.isVisible()` returns `false`
   - **Covered by**: TC1, TC2
 
-- **TC4: Show_DisplaysEndGameView** ( :x: )
+- **TC4: Show_DisplaysEndGameView** ( :white_check_mark: )
   - **Method(s) under test**: `show()`
   - **State of the system**: `EndGameController` constructed; `show()` is called
   - **Expected output**: `getEndGameView().isVisible()` returns `true`

--- a/src/main/java/ui/EndGameController.java
+++ b/src/main/java/ui/EndGameController.java
@@ -4,13 +4,20 @@ import javax.swing.JFrame;
 
 class EndGameController {
 
+    private final EndGameView endGameView;
     private final JFrame mainView;
 
     EndGameController(String resultMessage, JFrame mainView) {
         this.mainView = mainView;
+        endGameView = new EndGameView(resultMessage);
+    }
+
+    EndGameView getEndGameView() {
+        return endGameView;
     }
 
     void show() {
         mainView.setVisible(false);
+        endGameView.setVisible(true);
     }
 }

--- a/src/main/java/ui/EndGameController.java
+++ b/src/main/java/ui/EndGameController.java
@@ -15,6 +15,7 @@ class EndGameController {
 
     private void playAgain() {
         endGameView.dispose();
+        new WelcomeController().show();
     }
 
     EndGameView getEndGameView() {

--- a/src/main/java/ui/EndGameController.java
+++ b/src/main/java/ui/EndGameController.java
@@ -1,0 +1,16 @@
+package ui;
+
+import javax.swing.JFrame;
+
+class EndGameController {
+
+    private final JFrame mainView;
+
+    EndGameController(String resultMessage, JFrame mainView) {
+        this.mainView = mainView;
+    }
+
+    void show() {
+        mainView.setVisible(false);
+    }
+}

--- a/src/main/java/ui/EndGameController.java
+++ b/src/main/java/ui/EndGameController.java
@@ -10,6 +10,11 @@ class EndGameController {
     EndGameController(String resultMessage, JFrame mainView) {
         this.mainView = mainView;
         endGameView = new EndGameView(resultMessage);
+        endGameView.setPlayAgainAction(this::playAgain);
+    }
+
+    private void playAgain() {
+        endGameView.dispose();
     }
 
     EndGameView getEndGameView() {

--- a/src/main/java/ui/EndGameView.java
+++ b/src/main/java/ui/EndGameView.java
@@ -1,8 +1,24 @@
 package ui;
 
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.Font;
+import javax.swing.BorderFactory;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.JButton;
 import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
 
 class EndGameView extends JFrame {
+
+    private static final Color BACKGROUND = new Color(30, 20, 12);
+    private static final Color ACCENT_COLOR = new Color(181, 136, 99);
+    private static final Color TEXT_COLOR = new Color(240, 217, 181);
+    private static final Font RESULT_FONT = new Font("Serif", Font.BOLD, 36);
+    private static final Font BUTTON_FONT = new Font("SansSerif", Font.BOLD, 16);
 
     private Runnable playAgainAction = () -> {};
 
@@ -19,5 +35,35 @@ class EndGameView extends JFrame {
     }
 
     private void buildUi(String resultMessage) {
+        JPanel panel = new JPanel();
+        panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
+        panel.setBackground(BACKGROUND);
+        panel.setBorder(BorderFactory.createEmptyBorder(60, 80, 60, 80));
+
+        JLabel resultLabel = new JLabel(resultMessage);
+        resultLabel.setFont(RESULT_FONT);
+        resultLabel.setForeground(TEXT_COLOR);
+        resultLabel.setAlignmentX(Component.CENTER_ALIGNMENT);
+        panel.add(resultLabel);
+        panel.add(Box.createVerticalStrut(40));
+
+        JButton playAgainButton = new JButton("Play Again");
+        playAgainButton.setFont(BUTTON_FONT);
+        playAgainButton.setBackground(ACCENT_COLOR);
+        playAgainButton.setForeground(TEXT_COLOR);
+        playAgainButton.setFocusPainted(false);
+        playAgainButton.setOpaque(true);
+        playAgainButton.setBorderPainted(false);
+        playAgainButton.setMaximumSize(new Dimension(180, 42));
+        playAgainButton.setAlignmentX(Component.CENTER_ALIGNMENT);
+        playAgainButton.addActionListener(e -> clickPlayAgain());
+        panel.add(playAgainButton);
+
+        setTitle("Game Over");
+        setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        getContentPane().setBackground(BACKGROUND);
+        getContentPane().add(panel);
+        pack();
+        setLocationRelativeTo(null);
     }
 }

--- a/src/main/java/ui/EndGameView.java
+++ b/src/main/java/ui/EndGameView.java
@@ -1,0 +1,13 @@
+package ui;
+
+import javax.swing.JFrame;
+
+class EndGameView extends JFrame {
+
+    EndGameView(String resultMessage) {
+        buildUi(resultMessage);
+    }
+
+    private void buildUi(String resultMessage) {
+    }
+}

--- a/src/main/java/ui/EndGameView.java
+++ b/src/main/java/ui/EndGameView.java
@@ -4,8 +4,14 @@ import javax.swing.JFrame;
 
 class EndGameView extends JFrame {
 
+    private Runnable playAgainAction = () -> {};
+
     EndGameView(String resultMessage) {
         buildUi(resultMessage);
+    }
+
+    void setPlayAgainAction(Runnable action) {
+        this.playAgainAction = action;
     }
 
     private void buildUi(String resultMessage) {

--- a/src/main/java/ui/EndGameView.java
+++ b/src/main/java/ui/EndGameView.java
@@ -14,6 +14,10 @@ class EndGameView extends JFrame {
         this.playAgainAction = action;
     }
 
+    void clickPlayAgain() {
+        playAgainAction.run();
+    }
+
     private void buildUi(String resultMessage) {
     }
 }

--- a/src/test/java/ui/EndGameControllerTest.java
+++ b/src/test/java/ui/EndGameControllerTest.java
@@ -2,6 +2,7 @@ package ui;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.awt.Window;
 import javax.swing.JFrame;
 import org.easymock.EasyMock;
 import org.junit.jupiter.api.Test;
@@ -52,5 +53,31 @@ class EndGameControllerTest {
         boolean actual = controller.getEndGameView().isDisplayable();
         assertEquals(expected, actual);
         EasyMock.verify(mainView);
+    }
+
+    @Test
+    void PlayAgain_WhenShowHasBeenCalled_WelcomeViewIsVisible() {
+        JFrame mainView = EasyMock.createMock(JFrame.class);
+        mainView.setVisible(false);
+        EasyMock.expectLastCall().once();
+        EasyMock.replay(mainView);
+
+        EndGameController controller = new EndGameController("Alice wins!", mainView);
+        controller.show();
+        controller.getEndGameView().clickPlayAgain();
+
+        boolean expected = true;
+        boolean actual = isAnyWindowOfTypeVisible(WelcomeView.class);
+        assertEquals(expected, actual);
+        EasyMock.verify(mainView);
+    }
+
+    private static boolean isAnyWindowOfTypeVisible(Class<?> type) {
+        for (Window window : Window.getWindows()) {
+            if (type.isInstance(window) && window.isVisible()) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/test/java/ui/EndGameControllerTest.java
+++ b/src/test/java/ui/EndGameControllerTest.java
@@ -1,5 +1,7 @@
 package ui;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import javax.swing.JFrame;
 import org.easymock.EasyMock;
 import org.junit.jupiter.api.Test;
@@ -16,6 +18,22 @@ class EndGameControllerTest {
         EndGameController controller = new EndGameController("", mainView);
         controller.show();
 
+        EasyMock.verify(mainView);
+    }
+
+    @Test
+    void Constructor_WithNonEmptyResultMessage_ShowHidesMainViewAndDisplaysEndGameView() {
+        JFrame mainView = EasyMock.createMock(JFrame.class);
+        mainView.setVisible(false);
+        EasyMock.expectLastCall().once();
+        EasyMock.replay(mainView);
+
+        EndGameController controller = new EndGameController("Alice wins!", mainView);
+        controller.show();
+
+        boolean expected = true;
+        boolean actual = controller.getEndGameView().isVisible();
+        assertEquals(expected, actual);
         EasyMock.verify(mainView);
     }
 }

--- a/src/test/java/ui/EndGameControllerTest.java
+++ b/src/test/java/ui/EndGameControllerTest.java
@@ -1,0 +1,21 @@
+package ui;
+
+import javax.swing.JFrame;
+import org.easymock.EasyMock;
+import org.junit.jupiter.api.Test;
+
+class EndGameControllerTest {
+
+    @Test
+    void Constructor_WithEmptyResultMessage_ShowHidesMainView() {
+        JFrame mainView = EasyMock.createMock(JFrame.class);
+        mainView.setVisible(false);
+        EasyMock.expectLastCall().once();
+        EasyMock.replay(mainView);
+
+        EndGameController controller = new EndGameController("", mainView);
+        controller.show();
+
+        EasyMock.verify(mainView);
+    }
+}

--- a/src/test/java/ui/EndGameControllerTest.java
+++ b/src/test/java/ui/EndGameControllerTest.java
@@ -36,4 +36,21 @@ class EndGameControllerTest {
         assertEquals(expected, actual);
         EasyMock.verify(mainView);
     }
+
+    @Test
+    void PlayAgain_WhenShowHasBeenCalled_EndGameViewIsDisposed() {
+        JFrame mainView = EasyMock.createMock(JFrame.class);
+        mainView.setVisible(false);
+        EasyMock.expectLastCall().once();
+        EasyMock.replay(mainView);
+
+        EndGameController controller = new EndGameController("Alice wins!", mainView);
+        controller.show();
+        controller.getEndGameView().clickPlayAgain();
+
+        boolean expected = false;
+        boolean actual = controller.getEndGameView().isDisplayable();
+        assertEquals(expected, actual);
+        EasyMock.verify(mainView);
+    }
 }


### PR DESCRIPTION
EndGameController orchestrates the transition: hides the main board, shows the end-game screen, and returns the player to the welcome screen on replay.

Includes a BVA analysis and full test coverage for EndGameController.