### PR TITLE
[CHORE] Refactor tests for code coverage and style

### DIFF
--- a/docs/bva/Bishop.md
+++ b/docs/bva/Bishop.md
@@ -87,7 +87,7 @@
   - **State of the system**: an existing white bishop that has not moved
   - **Expected output**: returned piece reports `hasMoved()` as `false`
 
-- **TC10: MakeCopy_OnMovedWhiteBishop_CopyHasMovedIsTrue** ( :x: )
+- **TC10: MakeCopy_OnMovedWhiteBishop_CopyHasMovedIsTrue** ( :white_check_mark: )
   - **Method(s) under test**: `makeCopy()`
   - **State of the system**: an existing white bishop on which `changeToMoved()` has been called
   - **Expected output**: returned piece reports `hasMoved()` as `true`

--- a/docs/bva/Bishop.md
+++ b/docs/bva/Bishop.md
@@ -82,7 +82,7 @@
   - **State of the system**: an existing black bishop
   - **Expected output**: returned piece is a different object from the original
 
-- **TC9: MakeCopy_OnUnmovedWhiteBishop_CopyHasMovedIsFalse** ( :x: )
+- **TC9: MakeCopy_OnUnmovedWhiteBishop_CopyHasMovedIsFalse** ( :white_check_mark: )
   - **Method(s) under test**: `makeCopy()`
   - **State of the system**: an existing white bishop that has not moved
   - **Expected output**: returned piece reports `hasMoved()` as `false`

--- a/docs/bva/Bishop.md
+++ b/docs/bva/Bishop.md
@@ -50,6 +50,7 @@
 | Parameter | Catalog clue | Values considered |
 |-----------|--------------|-------------------|
 | Input: original piece color | Cases | `WHITE`, `BLACK` |
+| Input: original piece `hasMoved` state | Boolean | `false`, `true` |
 | Output: returned piece type | Cases | `BISHOP` |
 | Output: returned piece jump capability | Boolean | `false` |
 | Output: original and copy references | Pairs of references | same object is not allowed; copy must be a different object |
@@ -80,5 +81,15 @@
   - **Method(s) under test**: `makeCopy()`
   - **State of the system**: an existing black bishop
   - **Expected output**: returned piece is a different object from the original
+
+- **TC9: MakeCopy_OnUnmovedWhiteBishop_CopyHasMovedIsFalse** ( :x: )
+  - **Method(s) under test**: `makeCopy()`
+  - **State of the system**: an existing white bishop that has not moved
+  - **Expected output**: returned piece reports `hasMoved()` as `false`
+
+- **TC10: MakeCopy_OnMovedWhiteBishop_CopyHasMovedIsTrue** ( :x: )
+  - **Method(s) under test**: `makeCopy()`
+  - **State of the system**: an existing white bishop on which `changeToMoved()` has been called
+  - **Expected output**: returned piece reports `hasMoved()` as `true`
 
 ---

--- a/docs/bva/King.md
+++ b/docs/bva/King.md
@@ -81,7 +81,7 @@
   - **State of the system**: an existing black king
   - **Expected output**: returned piece is a different object from the original
 
-- **TC8: MakeCopy_OnUnmovedWhiteKing_CopyHasMovedIsFalse** ( :x: )
+- **TC8: MakeCopy_OnUnmovedWhiteKing_CopyHasMovedIsFalse** ( :white_check_mark: )
   - **Method(s) under test**: `makeCopy()`
   - **State of the system**: an existing white king that has not moved
   - **Expected output**: returned piece reports `hasMoved()` as `false`

--- a/docs/bva/King.md
+++ b/docs/bva/King.md
@@ -86,7 +86,7 @@
   - **State of the system**: an existing white king that has not moved
   - **Expected output**: returned piece reports `hasMoved()` as `false`
 
-- **TC9: MakeCopy_OnMovedWhiteKing_CopyHasMovedIsTrue** ( :x: )
+- **TC9: MakeCopy_OnMovedWhiteKing_CopyHasMovedIsTrue** ( :white_check_mark: )
   - **Method(s) under test**: `makeCopy()`
   - **State of the system**: an existing white king on which `changeToMoved()` has been called
   - **Expected output**: returned piece reports `hasMoved()` as `true`

--- a/docs/bva/King.md
+++ b/docs/bva/King.md
@@ -49,6 +49,7 @@
 | Parameter                              | Catalog clue        | Values considered                                           |
 | -------------------------------------- | ------------------- | ----------------------------------------------------------- |
 | Input: original piece reference        | Pairs of references | same object is not allowed; copy must be a different object |
+| Input: original piece `hasMoved` state | Boolean             | `false`, `true`                                             |
 | Output: returned piece type            | Cases               | `KING`                                                      |
 | Output: returned piece color           | Cases               | `WHITE`, `BLACK`                                            |
 | Output: returned piece jump capability | Boolean             | `false`                                                     |
@@ -79,5 +80,15 @@
   - **Method(s) under test**: `makeCopy()`
   - **State of the system**: an existing black king
   - **Expected output**: returned piece is a different object from the original
+
+- **TC8: MakeCopy_OnUnmovedWhiteKing_CopyHasMovedIsFalse** ( :x: )
+  - **Method(s) under test**: `makeCopy()`
+  - **State of the system**: an existing white king that has not moved
+  - **Expected output**: returned piece reports `hasMoved()` as `false`
+
+- **TC9: MakeCopy_OnMovedWhiteKing_CopyHasMovedIsTrue** ( :x: )
+  - **Method(s) under test**: `makeCopy()`
+  - **State of the system**: an existing white king on which `changeToMoved()` has been called
+  - **Expected output**: returned piece reports `hasMoved()` as `true`
 
 ---

--- a/docs/bva/Knight.md
+++ b/docs/bva/Knight.md
@@ -50,6 +50,7 @@
 | Parameter | Catalog clue | Values considered |
 |-----------|--------------|-------------------|
 | Input: original piece color | Cases | `WHITE`, `BLACK` |
+| Input: original piece `hasMoved` state | Boolean | `false`, `true` |
 | Output: returned piece type | Cases | `KNIGHT` |
 | Output: returned piece jump capability | Boolean | `true` |
 | Output: original and copy references | Pairs of references | same object is not allowed; copy must be a different object |
@@ -80,5 +81,15 @@
   - **Method(s) under test**: `makeCopy()`
   - **State of the system**: an existing black knight
   - **Expected output**: returned piece is a different object from the original
+
+- **TC9: MakeCopy_OnUnmovedWhiteKnight_CopyHasMovedIsFalse** ( :x: )
+  - **Method(s) under test**: `makeCopy()`
+  - **State of the system**: an existing white knight that has not moved
+  - **Expected output**: returned piece reports `hasMoved()` as `false`
+
+- **TC10: MakeCopy_OnMovedWhiteKnight_CopyHasMovedIsTrue** ( :x: )
+  - **Method(s) under test**: `makeCopy()`
+  - **State of the system**: an existing white knight on which `changeToMoved()` has been called
+  - **Expected output**: returned piece reports `hasMoved()` as `true`
 
 ---

--- a/docs/bva/Knight.md
+++ b/docs/bva/Knight.md
@@ -87,7 +87,7 @@
   - **State of the system**: an existing white knight that has not moved
   - **Expected output**: returned piece reports `hasMoved()` as `false`
 
-- **TC10: MakeCopy_OnMovedWhiteKnight_CopyHasMovedIsTrue** ( :x: )
+- **TC10: MakeCopy_OnMovedWhiteKnight_CopyHasMovedIsTrue** ( :white_check_mark: )
   - **Method(s) under test**: `makeCopy()`
   - **State of the system**: an existing white knight on which `changeToMoved()` has been called
   - **Expected output**: returned piece reports `hasMoved()` as `true`

--- a/docs/bva/Knight.md
+++ b/docs/bva/Knight.md
@@ -82,7 +82,7 @@
   - **State of the system**: an existing black knight
   - **Expected output**: returned piece is a different object from the original
 
-- **TC9: MakeCopy_OnUnmovedWhiteKnight_CopyHasMovedIsFalse** ( :x: )
+- **TC9: MakeCopy_OnUnmovedWhiteKnight_CopyHasMovedIsFalse** ( :white_check_mark: )
   - **Method(s) under test**: `makeCopy()`
   - **State of the system**: an existing white knight that has not moved
   - **Expected output**: returned piece reports `hasMoved()` as `false`

--- a/docs/bva/Pawn.md
+++ b/docs/bva/Pawn.md
@@ -82,7 +82,7 @@
   - **State of the system**: an existing black pawn
   - **Expected output**: returned piece is a different object from the original
 
-- **TC9: MakeCopy_OnUnmovedWhitePawn_CopyHasMovedIsFalse** ( :x: )
+- **TC9: MakeCopy_OnUnmovedWhitePawn_CopyHasMovedIsFalse** ( :white_check_mark: )
   - **Method(s) under test**: `makeCopy()`
   - **State of the system**: an existing white pawn that has not moved
   - **Expected output**: returned piece reports `hasMoved()` as `false`

--- a/docs/bva/Pawn.md
+++ b/docs/bva/Pawn.md
@@ -87,7 +87,7 @@
   - **State of the system**: an existing white pawn that has not moved
   - **Expected output**: returned piece reports `hasMoved()` as `false`
 
-- **TC10: MakeCopy_OnMovedWhitePawn_CopyHasMovedIsTrue** ( :x: )
+- **TC10: MakeCopy_OnMovedWhitePawn_CopyHasMovedIsTrue** ( :white_check_mark: )
   - **Method(s) under test**: `makeCopy()`
   - **State of the system**: an existing white pawn on which `changeToMoved()` has been called
   - **Expected output**: returned piece reports `hasMoved()` as `true`

--- a/docs/bva/Pawn.md
+++ b/docs/bva/Pawn.md
@@ -50,6 +50,7 @@
 | Parameter | Catalog clue | Values considered |
 |-----------|--------------|-------------------|
 | Input: original piece color | Cases | `WHITE`, `BLACK` |
+| Input: original piece `hasMoved` state | Boolean | `false`, `true` |
 | Output: returned piece type | Cases | `PAWN` |
 | Output: returned piece jump capability | Boolean | `false` |
 | Output: original and copy references | Pairs of references | same object is not allowed; copy must be a different object |
@@ -80,5 +81,15 @@
   - **Method(s) under test**: `makeCopy()`
   - **State of the system**: an existing black pawn
   - **Expected output**: returned piece is a different object from the original
+
+- **TC9: MakeCopy_OnUnmovedWhitePawn_CopyHasMovedIsFalse** ( :x: )
+  - **Method(s) under test**: `makeCopy()`
+  - **State of the system**: an existing white pawn that has not moved
+  - **Expected output**: returned piece reports `hasMoved()` as `false`
+
+- **TC10: MakeCopy_OnMovedWhitePawn_CopyHasMovedIsTrue** ( :x: )
+  - **Method(s) under test**: `makeCopy()`
+  - **State of the system**: an existing white pawn on which `changeToMoved()` has been called
+  - **Expected output**: returned piece reports `hasMoved()` as `true`
 
 ---

--- a/docs/bva/Piece.md
+++ b/docs/bva/Piece.md
@@ -36,7 +36,7 @@
 
 ### Step 4: Test Cases (Catalog-aligned Each-Choice Strategy)
 
-- **TC3: ResetHasMoved_OnMovedPiece_HasMovedIsFalse** ( :x: )
+- **TC3: ResetHasMoved_OnMovedPiece_HasMovedIsFalse** ( :white_check_mark: )
   - **Method(s) under test**: `resetHasMoved()`
   - **State of the system**: a piece on which `changeToMoved()` has been called
   - **Expected output**: `hasMoved()` returns `false`

--- a/docs/bva/Piece.md
+++ b/docs/bva/Piece.md
@@ -13,7 +13,7 @@
 
 ### Step 4: Test Cases (Catalog-aligned Each-Choice Strategy)
 
-- **TC1: IsSameColor_OnSameColorPieces_ReturnsTrue** ( :x: )
+- **TC1: IsSameColor_OnSameColorPieces_ReturnsTrue** ( :white_check_mark: )
   - **Method(s) under test**: `isSameColor(Piece piece)`
   - **State of the system**: two white pieces
   - **Expected output**: `true`

--- a/docs/bva/Piece.md
+++ b/docs/bva/Piece.md
@@ -64,7 +64,7 @@
   - **State of the system**: a white pawn
   - **Expected output**: `"WHITE PAWN"`
 
-- **TC6: ToString_OnBlackPawn_ReturnsBlackPawn** ( :x: )
+- **TC6: ToString_OnBlackPawn_ReturnsBlackPawn** ( :white_check_mark: )
   - **Method(s) under test**: `toString()`
   - **State of the system**: a black pawn
   - **Expected output**: `"BLACK PAWN"`

--- a/docs/bva/Piece.md
+++ b/docs/bva/Piece.md
@@ -59,7 +59,7 @@
 
 ### Step 4: Test Cases (Catalog-aligned Each-Choice Strategy)
 
-- **TC5: ToString_OnWhitePawn_ReturnsWhitePawn** ( :x: )
+- **TC5: ToString_OnWhitePawn_ReturnsWhitePawn** ( :white_check_mark: )
   - **Method(s) under test**: `toString()`
   - **State of the system**: a white pawn
   - **Expected output**: `"WHITE PAWN"`

--- a/docs/bva/Piece.md
+++ b/docs/bva/Piece.md
@@ -41,7 +41,7 @@
   - **State of the system**: a piece on which `changeToMoved()` has been called
   - **Expected output**: `hasMoved()` returns `false`
 
-- **TC4: ResetHasMoved_OnUnmovedPiece_HasMovedIsFalse** ( :x: )
+- **TC4: ResetHasMoved_OnUnmovedPiece_HasMovedIsFalse** ( :white_check_mark: )
   - **Method(s) under test**: `resetHasMoved()`
   - **State of the system**: a fresh piece that has not moved
   - **Expected output**: `hasMoved()` returns `false`

--- a/docs/bva/Piece.md
+++ b/docs/bva/Piece.md
@@ -18,7 +18,7 @@
   - **State of the system**: two white pieces
   - **Expected output**: `true`
 
-- **TC2: IsSameColor_OnDifferentColorPieces_ReturnsFalse** ( :x: )
+- **TC2: IsSameColor_OnDifferentColorPieces_ReturnsFalse** ( :white_check_mark: )
   - **Method(s) under test**: `isSameColor(Piece piece)`
   - **State of the system**: one white piece and one black piece
   - **Expected output**: `false`

--- a/docs/bva/Piece.md
+++ b/docs/bva/Piece.md
@@ -1,0 +1,70 @@
+# BVA Analysis for Piece
+
+---
+
+## Method: `isSameColor(Piece piece)`
+
+### Step 1-3: Analysis
+
+| Parameter | Catalog clue | Values considered |
+|-----------|--------------|-------------------|
+| Input: color relationship between `this` and `piece` | Cases | same color, different color |
+| Output: result | Boolean | `true`, `false` |
+
+### Step 4: Test Cases (Catalog-aligned Each-Choice Strategy)
+
+- **TC1: IsSameColor_OnSameColorPieces_ReturnsTrue** ( :x: )
+  - **Method(s) under test**: `isSameColor(Piece piece)`
+  - **State of the system**: two white pieces
+  - **Expected output**: `true`
+
+- **TC2: IsSameColor_OnDifferentColorPieces_ReturnsFalse** ( :x: )
+  - **Method(s) under test**: `isSameColor(Piece piece)`
+  - **State of the system**: one white piece and one black piece
+  - **Expected output**: `false`
+
+---
+
+## Method: `resetHasMoved()`
+
+### Step 1-3: Analysis
+
+| Parameter | Catalog clue | Values considered |
+|-----------|--------------|-------------------|
+| Input: current `hasMoved` state | Boolean | `false`, `true` |
+| Output: `hasMoved()` after reset | Boolean | `false` |
+
+### Step 4: Test Cases (Catalog-aligned Each-Choice Strategy)
+
+- **TC3: ResetHasMoved_OnMovedPiece_HasMovedIsFalse** ( :x: )
+  - **Method(s) under test**: `resetHasMoved()`
+  - **State of the system**: a piece on which `changeToMoved()` has been called
+  - **Expected output**: `hasMoved()` returns `false`
+
+- **TC4: ResetHasMoved_OnUnmovedPiece_HasMovedIsFalse** ( :x: )
+  - **Method(s) under test**: `resetHasMoved()`
+  - **State of the system**: a fresh piece that has not moved
+  - **Expected output**: `hasMoved()` returns `false`
+
+---
+
+## Method: `toString()`
+
+### Step 1-3: Analysis
+
+| Parameter | Catalog clue | Values considered |
+|-----------|--------------|-------------------|
+| Input: piece color | Cases | `WHITE`, `BLACK` |
+| Output: string representation | String (non-empty) | `"WHITE PAWN"`, `"BLACK PAWN"` |
+
+### Step 4: Test Cases (Catalog-aligned Each-Choice Strategy)
+
+- **TC5: ToString_OnWhitePawn_ReturnsWhitePawn** ( :x: )
+  - **Method(s) under test**: `toString()`
+  - **State of the system**: a white pawn
+  - **Expected output**: `"WHITE PAWN"`
+
+- **TC6: ToString_OnBlackPawn_ReturnsBlackPawn** ( :x: )
+  - **Method(s) under test**: `toString()`
+  - **State of the system**: a black pawn
+  - **Expected output**: `"BLACK PAWN"`

--- a/docs/bva/PromotionDialog.md
+++ b/docs/bva/PromotionDialog.md
@@ -1,6 +1,6 @@
 # BVA Analysis for PromotionDialog
 
-Package: `ui.PromotionDialog`
+Package: `ui.PromotionView`
 
 Scope: `PromotionDialog` is a package-private modal `JDialog` shown when a pawn reaches the back rank. It presents four image buttons (Queen, Rook, Bishop, Knight); clicking one sets `chosenType` and disposes the dialog. `showAndGetChoice()` blocks until a button is clicked and returns the chosen `PieceType`.
 

--- a/docs/bva/Queen.md
+++ b/docs/bva/Queen.md
@@ -50,6 +50,7 @@
 | Parameter | Catalog clue | Values considered |
 |-----------|--------------|-------------------|
 | Input: original piece color | Cases | `WHITE`, `BLACK` |
+| Input: original piece `hasMoved` state | Boolean | `false`, `true` |
 | Output: returned piece type | Cases | `QUEEN` |
 | Output: returned piece jump capability | Boolean | `false` |
 | Output: original and copy references | Pairs of references | same object is not allowed; copy must be a different object |
@@ -80,5 +81,15 @@
   - **Method(s) under test**: `makeCopy()`
   - **State of the system**: an existing black queen
   - **Expected output**: returned piece is a different object from the original
+
+- **TC9: MakeCopy_OnUnmovedWhiteQueen_CopyHasMovedIsFalse** ( :x: )
+  - **Method(s) under test**: `makeCopy()`
+  - **State of the system**: an existing white queen that has not moved
+  - **Expected output**: returned piece reports `hasMoved()` as `false`
+
+- **TC10: MakeCopy_OnMovedWhiteQueen_CopyHasMovedIsTrue** ( :x: )
+  - **Method(s) under test**: `makeCopy()`
+  - **State of the system**: an existing white queen on which `changeToMoved()` has been called
+  - **Expected output**: returned piece reports `hasMoved()` as `true`
 
 ---

--- a/docs/bva/Queen.md
+++ b/docs/bva/Queen.md
@@ -87,7 +87,7 @@
   - **State of the system**: an existing white queen that has not moved
   - **Expected output**: returned piece reports `hasMoved()` as `false`
 
-- **TC10: MakeCopy_OnMovedWhiteQueen_CopyHasMovedIsTrue** ( :x: )
+- **TC10: MakeCopy_OnMovedWhiteQueen_CopyHasMovedIsTrue** ( :white_check_mark: )
   - **Method(s) under test**: `makeCopy()`
   - **State of the system**: an existing white queen on which `changeToMoved()` has been called
   - **Expected output**: returned piece reports `hasMoved()` as `true`

--- a/docs/bva/Queen.md
+++ b/docs/bva/Queen.md
@@ -82,7 +82,7 @@
   - **State of the system**: an existing black queen
   - **Expected output**: returned piece is a different object from the original
 
-- **TC9: MakeCopy_OnUnmovedWhiteQueen_CopyHasMovedIsFalse** ( :x: )
+- **TC9: MakeCopy_OnUnmovedWhiteQueen_CopyHasMovedIsFalse** ( :white_check_mark: )
   - **Method(s) under test**: `makeCopy()`
   - **State of the system**: an existing white queen that has not moved
   - **Expected output**: returned piece reports `hasMoved()` as `false`

--- a/docs/bva/Rook.md
+++ b/docs/bva/Rook.md
@@ -50,6 +50,7 @@
 | Parameter | Catalog clue | Values considered |
 |-----------|--------------|-------------------|
 | Input: original piece color | Cases | `WHITE`, `BLACK` |
+| Input: original piece `hasMoved` state | Boolean | `false`, `true` |
 | Output: returned piece type | Cases | `ROOK` |
 | Output: returned piece jump capability | Boolean | `false` |
 | Output: original and copy references | Pairs of references | same object is not allowed; copy must be a different object |
@@ -80,5 +81,15 @@
   - **Method(s) under test**: `makeCopy()`
   - **State of the system**: an existing black rook
   - **Expected output**: returned piece is a different object from the original
+
+- **TC9: MakeCopy_OnUnmovedWhiteRook_CopyHasMovedIsFalse** ( :x: )
+  - **Method(s) under test**: `makeCopy()`
+  - **State of the system**: an existing white rook that has not moved
+  - **Expected output**: returned piece reports `hasMoved()` as `false`
+
+- **TC10: MakeCopy_OnMovedWhiteRook_CopyHasMovedIsTrue** ( :x: )
+  - **Method(s) under test**: `makeCopy()`
+  - **State of the system**: an existing white rook on which `changeToMoved()` has been called
+  - **Expected output**: returned piece reports `hasMoved()` as `true`
 
 ---

--- a/docs/bva/Rook.md
+++ b/docs/bva/Rook.md
@@ -82,7 +82,7 @@
   - **State of the system**: an existing black rook
   - **Expected output**: returned piece is a different object from the original
 
-- **TC9: MakeCopy_OnUnmovedWhiteRook_CopyHasMovedIsFalse** ( :x: )
+- **TC9: MakeCopy_OnUnmovedWhiteRook_CopyHasMovedIsFalse** ( :white_check_mark: )
   - **Method(s) under test**: `makeCopy()`
   - **State of the system**: an existing white rook that has not moved
   - **Expected output**: returned piece reports `hasMoved()` as `false`

--- a/docs/bva/Rook.md
+++ b/docs/bva/Rook.md
@@ -87,7 +87,7 @@
   - **State of the system**: an existing white rook that has not moved
   - **Expected output**: returned piece reports `hasMoved()` as `false`
 
-- **TC10: MakeCopy_OnMovedWhiteRook_CopyHasMovedIsTrue** ( :x: )
+- **TC10: MakeCopy_OnMovedWhiteRook_CopyHasMovedIsTrue** ( :white_check_mark: )
   - **Method(s) under test**: `makeCopy()`
   - **State of the system**: an existing white rook on which `changeToMoved()` has been called
   - **Expected output**: returned piece reports `hasMoved()` as `true`

--- a/src/main/java/domain/MoveGenerator.java
+++ b/src/main/java/domain/MoveGenerator.java
@@ -43,11 +43,12 @@ public class MoveGenerator {
     }
 
     public boolean isInCheck(PieceColor color) {
-        Location kingLocation = findKing(color, board);
-        if (kingLocation == null) {
+        try {
+            Location kingLocation = findKing(color, board);
+            return isSquareAttackedBy(kingLocation, opponent(color), board);
+        } catch (IllegalStateException e) {
             return false;
         }
-        return isSquareAttackedBy(kingLocation, opponent(color), board);
     }
 
     public boolean hasLegalMovesForColor(PieceColor color) {
@@ -506,7 +507,7 @@ public class MoveGenerator {
                 }
             }
         }
-        return null;
+        throw new IllegalStateException("No king found for " + color);
     }
 
     private static PieceColor opponent(PieceColor color) {

--- a/src/main/java/ui/BoardController.java
+++ b/src/main/java/ui/BoardController.java
@@ -186,7 +186,7 @@ public class BoardController {
     }
 
     private PieceType promptForPromotionPiece(PieceColor color) {
-        return new PromotionDialog(mainView, color).showAndGetChoice();
+        return new PromotionView(mainView, color).showAndGetChoice();
     }
 
     private void showEndGame() {

--- a/src/main/java/ui/BoardController.java
+++ b/src/main/java/ui/BoardController.java
@@ -203,9 +203,7 @@ public class BoardController {
     }
 
     private void repaintBoardView() {
-        if (boardView != null) {
-            boardView.repaint();
-        }
+        boardView.repaint();
     }
 
     private static boolean isInBounds(Location loc) {

--- a/src/main/java/ui/BoardController.java
+++ b/src/main/java/ui/BoardController.java
@@ -43,9 +43,6 @@ public class BoardController {
     }
 
     private void updateCurrentPlayerLabel() {
-        if (mainView == null) {
-            return;
-        }
         String text;
         switch (board.getCurrentGameState()) {
             case WHITE_TURN:

--- a/src/main/java/ui/BoardView.java
+++ b/src/main/java/ui/BoardView.java
@@ -149,7 +149,8 @@ public class BoardView extends JPanel {
                         piece.getColor() == PieceColor.WHITE ? whitePieceImages : blackPieceImages;
                 Image img = images.get(piece.getType());
                 if (img == null) {
-                    throw new IllegalStateException("No image loaded for piece: " + piece.getType());
+                    throw new IllegalStateException(
+                            "No image loaded for piece: " + piece.getType());
                 }
                 int screenRow = rank;
                 g.drawImage(img, file * TILE_SIZE, screenRow * TILE_SIZE,

--- a/src/main/java/ui/BoardView.java
+++ b/src/main/java/ui/BoardView.java
@@ -129,7 +129,7 @@ public class BoardView extends JPanel {
         // untestable: I/O / resource loading
         java.net.URL resource = getClass().getClassLoader().getResource(imagePath);
         if (resource == null) {
-            return;
+            throw new IllegalStateException("Missing image resource: " + imagePath);
         }
         Image image = new javax.swing.ImageIcon(resource).getImage();
         if (color == PieceColor.WHITE) {
@@ -152,7 +152,7 @@ public class BoardView extends JPanel {
                         piece.getColor() == PieceColor.WHITE ? whitePieceImages : blackPieceImages;
                 Image img = images.get(piece.getType());
                 if (img == null) {
-                    continue;
+                    throw new IllegalStateException("No image loaded for piece: " + piece.getType());
                 }
                 int screenRow = rank;
                 g.drawImage(img, file * TILE_SIZE, screenRow * TILE_SIZE,

--- a/src/main/java/ui/BoardView.java
+++ b/src/main/java/ui/BoardView.java
@@ -128,9 +128,6 @@ public class BoardView extends JPanel {
     private void loadOnePieceImage(PieceType pieceType, PieceColor color, String imagePath) {
         // untestable: I/O / resource loading
         java.net.URL resource = getClass().getClassLoader().getResource(imagePath);
-        if (resource == null) {
-            throw new IllegalStateException("Missing image resource: " + imagePath);
-        }
         Image image = new javax.swing.ImageIcon(resource).getImage();
         if (color == PieceColor.WHITE) {
             whitePieceImages.put(pieceType, image);

--- a/src/main/java/ui/PromotionDialog.java
+++ b/src/main/java/ui/PromotionDialog.java
@@ -68,14 +68,8 @@ class PromotionDialog {
         button.setBorderPainted(false);
         button.setOpaque(true);
         Image img = loadImage(type);
-        if (img != null) {
-            button.setIcon(new ImageIcon(
-                    img.getScaledInstance(BUTTON_SIZE, BUTTON_SIZE, Image.SCALE_SMOOTH)));
-        } else {
-            button.setText(type.name().substring(0, 1));
-            button.setForeground(TEXT_COLOR);
-            button.setFont(LABEL_FONT);
-        }
+        button.setIcon(new ImageIcon(
+                img.getScaledInstance(BUTTON_SIZE, BUTTON_SIZE, Image.SCALE_SMOOTH)));
         button.addActionListener(e -> {
             chosenType = type;
             dialog.dispose();
@@ -89,7 +83,7 @@ class PromotionDialog {
         String path = "pieces/" + prefix + "_" + type.name().toLowerCase() + ".png";
         java.net.URL resource = getClass().getClassLoader().getResource(path);
         if (resource == null) {
-            return null;
+            throw new IllegalStateException("Missing image resource: " + path);
         }
         return new ImageIcon(resource).getImage();
     }

--- a/src/main/java/ui/PromotionView.java
+++ b/src/main/java/ui/PromotionView.java
@@ -82,9 +82,6 @@ class PromotionView {
         String prefix = (color == PieceColor.WHITE) ? "white" : "black";
         String path = "pieces/" + prefix + "_" + type.name().toLowerCase() + ".png";
         java.net.URL resource = getClass().getClassLoader().getResource(path);
-        if (resource == null) {
-            throw new IllegalStateException("Missing image resource: " + path);
-        }
         return new ImageIcon(resource).getImage();
     }
 }

--- a/src/main/java/ui/PromotionView.java
+++ b/src/main/java/ui/PromotionView.java
@@ -15,7 +15,7 @@ import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 
-class PromotionDialog {
+class PromotionView {
 
     private static final Color BACKGROUND = new Color(30, 20, 12);
     private static final Color BUTTON_BG = new Color(181, 136, 99);
@@ -27,7 +27,7 @@ class PromotionDialog {
     private final PieceColor color;
     private PieceType chosenType = PieceType.QUEEN;
 
-    PromotionDialog(JFrame parent, PieceColor color) {
+    PromotionView(JFrame parent, PieceColor color) {
         // untestable: creates JDialog (Swing/AWT component)
         this.color = color;
         this.dialog = new JDialog(parent, "Promote Pawn", true);

--- a/src/test/java/domain/piece/BishopTest.java
+++ b/src/test/java/domain/piece/BishopTest.java
@@ -3,6 +3,7 @@ package domain.piece;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
@@ -72,5 +73,12 @@ class BishopTest {
         Bishop bishop = new Bishop(PieceColor.BLACK);
 
         assertNotSame(bishop, bishop.makeCopy());
+    }
+
+    @Test
+    void MakeCopy_OnUnmovedWhiteBishop_CopyHasMovedIsFalse() {
+        Bishop bishop = new Bishop(PieceColor.WHITE);
+
+        assertFalse(bishop.makeCopy().hasMoved());
     }
 }

--- a/src/test/java/domain/piece/BishopTest.java
+++ b/src/test/java/domain/piece/BishopTest.java
@@ -81,4 +81,12 @@ class BishopTest {
 
         assertFalse(bishop.makeCopy().hasMoved());
     }
+
+    @Test
+    void MakeCopy_OnMovedWhiteBishop_CopyHasMovedIsTrue() {
+        Bishop bishop = new Bishop(PieceColor.WHITE);
+        bishop.changeToMoved();
+
+        assertTrue(bishop.makeCopy().hasMoved());
+    }
 }

--- a/src/test/java/domain/piece/KingTest.java
+++ b/src/test/java/domain/piece/KingTest.java
@@ -73,4 +73,11 @@ class KingTest {
 
         assertNotSame(king, king.makeCopy());
     }
+
+    @Test
+    void MakeCopy_OnUnmovedWhiteKing_CopyHasMovedIsFalse() {
+        King king = new King(PieceColor.WHITE);
+
+        assertFalse(king.makeCopy().hasMoved());
+    }
 }

--- a/src/test/java/domain/piece/KingTest.java
+++ b/src/test/java/domain/piece/KingTest.java
@@ -3,6 +3,7 @@ package domain.piece;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
@@ -79,5 +80,13 @@ class KingTest {
         King king = new King(PieceColor.WHITE);
 
         assertFalse(king.makeCopy().hasMoved());
+    }
+
+    @Test
+    void MakeCopy_OnMovedWhiteKing_CopyHasMovedIsTrue() {
+        King king = new King(PieceColor.WHITE);
+        king.changeToMoved();
+
+        assertTrue(king.makeCopy().hasMoved());
     }
 }

--- a/src/test/java/domain/piece/KnightTest.java
+++ b/src/test/java/domain/piece/KnightTest.java
@@ -1,6 +1,7 @@
 package domain.piece;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -77,5 +78,12 @@ class KnightTest {
         Knight knight = new Knight(PieceColor.BLACK);
 
         assertNotSame(knight, knight.makeCopy());
+    }
+
+    @Test
+    void MakeCopy_OnUnmovedWhiteKnight_CopyHasMovedIsFalse() {
+        Knight knight = new Knight(PieceColor.WHITE);
+
+        assertFalse(knight.makeCopy().hasMoved());
     }
 }

--- a/src/test/java/domain/piece/KnightTest.java
+++ b/src/test/java/domain/piece/KnightTest.java
@@ -86,4 +86,12 @@ class KnightTest {
 
         assertFalse(knight.makeCopy().hasMoved());
     }
+
+    @Test
+    void MakeCopy_OnMovedWhiteKnight_CopyHasMovedIsTrue() {
+        Knight knight = new Knight(PieceColor.WHITE);
+        knight.changeToMoved();
+
+        assertTrue(knight.makeCopy().hasMoved());
+    }
 }

--- a/src/test/java/domain/piece/PawnTest.java
+++ b/src/test/java/domain/piece/PawnTest.java
@@ -73,4 +73,11 @@ class PawnTest {
 
         assertNotSame(pawn, pawn.makeCopy());
     }
+
+    @Test
+    void MakeCopy_OnUnmovedWhitePawn_CopyHasMovedIsFalse() {
+        Pawn pawn = new Pawn(PieceColor.WHITE);
+
+        assertFalse(pawn.makeCopy().hasMoved());
+    }
 }

--- a/src/test/java/domain/piece/PawnTest.java
+++ b/src/test/java/domain/piece/PawnTest.java
@@ -3,6 +3,7 @@ package domain.piece;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
@@ -79,5 +80,13 @@ class PawnTest {
         Pawn pawn = new Pawn(PieceColor.WHITE);
 
         assertFalse(pawn.makeCopy().hasMoved());
+    }
+
+    @Test
+    void MakeCopy_OnMovedWhitePawn_CopyHasMovedIsTrue() {
+        Pawn pawn = new Pawn(PieceColor.WHITE);
+        pawn.changeToMoved();
+
+        assertTrue(pawn.makeCopy().hasMoved());
     }
 }

--- a/src/test/java/domain/piece/PieceTest.java
+++ b/src/test/java/domain/piece/PieceTest.java
@@ -1,5 +1,6 @@
 package domain.piece;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
@@ -12,5 +13,13 @@ class PieceTest {
         Piece piece2 = new Pawn(PieceColor.WHITE);
 
         assertTrue(piece1.isSameColor(piece2));
+    }
+
+    @Test
+    void IsSameColor_OnDifferentColorPieces_ReturnsFalse() {
+        Piece piece1 = new Pawn(PieceColor.WHITE);
+        Piece piece2 = new Pawn(PieceColor.BLACK);
+
+        assertFalse(piece1.isSameColor(piece2));
     }
 }

--- a/src/test/java/domain/piece/PieceTest.java
+++ b/src/test/java/domain/piece/PieceTest.java
@@ -1,5 +1,6 @@
 package domain.piece;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -40,6 +41,13 @@ class PieceTest {
         piece.resetHasMoved();
 
         assertFalse(piece.hasMoved());
+    }
+
+    @Test
+    void ToString_OnWhitePawn_ReturnsWhitePawn() {
+        Piece piece = new Pawn(PieceColor.WHITE);
+
+        assertEquals("WHITE PAWN", piece.toString());
     }
 
 }

--- a/src/test/java/domain/piece/PieceTest.java
+++ b/src/test/java/domain/piece/PieceTest.java
@@ -1,0 +1,16 @@
+package domain.piece;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class PieceTest {
+
+    @Test
+    void IsSameColor_OnSameColorPieces_ReturnsTrue() {
+        Piece piece1 = new Pawn(PieceColor.WHITE);
+        Piece piece2 = new Pawn(PieceColor.WHITE);
+
+        assertTrue(piece1.isSameColor(piece2));
+    }
+}

--- a/src/test/java/domain/piece/PieceTest.java
+++ b/src/test/java/domain/piece/PieceTest.java
@@ -50,4 +50,11 @@ class PieceTest {
         assertEquals("WHITE PAWN", piece.toString());
     }
 
+    @Test
+    void ToString_OnBlackPawn_ReturnsBlackPawn() {
+        Piece piece = new Pawn(PieceColor.BLACK);
+
+        assertEquals("BLACK PAWN", piece.toString());
+    }
+
 }

--- a/src/test/java/domain/piece/PieceTest.java
+++ b/src/test/java/domain/piece/PieceTest.java
@@ -22,4 +22,14 @@ class PieceTest {
 
         assertFalse(piece1.isSameColor(piece2));
     }
+
+    @Test
+    void ResetHasMoved_OnMovedPiece_HasMovedIsFalse() {
+        Piece piece = new Pawn(PieceColor.WHITE);
+        piece.changeToMoved();
+
+        piece.resetHasMoved();
+
+        assertFalse(piece.hasMoved());
+    }
 }

--- a/src/test/java/domain/piece/PieceTest.java
+++ b/src/test/java/domain/piece/PieceTest.java
@@ -32,4 +32,14 @@ class PieceTest {
 
         assertFalse(piece.hasMoved());
     }
+
+    @Test
+    void ResetHasMoved_OnUnmovedPiece_HasMovedIsFalse() {
+        Piece piece = new Pawn(PieceColor.WHITE);
+
+        piece.resetHasMoved();
+
+        assertFalse(piece.hasMoved());
+    }
+
 }

--- a/src/test/java/domain/piece/QueenTest.java
+++ b/src/test/java/domain/piece/QueenTest.java
@@ -81,4 +81,12 @@ class QueenTest {
 
         assertFalse(queen.makeCopy().hasMoved());
     }
+
+    @Test
+    void MakeCopy_OnMovedWhiteQueen_CopyHasMovedIsTrue() {
+        Queen queen = new Queen(PieceColor.WHITE);
+        queen.changeToMoved();
+
+        assertTrue(queen.makeCopy().hasMoved());
+    }
 }

--- a/src/test/java/domain/piece/QueenTest.java
+++ b/src/test/java/domain/piece/QueenTest.java
@@ -3,6 +3,7 @@ package domain.piece;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
@@ -72,5 +73,12 @@ class QueenTest {
         Queen queen = new Queen(PieceColor.BLACK);
 
         assertNotSame(queen, queen.makeCopy());
+    }
+
+    @Test
+    void MakeCopy_OnUnmovedWhiteQueen_CopyHasMovedIsFalse() {
+        Queen queen = new Queen(PieceColor.WHITE);
+
+        assertFalse(queen.makeCopy().hasMoved());
     }
 }

--- a/src/test/java/domain/piece/RookTest.java
+++ b/src/test/java/domain/piece/RookTest.java
@@ -81,4 +81,12 @@ class RookTest {
 
         assertFalse(rook.makeCopy().hasMoved());
     }
+
+    @Test
+    void MakeCopy_OnMovedWhiteRook_CopyHasMovedIsTrue() {
+        Rook rook = new Rook(PieceColor.WHITE);
+        rook.changeToMoved();
+
+        assertTrue(rook.makeCopy().hasMoved());
+    }
 }

--- a/src/test/java/domain/piece/RookTest.java
+++ b/src/test/java/domain/piece/RookTest.java
@@ -3,6 +3,7 @@ package domain.piece;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
@@ -72,5 +73,12 @@ class RookTest {
         Rook rook = new Rook(PieceColor.BLACK);
 
         assertNotSame(rook, rook.makeCopy());
+    }
+
+    @Test
+    void MakeCopy_OnUnmovedWhiteRook_CopyHasMovedIsFalse() {
+        Rook rook = new Rook(PieceColor.WHITE);
+
+        assertFalse(rook.makeCopy().hasMoved());
     }
 }

--- a/src/test/java/ui/BoardControllerTest.java
+++ b/src/test/java/ui/BoardControllerTest.java
@@ -1113,22 +1113,28 @@ class BoardControllerTest {
         Location destination = new Location(0, 5);
         Move move = new Move(selected, destination);
         Board boardMock = EasyMock.createMock(Board.class);
-        EasyMock.expect(boardMock.getCurrentGameState()).andReturn(GameState.WHITE_TURN).times(3);
+        final MainView mainViewMock = EasyMock.createMock(MainView.class);
+        final GameStatsView statsMock = EasyMock.createMock(GameStatsView.class);
+        EasyMock.expect(boardMock.getCurrentGameState()).andReturn(GameState.WHITE_TURN).times(4);
         EasyMock.expect(boardMock.getPieceAt(6, 0)).andReturn(standardGrid[6][0]);
         EasyMock.expect(boardMock.getPieceAt(5, 0)).andReturn(standardGrid[5][0]);
         EasyMock.expect(boardMock.getLegalMoves(selected)).andReturn(List.of(move));
         boardMock.makeMove(move);
         EasyMock.expectLastCall().once();
-        EasyMock.replay(boardMock);
+        EasyMock.expect(mainViewMock.getGameStatsView()).andReturn(statsMock);
+        statsMock.updateCurrentPlayerLabel(TEST_PLAYER_ONE);
+        EasyMock.expectLastCall().once();
+        EasyMock.replay(boardMock, mainViewMock, statsMock);
 
         BoardController controller = controllerFor(boardMock);
+        controller.setMainView(mainViewMock);
         controller.handleSquareClick(selected);
         controller.handleSquareClick(destination);
 
         boolean expected = false;
         boolean actual = controller.hasSelection();
         assertEquals(expected, actual);
-        EasyMock.verify(boardMock);
+        EasyMock.verify(boardMock, mainViewMock, statsMock);
     }
 
     @Test
@@ -1316,22 +1322,28 @@ class BoardControllerTest {
         Location destination = new Location(0, 2);
         Move move = new Move(selected, destination);
         Board boardMock = EasyMock.createMock(Board.class);
-        EasyMock.expect(boardMock.getCurrentGameState()).andReturn(GameState.BLACK_TURN).times(3);
+        final MainView mainViewMock = EasyMock.createMock(MainView.class);
+        final GameStatsView statsMock = EasyMock.createMock(GameStatsView.class);
+        EasyMock.expect(boardMock.getCurrentGameState()).andReturn(GameState.BLACK_TURN).times(4);
         EasyMock.expect(boardMock.getPieceAt(1, 0)).andReturn(standardGrid[1][0]);
         EasyMock.expect(boardMock.getPieceAt(2, 0)).andReturn(standardGrid[2][0]);
         EasyMock.expect(boardMock.getLegalMoves(selected)).andReturn(List.of(move));
         boardMock.makeMove(move);
         EasyMock.expectLastCall().once();
-        EasyMock.replay(boardMock);
+        EasyMock.expect(mainViewMock.getGameStatsView()).andReturn(statsMock);
+        statsMock.updateCurrentPlayerLabel(TEST_PLAYER_TWO);
+        EasyMock.expectLastCall().once();
+        EasyMock.replay(boardMock, mainViewMock, statsMock);
 
         BoardController controller = controllerFor(boardMock);
+        controller.setMainView(mainViewMock);
         controller.handleSquareClick(selected);
         controller.handleSquareClick(destination);
 
         boolean expected = false;
         boolean actual = controller.hasSelection();
         assertEquals(expected, actual);
-        EasyMock.verify(boardMock);
+        EasyMock.verify(boardMock, mainViewMock, statsMock);
     }
 
     @Test
@@ -1341,22 +1353,28 @@ class BoardControllerTest {
         Location destination = new Location(0, 5);
         Move promotionMove = new Move(selected, destination, MoveType.PROMOTION);
         Board boardMock = EasyMock.createMock(Board.class);
-        EasyMock.expect(boardMock.getCurrentGameState()).andReturn(GameState.WHITE_TURN).times(3);
+        final MainView mainViewMock = EasyMock.createMock(MainView.class);
+        final GameStatsView statsMock = EasyMock.createMock(GameStatsView.class);
+        EasyMock.expect(boardMock.getCurrentGameState()).andReturn(GameState.WHITE_TURN).times(4);
         EasyMock.expect(boardMock.getPieceAt(6, 0)).andReturn(standardGrid[6][0]);
         EasyMock.expect(boardMock.getPieceAt(5, 0)).andReturn(standardGrid[5][0]);
         EasyMock.expect(boardMock.getLegalMoves(selected)).andReturn(List.of(promotionMove));
         Capture<Move> capturedMove = EasyMock.newCapture();
         boardMock.makeMove(EasyMock.capture(capturedMove));
         EasyMock.expectLastCall().once();
-        EasyMock.replay(boardMock);
+        EasyMock.expect(mainViewMock.getGameStatsView()).andReturn(statsMock);
+        statsMock.updateCurrentPlayerLabel(TEST_PLAYER_ONE);
+        EasyMock.expectLastCall().once();
+        EasyMock.replay(boardMock, mainViewMock, statsMock);
 
         BoardController controller = controllerFor(boardMock);
+        controller.setMainView(mainViewMock);
         controller.setPromotionPicker(color -> PieceType.QUEEN);
         controller.handleSquareClick(selected);
         controller.handleSquareClick(destination);
 
         assertEquals(Optional.of(PieceType.QUEEN), capturedMove.getValue().getPromotionType());
-        EasyMock.verify(boardMock);
+        EasyMock.verify(boardMock, mainViewMock, statsMock);
     }
 
     @Test
@@ -1366,22 +1384,28 @@ class BoardControllerTest {
         Location destination = new Location(0, 2);
         Move promotionMove = new Move(selected, destination, MoveType.PROMOTION);
         Board boardMock = EasyMock.createMock(Board.class);
-        EasyMock.expect(boardMock.getCurrentGameState()).andReturn(GameState.BLACK_TURN).times(3);
+        final MainView mainViewMock = EasyMock.createMock(MainView.class);
+        final GameStatsView statsMock = EasyMock.createMock(GameStatsView.class);
+        EasyMock.expect(boardMock.getCurrentGameState()).andReturn(GameState.BLACK_TURN).times(4);
         EasyMock.expect(boardMock.getPieceAt(1, 0)).andReturn(standardGrid[1][0]);
         EasyMock.expect(boardMock.getPieceAt(2, 0)).andReturn(standardGrid[2][0]);
         EasyMock.expect(boardMock.getLegalMoves(selected)).andReturn(List.of(promotionMove));
         Capture<Move> capturedMove = EasyMock.newCapture();
         boardMock.makeMove(EasyMock.capture(capturedMove));
         EasyMock.expectLastCall().once();
-        EasyMock.replay(boardMock);
+        EasyMock.expect(mainViewMock.getGameStatsView()).andReturn(statsMock);
+        statsMock.updateCurrentPlayerLabel(TEST_PLAYER_TWO);
+        EasyMock.expectLastCall().once();
+        EasyMock.replay(boardMock, mainViewMock, statsMock);
 
         BoardController controller = controllerFor(boardMock);
+        controller.setMainView(mainViewMock);
         controller.setPromotionPicker(color -> PieceType.QUEEN);
         controller.handleSquareClick(selected);
         controller.handleSquareClick(destination);
 
         assertEquals(Optional.of(PieceType.QUEEN), capturedMove.getValue().getPromotionType());
-        EasyMock.verify(boardMock);
+        EasyMock.verify(boardMock, mainViewMock, statsMock);
     }
 
 }

--- a/src/test/java/ui/BoardControllerTest.java
+++ b/src/test/java/ui/BoardControllerTest.java
@@ -33,7 +33,7 @@ class BoardControllerTest {
 
     @Test
     void Constructor_FreshInstance_LastSelectedUnset() {
-        Board boardMock = replayNiceBoard();
+        Board boardMock = replayEmptyBoard();
         BoardController controller = controllerFor(boardMock);
 
         boolean expected = false;
@@ -44,7 +44,7 @@ class BoardControllerTest {
 
     @Test
     void GetSelectedLocation_FreshInstance_ReturnsEmpty() {
-        Board boardMock = replayNiceBoard();
+        Board boardMock = replayEmptyBoard();
         BoardController controller = controllerFor(boardMock);
 
         Optional<Location> expected = Optional.empty();
@@ -95,7 +95,7 @@ class BoardControllerTest {
 
     @Test
     void GetLegalMovesForSelection_NoSelection_ReturnsEmptyList() {
-        Board boardMock = replayNiceBoard();
+        Board boardMock = replayEmptyBoard();
         BoardController controller = controllerFor(boardMock);
 
         int expected = 0;
@@ -571,7 +571,7 @@ class BoardControllerTest {
 
     @Test
     void HandleSquareClick_InvalidLocation_NoSelectionAfterClick() {
-        Board boardMock = replayNiceBoard();
+        Board boardMock = replayEmptyBoard();
         BoardController controller = controllerFor(boardMock);
 
         controller.handleSquareClick(new Location(-1, 0));
@@ -838,8 +838,8 @@ class BoardControllerTest {
         return controller;
     }
 
-    private static Board replayNiceBoard() {
-        Board boardMock = EasyMock.createNiceMock(Board.class);
+    private static Board replayEmptyBoard() {
+        Board boardMock = EasyMock.createMock(Board.class);
         EasyMock.replay(boardMock);
         return boardMock;
     }

--- a/src/test/java/ui/BoardControllerTest.java
+++ b/src/test/java/ui/BoardControllerTest.java
@@ -829,7 +829,13 @@ class BoardControllerTest {
     }
 
     private static BoardController controllerFor(Board board) {
-        return new BoardController(TEST_PLAYER_ONE, TEST_PLAYER_TWO, board);
+        BoardController controller = new BoardController(TEST_PLAYER_ONE, TEST_PLAYER_TWO, board);
+        BoardView boardViewMock = EasyMock.createMock(BoardView.class);
+        boardViewMock.repaint();
+        EasyMock.expectLastCall().anyTimes();
+        EasyMock.replay(boardViewMock);
+        controller.setBoardView(boardViewMock);
+        return controller;
     }
 
     private static Board replayNiceBoard() {

--- a/src/test/java/ui/BoardControllerTest.java
+++ b/src/test/java/ui/BoardControllerTest.java
@@ -829,7 +829,8 @@ class BoardControllerTest {
     }
 
     private static BoardController controllerFor(Board board) {
-        BoardController controller = new BoardController(TEST_PLAYER_ONE, TEST_PLAYER_TWO, board);
+        final BoardController controller =
+                new BoardController(TEST_PLAYER_ONE, TEST_PLAYER_TWO, board);
         BoardView boardViewMock = EasyMock.createMock(BoardView.class);
         boardViewMock.repaint();
         EasyMock.expectLastCall().anyTimes();

--- a/src/test/java/ui/BoardViewTest.java
+++ b/src/test/java/ui/BoardViewTest.java
@@ -173,7 +173,7 @@ class BoardViewTest {
 
     @Test
     void Constructor_WithValidController_PreferredHeightIsBoardSizeTimesTileSize() {
-        BoardController mockController = EasyMock.createNiceMock(BoardController.class);
+        BoardController mockController = EasyMock.createMock(BoardController.class);
         EasyMock.replay(mockController);
         BoardView view = new BoardView(mockController);
 
@@ -186,7 +186,7 @@ class BoardViewTest {
 
     @Test
     void Constructor_WithValidController_PreferredWidthIsBoardSizeTimesTileSize() {
-        BoardController mockController = EasyMock.createNiceMock(BoardController.class);
+        BoardController mockController = EasyMock.createMock(BoardController.class);
         EasyMock.replay(mockController);
         BoardView view = new BoardView(mockController);
 
@@ -199,7 +199,7 @@ class BoardViewTest {
 
     @Test
     void Constructor_WithValidController_RegistersExactlyOneMouseListener() {
-        BoardController mockController = EasyMock.createNiceMock(BoardController.class);
+        BoardController mockController = EasyMock.createMock(BoardController.class);
         EasyMock.replay(mockController);
         BoardView view = new BoardView(mockController);
 

--- a/src/test/java/ui/MainViewTest.java
+++ b/src/test/java/ui/MainViewTest.java
@@ -30,7 +30,7 @@ class MainViewTest {
 
     @Test
     void Constructor_OnAliceAndBob_WiresStatsBoardAndLayout() {
-        Board boardMock = replayNiceBoard();
+        Board boardMock = replayEmptyBoard();
         MainView view = new MainView("Alice", "Bob",
                 new BoardController("Alice", "Bob", boardMock));
 
@@ -50,7 +50,7 @@ class MainViewTest {
 
     @Test
     void Constructor_InitialReadinessFromInjectedController() {
-        Board boardMock = EasyMock.createNiceMock(Board.class);
+        Board boardMock = EasyMock.createMock(Board.class);
         EasyMock.expect(boardMock.getCurrentGameState()).andReturn(GameState.WHITE_TURN);
         EasyMock.replay(boardMock);
         MainView view = new MainView("Alice", "Bob",
@@ -66,8 +66,8 @@ class MainViewTest {
         EasyMock.verify(boardMock);
     }
 
-    private static Board replayNiceBoard() {
-        Board boardMock = EasyMock.createNiceMock(Board.class);
+    private static Board replayEmptyBoard() {
+        Board boardMock = EasyMock.createMock(Board.class);
         EasyMock.replay(boardMock);
         return boardMock;
     }


### PR DESCRIPTION
Removes defensive null checks across MoveGenerator, MainView, BoardView, and PromotionView. Adds full unit test coverage for Piece: isSameColor, hasMoved/resetHasMoved, toString, and makeCopy across all piece types.