### PR TITLE
[TEST] MoveGenerator

### DIFF
--- a/docs/bva/MoveGenerator.md
+++ b/docs/bva/MoveGenerator.md
@@ -286,7 +286,7 @@ Scope: simulate a move on a deep copy for **check filtering**. Supports `NORMAL`
   - **Method(s) under test**: `applyMoveToBoard(Piece[][], Move)`
   - **State of the system**: white pawn `(4, 1)`; `PROMOTION` to `(4, 0)` with `PieceType.KNIGHT`
   - **Expected output**: returned board at `(4, 0)` has type `KNIGHT`
-- **MG-TC81: GenerateLegalMoves_OnUnmovedQueensideRookAtAFile_FindsRookAtFileZero** ( :white_check_mark: )
+- **MG-TC81: GenerateLegalMoves_OnUnmovedQueensideRookAtFileZero_FindsRookAtFileThree** ( :white_check_mark: )
   - **Method(s) under test**: `applyMoveToBoard(Piece[][], Move)` (via `findUnmovedRookFileIn`)
   - **State of the system**: white king `(4, 7)`, rook `(0, 7)`; `CASTLING_QUEENSIDE` to `(2, 7)`
   - **Expected output**: returned board at `(3, 7)` has type `ROOK`

--- a/docs/bva/MoveGenerator.md
+++ b/docs/bva/MoveGenerator.md
@@ -78,10 +78,26 @@ Scope: pseudo-legal moves for the piece at `from`, then check filtering (see che
   - **Method(s) under test**: `generateLegalMoves(Location)`
   - **State of the system**: `from` `(3, 3)` holds `NonePiece`
   - **Expected output**: returned move list size is `0`
+- **MG-TC53: GenerateLegalMoves_OnEmptySquare_ReturnsMutableEmptyList** ( :white_check_mark: )
+  - **Method(s) under test**: `generateLegalMoves(Location)`
+  - **State of the system**: `from` `(3, 3)` holds `NonePiece`
+  - **Expected output**: returned list accepts an added move (mutable `ArrayList`)
 - **MG-TC3: GenerateLegalMoves_OnKnightAtCenter_ReturnsEightMoves** ( :white_check_mark: )
   - **Method(s) under test**: `generateLegalMoves(Location)`
   - **State of the system**: white knight at `(4, 4)`; all other squares `NonePiece`
   - **Expected output**: returned move list size is `8`
+- **MG-TC70: GenerateLegalMoves_OnKnightAtCorner_ReturnsTwoMoves** ( :white_check_mark: )
+  - **Method(s) under test**: `generateLegalMoves(Location)` (via `generateKnightMoves`)
+  - **State of the system**: white knight at `(0, 0)`; board otherwise empty
+  - **Expected output**: returned move list size is `2`
+- **MG-TC71: GenerateLegalMoves_OnKnightAtCorner_IncludesDestinationOneTwo** ( :white_check_mark: )
+  - **Method(s) under test**: `generateLegalMoves(Location)` (via `generateKnightMoves`)
+  - **State of the system**: white knight at `(0, 0)`; board otherwise empty
+  - **Expected output**: returned moves include destination `(1, 2)`
+- **MG-TC54: GenerateLegalMoves_OnKnightBlockedByFriendly_ExcludesBlockedSquare** ( :white_check_mark: )
+  - **Method(s) under test**: `generateLegalMoves(Location)` (via `generateKnightMoves`)
+  - **State of the system**: white knight at `(4, 4)`; white pawn at `(5, 6)`
+  - **Expected output**: no returned move has destination `(5, 6)`
 - **MG-TC4: GenerateLegalMoves_OnBishopAtCenter_ReturnsThirteenMoves** ( :white_check_mark: )
   - **Method(s) under test**: `generateLegalMoves(Location)`
   - **State of the system**: white bishop at `(4, 4)`; all other squares `NonePiece`
@@ -90,6 +106,18 @@ Scope: pseudo-legal moves for the piece at `from`, then check filtering (see che
   - **Method(s) under test**: `generateLegalMoves(Location)`
   - **State of the system**: white rook at `(4, 4)`; all other squares `NonePiece`
   - **Expected output**: returned move list size is `14`
+- **MG-TC55: GenerateLegalMoves_OnRookBlockedByFriendly_ExcludesSquareBeyondFriendly** ( :white_check_mark: )
+  - **Method(s) under test**: `generateLegalMoves(Location)` (via `generateSlidingMoves`)
+  - **State of the system**: white rook at `(4, 4)`; white pawn at `(4, 6)`
+  - **Expected output**: no returned move has destination `(4, 6)` or `(4, 7)`
+- **MG-TC72: GenerateLegalMoves_OnRookFacingEnemy_IncludesCaptureDestination** ( :white_check_mark: )
+  - **Method(s) under test**: `generateLegalMoves(Location)` (via `generateSlidingMoves`)
+  - **State of the system**: white rook at `(4, 4)`; black rook at `(4, 6)`
+  - **Expected output**: returned moves include destination `(4, 6)`
+- **MG-TC73: GenerateLegalMoves_OnRookFacingEnemy_ReturnsThirteenMoves** ( :white_check_mark: )
+  - **Method(s) under test**: `generateLegalMoves(Location)` (via `generateSlidingMoves`)
+  - **State of the system**: white rook at `(4, 4)`; black rook at `(4, 6)`
+  - **Expected output**: returned move list size is `13`
 - **MG-TC6: GenerateLegalMoves_OnQueenAtCenter_ReturnsTwentySevenMoves** ( :white_check_mark: )
   - **Method(s) under test**: `generateLegalMoves(Location)`
   - **State of the system**: white queen at `(4, 4)`; all other squares `NonePiece`
@@ -98,9 +126,33 @@ Scope: pseudo-legal moves for the piece at `from`, then check filtering (see che
   - **Method(s) under test**: `generateLegalMoves(Location)`
   - **State of the system**: white king at `(4, 4)`; all other squares `NonePiece`
   - **Expected output**: returned move list size is `8`
+- **MG-TC56: GenerateLegalMoves_OnKingBlockedByFriendly_ExcludesFriendlySquare** ( :white_check_mark: )
+  - **Method(s) under test**: `generateLegalMoves(Location)` (via `generateKingMoves`)
+  - **State of the system**: white king at `(4, 4)`; white pawn at `(5, 5)`
+  - **Expected output**: no returned move has destination `(5, 5)`
+- **MG-TC69: GenerateLegalMoves_OnKingAtCenter_IncludesNorthEastDestination** ( :white_check_mark: )
+  - **Method(s) under test**: `generateLegalMoves(Location)` (via `generateKingMoves`)
+  - **State of the system**: white king at `(4, 4)`; board otherwise empty
+  - **Expected output**: returned moves include destination `(5, 3)`
+- **MG-TC74: GenerateLegalMoves_OnKingAtCenter_IncludesSouthWestDestination** ( :white_check_mark: )
+  - **Method(s) under test**: `generateLegalMoves(Location)` (via `generateKingMoves`)
+  - **State of the system**: white king at `(4, 4)`; board otherwise empty
+  - **Expected output**: returned moves include destination `(3, 5)`
 - **MG-TC8: GenerateLegalMoves_OnWhitePawnAtStart_ReturnsOneAndTwoStepMoves** ( :white_check_mark: )
   - **Method(s) under test**: `generateLegalMoves(Location)`
   - **State of the system**: white pawn at `(4, 6)`; squares `(4, 5)` and `(4, 4)` empty
+  - **Expected output**: returned move list size is `2`
+- **MG-TC61: GenerateLegalMoves_OnWhitePawnAtStart_IncludesTwoStepDestination** ( :white_check_mark: )
+  - **Method(s) under test**: `generateLegalMoves(Location)` (via `addPawnForwardMoves`)
+  - **State of the system**: white pawn at `(4, 6)`; squares ahead empty
+  - **Expected output**: returned moves include destination `(4, 4)`
+- **MG-TC62: GenerateLegalMoves_OnWhitePawnAtStartWithBlockerAtTwoAhead_ExcludesTwoStep** ( :white_check_mark: )
+  - **Method(s) under test**: `generateLegalMoves(Location)` (via `addPawnForwardMoves`)
+  - **State of the system**: white pawn at `(4, 6)`; blocker at `(4, 4)`; `(4, 5)` empty
+  - **Expected output**: no returned move has destination `(4, 4)`
+- **MG-TC67: GenerateLegalMoves_OnBlackPawnAtStart_ReturnsOneAndTwoStepMoves** ( :white_check_mark: )
+  - **Method(s) under test**: `generateLegalMoves(Location)` (via `generatePawnMoves`)
+  - **State of the system**: black pawn at `(4, 1)`; squares ahead empty
   - **Expected output**: returned move list size is `2`
 
 ---
@@ -222,6 +274,71 @@ Scope: simulate a move on a deep copy for **check filtering**. Supports `NORMAL`
   - **Method(s) under test**: `applyMoveToBoard(Piece[][], Move)`
   - **State of the system**: white pawn `(4, 1)`; `PROMOTION` to `(4, 0)` with `PieceType.QUEEN`
   - **Expected output**: returned board at `(4, 0)` has type `QUEEN`
+- **MG-TC64: ApplyMoveToBoard_OnPromotionRook_DestinationHasRook** ( :white_check_mark: )
+  - **Method(s) under test**: `applyMoveToBoard(Piece[][], Move)` (via `createPiece`)
+  - **State of the system**: white pawn `(4, 1)`; `PROMOTION` to `(4, 0)` with `PieceType.ROOK`
+  - **Expected output**: returned board at `(4, 0)` has type `ROOK`
+- **MG-TC65: ApplyMoveToBoard_OnPromotionBishop_DestinationHasBishop** ( :white_check_mark: )
+  - **Method(s) under test**: `applyMoveToBoard(Piece[][], Move)`
+  - **State of the system**: white pawn `(4, 1)`; `PROMOTION` to `(4, 0)` with `PieceType.BISHOP`
+  - **Expected output**: returned board at `(4, 0)` has type `BISHOP`
+- **MG-TC66: ApplyMoveToBoard_OnPromotionKnight_DestinationHasKnight** ( :white_check_mark: )
+  - **Method(s) under test**: `applyMoveToBoard(Piece[][], Move)`
+  - **State of the system**: white pawn `(4, 1)`; `PROMOTION` to `(4, 0)` with `PieceType.KNIGHT`
+  - **Expected output**: returned board at `(4, 0)` has type `KNIGHT`
+- **MG-TC81: GenerateLegalMoves_OnUnmovedQueensideRookAtAFile_FindsRookAtFileZero** ( :white_check_mark: )
+  - **Method(s) under test**: `applyMoveToBoard(Piece[][], Move)` (via `findUnmovedRookFileIn`)
+  - **State of the system**: white king `(4, 7)`, rook `(0, 7)`; `CASTLING_QUEENSIDE` to `(2, 7)`
+  - **Expected output**: returned board at `(3, 7)` has type `ROOK`
+
+---
+
+## Method: `createPiece(PieceType type, PieceColor color)` (package-private static)
+
+Scope: factory used by `applyMoveToBoard` for promotion pieces. Each `PieceType` maps to the corresponding piece class.
+
+### Step 1: Equivalence Classes
+
+- **Input: `type`** — ROOK, BISHOP, KNIGHT, PAWN, KING, NONE
+- **Output: piece type** — matches input type
+
+### Step 2: Data Types (from BVA Catalog)
+
+| Variable / output | Catalog data type |
+| ----------------- | ----------------- |
+| `type` | Cases |
+| Returned piece | Cases |
+
+### Step 3: Concrete boundary values
+
+- One TC per `PieceType` enum value
+
+### Step 4: Test Cases (Each-Choice Strategy)
+
+- **MG-TC47: CreatePiece_OnRookType_ReturnsRook** ( :white_check_mark: )
+  - **Method(s) under test**: `createPiece(PieceType, PieceColor)`
+  - **State of the system**: `PieceType.ROOK`, `PieceColor.WHITE`
+  - **Expected output**: returned piece type is `ROOK`
+- **MG-TC48: CreatePiece_OnBishopType_ReturnsBishop** ( :white_check_mark: )
+  - **Method(s) under test**: `createPiece(PieceType, PieceColor)`
+  - **State of the system**: `PieceType.BISHOP`, `PieceColor.WHITE`
+  - **Expected output**: returned piece type is `BISHOP`
+- **MG-TC49: CreatePiece_OnKnightType_ReturnsKnight** ( :white_check_mark: )
+  - **Method(s) under test**: `createPiece(PieceType, PieceColor)`
+  - **State of the system**: `PieceType.KNIGHT`, `PieceColor.WHITE`
+  - **Expected output**: returned piece type is `KNIGHT`
+- **MG-TC50: CreatePiece_OnPawnType_ReturnsPawn** ( :white_check_mark: )
+  - **Method(s) under test**: `createPiece(PieceType, PieceColor)`
+  - **State of the system**: `PieceType.PAWN`, `PieceColor.WHITE`
+  - **Expected output**: returned piece type is `PAWN`
+- **MG-TC51: CreatePiece_OnKingType_ReturnsKing** ( :white_check_mark: )
+  - **Method(s) under test**: `createPiece(PieceType, PieceColor)`
+  - **State of the system**: `PieceType.KING`, `PieceColor.WHITE`
+  - **Expected output**: returned piece type is `KING`
+- **MG-TC52: CreatePiece_OnNoneType_ReturnsNonePiece** ( :white_check_mark: )
+  - **Method(s) under test**: `createPiece(PieceType, PieceColor)`
+  - **State of the system**: `PieceType.NONE`, `PieceColor.WHITE`
+  - **Expected output**: returned piece type is `NONE`
 
 ---
 
@@ -378,12 +495,18 @@ Scope: aggregates `generateLegalMoves` for every piece of `color`, so check filt
 **King attack state — Cases:**
 
 - Attacked: white king `(4, 4)`; black rook `(4, 0)`; clear file between
+- Attacked by pawn: black king `(4, 4)`; white pawn `(3, 5)`
+- Attacked by knight: white king `(4, 4)`; black knight `(6, 5)` or `(2, 5)`
+- Attacked by bishop/queen slider: white king `(4, 4)`; black bishop `(0, 0)` or queen `(4, 0)`
+- Attacked by adjacent king: white king `(4, 4)`; black king `(5, 5)` or `(3, 3)`
+- Missing king: board with no white king
 - Not attacked: white king `(4, 4)`; black rook at `(0, 0)` (no attack line)
+- Near-miss: knight one square off L-shape; pawn one file off; king two squares away
 
 **Result — Boolean:**
 
-- `true` — king attacked on open file
-- `false` — king not attacked
+- `true` — king attacked on open file, by piece type, or adjacent king
+- `false` — king not attacked; no king for color
 
 ### Step 4: Test Cases (Each-Choice Strategy)
 
@@ -394,6 +517,54 @@ Scope: aggregates `generateLegalMoves` for every piece of `color`, so check filt
 - **MG-TC13: IsInCheck_WhenKingNotAttacked_ReturnsFalse** ( :white_check_mark: )
   - **Method(s) under test**: `isInCheck(PieceColor)`
   - **State of the system**: white king present; no black piece attacks it
+  - **Expected output**: `isInCheck(PieceColor.WHITE)` is `false`
+- **MG-TC41: IsInCheck_WhenNoKingForColor_ReturnsFalse** ( :white_check_mark: )
+  - **Method(s) under test**: `isInCheck(PieceColor)`
+  - **State of the system**: board with no white king
+  - **Expected output**: `isInCheck(PieceColor.WHITE)` is `false`
+- **MG-TC42: IsInCheck_WhenPawnAttacksKing_ReturnsTrue** ( :white_check_mark: )
+  - **Method(s) under test**: `isInCheck(PieceColor)` (via `isPawnAttacking`)
+  - **State of the system**: black king at `(4, 4)`; white pawn at `(3, 5)`
+  - **Expected output**: `isInCheck(PieceColor.BLACK)` is `true`
+- **MG-TC43: IsInCheck_WhenKnightAttacksKing_ReturnsTrue** ( :white_check_mark: )
+  - **Method(s) under test**: `isInCheck(PieceColor)` (via `isKnightAttacking`)
+  - **State of the system**: white king at `(4, 4)`; black knight at `(6, 5)`
+  - **Expected output**: `isInCheck(PieceColor.WHITE)` is `true`
+- **MG-TC44: IsInCheck_WhenBishopAttacksKing_ReturnsTrue** ( :white_check_mark: )
+  - **Method(s) under test**: `isInCheck(PieceColor)` (via `isSliderAttacking`)
+  - **State of the system**: white king at `(4, 4)`; black bishop at `(0, 0)`
+  - **Expected output**: `isInCheck(PieceColor.WHITE)` is `true`
+- **MG-TC45: IsInCheck_WhenQueenAttacksKing_ReturnsTrue** ( :white_check_mark: )
+  - **Method(s) under test**: `isInCheck(PieceColor)` (via `isSliderAttacking`)
+  - **State of the system**: white king at `(4, 4)`; black queen at `(4, 0)`
+  - **Expected output**: `isInCheck(PieceColor.WHITE)` is `true`
+- **MG-TC46: IsInCheck_WhenAdjacentEnemyKingAttacksKing_ReturnsTrue** ( :white_check_mark: )
+  - **Method(s) under test**: `isInCheck(PieceColor)` (via `isKingAttacking`)
+  - **State of the system**: white king at `(4, 4)`; black king at `(5, 5)`
+  - **Expected output**: `isInCheck(PieceColor.WHITE)` is `true`
+- **MG-TC75: IsInCheck_WhenKnightOnExactAttackSquare_ReturnsTrue** ( :white_check_mark: )
+  - **Method(s) under test**: `isInCheck(PieceColor)` (via `isKnightAttacking`)
+  - **State of the system**: white king at `(4, 4)`; black knight at `(2, 5)`
+  - **Expected output**: `isInCheck(PieceColor.WHITE)` is `true`
+- **MG-TC76: IsInCheck_WhenPawnOnExactAttackSquare_ReturnsTrue** ( :white_check_mark: )
+  - **Method(s) under test**: `isInCheck(PieceColor)` (via `isPawnAttacking`)
+  - **State of the system**: white king at `(3, 4)`; black pawn at `(2, 3)`
+  - **Expected output**: `isInCheck(PieceColor.WHITE)` is `true`
+- **MG-TC77: IsInCheck_WhenKingOnExactAdjacentSquare_ReturnsTrue** ( :white_check_mark: )
+  - **Method(s) under test**: `isInCheck(PieceColor)` (via `isKingAttacking`)
+  - **State of the system**: white king at `(4, 4)`; black king at `(3, 3)`
+  - **Expected output**: `isInCheck(PieceColor.WHITE)` is `true`
+- **MG-TC78: IsInCheck_WhenKnightOneSquareOffAttackLine_ReturnsFalse** ( :white_check_mark: )
+  - **Method(s) under test**: `isInCheck(PieceColor)` (via `isKnightAttacking`)
+  - **State of the system**: white king at `(4, 4)`; black knight at `(2, 6)` (not on L-shape)
+  - **Expected output**: `isInCheck(PieceColor.WHITE)` is `false`
+- **MG-TC79: IsInCheck_WhenPawnOneFileOffAttackLine_ReturnsFalse** ( :white_check_mark: )
+  - **Method(s) under test**: `isInCheck(PieceColor)` (via `isPawnAttacking`)
+  - **State of the system**: white king at `(3, 4)`; black pawn at `(2, 4)` (same file, not diagonal)
+  - **Expected output**: `isInCheck(PieceColor.WHITE)` is `false`
+- **MG-TC80: IsInCheck_WhenKingTwoSquaresAway_ReturnsFalse** ( :white_check_mark: )
+  - **Method(s) under test**: `isInCheck(PieceColor)` (via `isKingAttacking`)
+  - **State of the system**: white king at `(4, 4)`; black king at `(6, 6)`
   - **Expected output**: `isInCheck(PieceColor.WHITE)` is `false`
 
 ---
@@ -452,6 +623,10 @@ Scope: pseudo-legal **en passant** (via stored `enPassantTarget`) and **castling
   - **Method(s) under test**: `generateLegalMoves(Location)` (via `addEnPassantMoves`)
   - **State of the system**: white pawn at `(4, 3)`; `enPassantTarget` at `(5, 2)`
   - **Expected output**: returned moves include destination `(5, 2)` with `MoveType.EN_PASSANT`
+- **MG-TC68: GenerateLegalMoves_OnBlackPawnWithEnPassantTarget_IncludesEnPassantMove** ( :white_check_mark: )
+  - **Method(s) under test**: `generateLegalMoves(Location)` (via `addEnPassantMoves`)
+  - **State of the system**: black pawn at `(4, 4)`; `enPassantTarget` at `(3, 5)`
+  - **Expected output**: returned moves include destination `(3, 5)` with `MoveType.EN_PASSANT`
 - **MG-TC26: GenerateLegalMoves_OnWhitePawnWithoutEnPassantTarget_ExcludesEnPassantMove** ( :white_check_mark: )
   - **Method(s) under test**: `generateLegalMoves(Location)` (via `addEnPassantMoves`)
   - **State of the system**: white pawn at `(4, 3)`; `Optional.empty()` en-passant target
@@ -480,6 +655,30 @@ Scope: pseudo-legal **en passant** (via stored `enPassantTarget`) and **castling
   - **Method(s) under test**: `generateLegalMoves(Location)` (via `addEnPassantMoves`)
   - **State of the system**: white pawn at `(4, 3)`; `enPassantTarget` at `(5, 4)` (not on capture rank `2`)
   - **Expected output**: no returned move has `MoveType.EN_PASSANT`
+- **MG-TC60: GenerateLegalMoves_OnEnPassantTargetSameFile_ExcludesEnPassantMove** ( :white_check_mark: )
+  - **Method(s) under test**: `generateLegalMoves(Location)` (via `addEnPassantMoves`)
+  - **State of the system**: white pawn at `(4, 3)`; `enPassantTarget` at `(4, 2)` (same file)
+  - **Expected output**: no returned move has `MoveType.EN_PASSANT`
+- **MG-TC57: GenerateLegalMoves_OnKingsideCastlingWithBlockingPiece_ExcludesKingsideCastling** ( :white_check_mark: )
+  - **Method(s) under test**: `generateLegalMoves(Location)` (via `isPathClearForCastling`)
+  - **State of the system**: white king `(4, 7)`, rook `(7, 7)`; white bishop at `(5, 7)`
+  - **Expected output**: no returned move has `MoveType.CASTLING_KINGSIDE`
+- **MG-TC58: GenerateLegalMoves_OnQueensideCastlingWithBlockingPiece_ExcludesQueensideCastling** ( :white_check_mark: )
+  - **Method(s) under test**: `generateLegalMoves(Location)` (via `isPathClearForCastling`)
+  - **State of the system**: white king `(4, 7)`, rook `(0, 7)`; white knight at `(1, 7)`
+  - **Expected output**: no returned move has `MoveType.CASTLING_QUEENSIDE`
+- **MG-TC59: GenerateLegalMoves_OnMovedQueensideRook_ExcludesQueensideCastling** ( :white_check_mark: )
+  - **Method(s) under test**: `generateLegalMoves(Location)` (via `findUnmovedRookFileIn`)
+  - **State of the system**: white king `(4, 7)` unmoved; rook `(0, 7)` with `hasMoved() == true`
+  - **Expected output**: no returned move has `MoveType.CASTLING_QUEENSIDE`
+- **MG-TC82: GenerateLegalMoves_OnKingWithOnlyKingsideRook_ExcludesQueensideCastling** ( :white_check_mark: )
+  - **Method(s) under test**: `generateLegalMoves(Location)` (via `addCastlingMoves`)
+  - **State of the system**: white king `(4, 7)` and kingside rook `(7, 7)` only; no queenside rook
+  - **Expected output**: no returned move has `MoveType.CASTLING_QUEENSIDE`
+- **MG-TC83: GenerateLegalMoves_OnKingWithoutRooks_ExcludesAllCastling** ( :white_check_mark: )
+  - **Method(s) under test**: `generateLegalMoves(Location)` (via `addCastlingMoves`)
+  - **State of the system**: white king `(4, 7)` alone; no rooks on back rank
+  - **Expected output**: no returned move has `MoveType.CASTLING_KINGSIDE`
 
 ---
 
@@ -505,9 +704,9 @@ Scope: pseudo-legal **en passant** (via stored `enPassantTarget`) and **castling
 ### Step 3: Concrete boundary values
 
 - White promotion rank: 0. White pawn at rank 1 is one step from back rank.
-- Diagonal capture: enemy piece at (file±1, rank+direction).
+- Diagonal capture: enemy piece at (file±1, rank+direction); friendly diagonal skipped.
 - Capture-promotion: enemy piece at (file±1, promotionRank).
-- En passant: enPassantTarget set to (file±1, rank+direction).
+- Back rank with no captures: pawn already on rank 0 with no legal moves.
 
 ### Step 4: Test Cases (Each-Choice Strategy)
 
@@ -529,142 +728,40 @@ Scope: pseudo-legal **en passant** (via stored `enPassantTarget`) and **castling
   - **Method(s) under test**: `generateLegalMoves(Location)` (via `addPawnForwardMoves`, `addEnPassantMoves`)
   - **State of the system**: white pawn at `(4, 3)`; `enPassantTarget` at `(5, 2)`; square `(4, 2)` empty
   - **Expected output**: returned move list size is `2` (forward to `(4, 2)` + `EN_PASSANT` to `(5, 2)`)
-
----
-
-## Method: `isInCheck(PieceColor color)` — attack-type coverage
-
-Scope: `isSquareAttackedBy` paths for pawn, knight, bishop, queen, king; missing-king guard.
-
-### Step 4: Test Cases
-
-- **MG-TC41: IsInCheck_WhenNoKingForColor_ReturnsFalse** ( :white_check_mark: )
-  - **Method(s) under test**: `isInCheck(PieceColor)`
-  - **State of the system**: board with no white king
-  - **Expected output**: `isInCheck(PieceColor.WHITE)` is `false`
-- **MG-TC42: IsInCheck_WhenPawnAttacksKing_ReturnsTrue** ( :white_check_mark: )
-  - **Method(s) under test**: `isInCheck(PieceColor)` (via `isPawnAttacking`)
-  - **State of the system**: black king at `(4, 4)`; white pawn at `(3, 5)`
-  - **Expected output**: `isInCheck(PieceColor.BLACK)` is `true`
-- **MG-TC43: IsInCheck_WhenKnightAttacksKing_ReturnsTrue** ( :white_check_mark: )
-  - **Method(s) under test**: `isInCheck(PieceColor)` (via `isKnightAttacking`)
-  - **State of the system**: white king at `(4, 4)`; black knight at `(6, 5)`
-  - **Expected output**: `isInCheck(PieceColor.WHITE)` is `true`
-- **MG-TC44: IsInCheck_WhenBishopAttacksKing_ReturnsTrue** ( :white_check_mark: )
-  - **Method(s) under test**: `isInCheck(PieceColor)` (via `isSliderAttacking`)
-  - **State of the system**: white king at `(4, 4)`; black bishop at `(0, 0)`
-  - **Expected output**: `isInCheck(PieceColor.WHITE)` is `true`
-- **MG-TC45: IsInCheck_WhenQueenAttacksKing_ReturnsTrue** ( :white_check_mark: )
-  - **Method(s) under test**: `isInCheck(PieceColor)` (via `isSliderAttacking`)
-  - **State of the system**: white king at `(4, 4)`; black queen at `(4, 0)`
-  - **Expected output**: `isInCheck(PieceColor.WHITE)` is `true`
-- **MG-TC46: IsInCheck_WhenAdjacentEnemyKingAttacksKing_ReturnsTrue** ( :white_check_mark: )
-  - **Method(s) under test**: `isInCheck(PieceColor)` (via `isKingAttacking`)
-  - **State of the system**: white king at `(4, 4)`; black king at `(5, 5)`
-  - **Expected output**: `isInCheck(PieceColor.WHITE)` is `true`
-
----
-
-## Method: `createPiece(PieceType type, PieceColor color)` (package-private static)
-
-### Step 4: Test Cases
-
-- **MG-TC47: CreatePiece_OnRookType_ReturnsRook** ( :white_check_mark: )
-  - **Method(s) under test**: `createPiece(PieceType, PieceColor)`
-  - **State of the system**: `PieceType.ROOK`, `PieceColor.WHITE`
-  - **Expected output**: returned piece type is `ROOK`
-- **MG-TC48: CreatePiece_OnBishopType_ReturnsBishop** ( :white_check_mark: )
-  - **Method(s) under test**: `createPiece(PieceType, PieceColor)`
-  - **State of the system**: `PieceType.BISHOP`, `PieceColor.WHITE`
-  - **Expected output**: returned piece type is `BISHOP`
-- **MG-TC49: CreatePiece_OnKnightType_ReturnsKnight** ( :white_check_mark: )
-  - **Method(s) under test**: `createPiece(PieceType, PieceColor)`
-  - **State of the system**: `PieceType.KNIGHT`, `PieceColor.WHITE`
-  - **Expected output**: returned piece type is `KNIGHT`
-- **MG-TC50: CreatePiece_OnPawnType_ReturnsPawn** ( :white_check_mark: )
-  - **Method(s) under test**: `createPiece(PieceType, PieceColor)`
-  - **State of the system**: `PieceType.PAWN`, `PieceColor.WHITE`
-  - **Expected output**: returned piece type is `PAWN`
-- **MG-TC51: CreatePiece_OnKingType_ReturnsKing** ( :white_check_mark: )
-  - **Method(s) under test**: `createPiece(PieceType, PieceColor)`
-  - **State of the system**: `PieceType.KING`, `PieceColor.WHITE`
-  - **Expected output**: returned piece type is `KING`
-- **MG-TC52: CreatePiece_OnNoneType_ReturnsNonePiece** ( :white_check_mark: )
-  - **Method(s) under test**: `createPiece(PieceType, PieceColor)`
-  - **State of the system**: `PieceType.NONE`, `PieceColor.WHITE`
-  - **Expected output**: returned piece type is `NONE`
-
----
-
-## Method / behavior: friendly-piece blocking and castling path blockers
-
-### Step 4: Test Cases
-
-- **MG-TC53: GenerateLegalMoves_OnEmptySquare_ReturnsMutableEmptyList** ( :white_check_mark: )
-  - **Method(s) under test**: `generateLegalMoves(Location)`
-  - **State of the system**: `from` `(3, 3)` holds `NonePiece`
-  - **Expected output**: returned list accepts an added move (mutable `ArrayList`)
-- **MG-TC54: GenerateLegalMoves_OnKnightBlockedByFriendly_ExcludesBlockedSquare** ( :white_check_mark: )
-  - **Method(s) under test**: `generateLegalMoves(Location)` (via `generateKnightMoves`)
-  - **State of the system**: white knight at `(4, 4)`; white pawn at `(5, 6)`
-  - **Expected output**: no returned move has destination `(5, 6)`
-- **MG-TC55: GenerateLegalMoves_OnRookBlockedByFriendly_ExcludesSquareBeyondFriendly** ( :white_check_mark: )
-  - **Method(s) under test**: `generateLegalMoves(Location)` (via `generateSlidingMoves`)
-  - **State of the system**: white rook at `(4, 4)`; white pawn at `(4, 6)`
-  - **Expected output**: no returned move has destination `(4, 6)` or `(4, 7)`
-- **MG-TC56: GenerateLegalMoves_OnKingBlockedByFriendly_ExcludesFriendlySquare** ( :white_check_mark: )
-  - **Method(s) under test**: `generateLegalMoves(Location)` (via `generateKingMoves`)
-  - **State of the system**: white king at `(4, 4)`; white pawn at `(5, 5)`
-  - **Expected output**: no returned move has destination `(5, 5)`
-- **MG-TC57: GenerateLegalMoves_OnKingsideCastlingWithBlockingPiece_ExcludesKingsideCastling** ( :white_check_mark: )
-  - **Method(s) under test**: `generateLegalMoves(Location)` (via `isPathClearForCastling`)
-  - **State of the system**: white king `(4, 7)`, rook `(7, 7)`; white bishop at `(5, 7)`
-  - **Expected output**: no returned move has `MoveType.CASTLING_KINGSIDE`
-- **MG-TC58: GenerateLegalMoves_OnQueensideCastlingWithBlockingPiece_ExcludesQueensideCastling** ( :white_check_mark: )
-  - **Method(s) under test**: `generateLegalMoves(Location)` (via `isPathClearForCastling`)
-  - **State of the system**: white king `(4, 7)`, rook `(0, 7)`; white knight at `(1, 7)`
-  - **Expected output**: no returned move has `MoveType.CASTLING_QUEENSIDE`
-- **MG-TC59: GenerateLegalMoves_OnMovedQueensideRook_ExcludesQueensideCastling** ( :white_check_mark: )
-  - **Method(s) under test**: `generateLegalMoves(Location)` (via `findUnmovedRookFileIn`)
-  - **State of the system**: white king `(4, 7)` unmoved; rook `(0, 7)` with `hasMoved() == true`
-  - **Expected output**: no returned move has `MoveType.CASTLING_QUEENSIDE`
-- **MG-TC60: GenerateLegalMoves_OnEnPassantTargetSameFile_ExcludesEnPassantMove** ( :white_check_mark: )
-  - **Method(s) under test**: `generateLegalMoves(Location)` (via `addEnPassantMoves`)
-  - **State of the system**: white pawn at `(4, 3)`; `enPassantTarget` at `(4, 2)` (same file)
-  - **Expected output**: no returned move has `MoveType.EN_PASSANT`
-- **MG-TC61: GenerateLegalMoves_OnWhitePawnAtStart_IncludesTwoStepDestination** ( :white_check_mark: )
-  - **Method(s) under test**: `generateLegalMoves(Location)` (via `addPawnForwardMoves`)
-  - **State of the system**: white pawn at `(4, 6)`; squares ahead empty
-  - **Expected output**: returned moves include destination `(4, 4)`
-- **MG-TC62: GenerateLegalMoves_OnWhitePawnAtStartWithBlockerAtTwoAhead_ExcludesTwoStep** ( :white_check_mark: )
-  - **Method(s) under test**: `generateLegalMoves(Location)` (via `addPawnForwardMoves`)
-  - **State of the system**: white pawn at `(4, 6)`; blocker at `(4, 4)`; `(4, 5)` empty
-  - **Expected output**: no returned move has destination `(4, 4)`
 - **MG-TC63: GenerateLegalMoves_OnWhitePawnWithFriendlyDiagonal_SkipsDiagonalCapture** ( :white_check_mark: )
   - **Method(s) under test**: `generateLegalMoves(Location)` (via `addPawnCaptureMoves`)
   - **State of the system**: white pawn at `(4, 4)`; white pawn at `(5, 3)`; `(4, 3)` empty
   - **Expected output**: returned move list size is `1` (forward only)
-- **MG-TC64: ApplyMoveToBoard_OnPromotionRook_DestinationHasRook** ( :white_check_mark: )
-  - **Method(s) under test**: `applyMoveToBoard(Piece[][], Move)` (via `createPiece`)
-  - **State of the system**: white pawn `(4, 1)`; `PROMOTION` to `(4, 0)` with `PieceType.ROOK`
-  - **Expected output**: returned board at `(4, 0)` has type `ROOK`
-- **MG-TC65: ApplyMoveToBoard_OnPromotionBishop_DestinationHasBishop** ( :white_check_mark: )
-  - **Method(s) under test**: `applyMoveToBoard(Piece[][], Move)`
-  - **State of the system**: white pawn `(4, 1)`; `PROMOTION` to `(4, 0)` with `PieceType.BISHOP`
-  - **Expected output**: returned board at `(4, 0)` has type `BISHOP`
-- **MG-TC66: ApplyMoveToBoard_OnPromotionKnight_DestinationHasKnight** ( :white_check_mark: )
-  - **Method(s) under test**: `applyMoveToBoard(Piece[][], Move)`
-  - **State of the system**: white pawn `(4, 1)`; `PROMOTION` to `(4, 0)` with `PieceType.KNIGHT`
-  - **Expected output**: returned board at `(4, 0)` has type `KNIGHT`
-- **MG-TC67: GenerateLegalMoves_OnBlackPawnAtStart_ReturnsOneAndTwoStepMoves** ( :white_check_mark: )
-  - **Method(s) under test**: `generateLegalMoves(Location)` (via `generatePawnMoves`)
-  - **State of the system**: black pawn at `(4, 1)`; squares ahead empty
-  - **Expected output**: returned move list size is `2`
-- **MG-TC68: GenerateLegalMoves_OnBlackPawnWithEnPassantTarget_IncludesEnPassantMove** ( :white_check_mark: )
-  - **Method(s) under test**: `generateLegalMoves(Location)` (via `addEnPassantMoves`)
-  - **State of the system**: black pawn at `(4, 4)`; `enPassantTarget` at `(3, 5)`
-  - **Expected output**: returned moves include destination `(3, 5)` with `MoveType.EN_PASSANT`
-- **MG-TC69: GenerateLegalMoves_OnKingAtCenter_IncludesNorthEastDestination** ( :white_check_mark: )
-  - **Method(s) under test**: `generateLegalMoves(Location)` (via `generateKingMoves`)
-  - **State of the system**: white king at `(4, 4)`; board otherwise empty
+- **MG-TC84: GenerateLegalMoves_OnWhitePawnWithEnemyDiagonal_IncludesCaptureDestination** ( :white_check_mark: )
+  - **Method(s) under test**: `generateLegalMoves(Location)` (via `addPawnCaptureMoves`)
+  - **State of the system**: white pawn at `(4, 4)`; black rook at `(5, 3)`
   - **Expected output**: returned moves include destination `(5, 3)`
+- **MG-TC85: GenerateLegalMoves_OnWhitePawnWithLeftDiagonalEnemy_IncludesLeftCaptureOnly** ( :white_check_mark: )
+  - **Method(s) under test**: `generateLegalMoves(Location)` (via `addPawnCaptureMoves`)
+  - **State of the system**: white pawn at `(4, 4)`; black rook at `(3, 3)` only
+  - **Expected output**: returned moves include destination `(3, 3)`
+- **MG-TC86: GenerateLegalMoves_OnWhitePawnWithLeftDiagonalEnemy_ExcludesRightCapture** ( :white_check_mark: )
+  - **Method(s) under test**: `generateLegalMoves(Location)` (via `addPawnCaptureMoves`)
+  - **State of the system**: white pawn at `(4, 4)`; black rook at `(3, 3)` only
+  - **Expected output**: no returned move has destination `(5, 3)`
+- **MG-TC87: GenerateLegalMoves_OnWhitePawnAtBackRankWithNoCaptures_ReturnsEmptyList** ( :white_check_mark: )
+  - **Method(s) under test**: `generateLegalMoves(Location)` (via `generatePawnMoves`)
+  - **State of the system**: white pawn at `(4, 0)`; no diagonal enemies
+  - **Expected output**: returned move list size is `0`
+
+---
+
+## Method: `generatePseudoLegalMoves(Location from, Piece piece)` (private)
+
+Scope: fallback when `piece.getType()` is `NONE`; exercised via reflection in unit tests.
+
+### Step 4: Test Cases
+
+- **MG-TC88: GeneratePseudoLegalMoves_OnNonePiece_ReturnsEmptyList** ( :white_check_mark: )
+  - **Method(s) under test**: `generatePseudoLegalMoves(Location, Piece)` (via reflection)
+  - **State of the system**: `NonePiece` at `(3, 3)`
+  - **Expected output**: returned move list size is `0`
+- **MG-TC89: GeneratePseudoLegalMoves_OnNonePiece_ReturnsMutableEmptyList** ( :white_check_mark: )
+  - **Method(s) under test**: `generatePseudoLegalMoves(Location, Piece)` (via reflection)
+  - **State of the system**: `NonePiece` at `(3, 3)`
+  - **Expected output**: returned list accepts an added move (mutable `ArrayList`)

--- a/docs/bva/MoveGenerator.md
+++ b/docs/bva/MoveGenerator.md
@@ -529,3 +529,142 @@ Scope: pseudo-legal **en passant** (via stored `enPassantTarget`) and **castling
   - **Method(s) under test**: `generateLegalMoves(Location)` (via `addPawnForwardMoves`, `addEnPassantMoves`)
   - **State of the system**: white pawn at `(4, 3)`; `enPassantTarget` at `(5, 2)`; square `(4, 2)` empty
   - **Expected output**: returned move list size is `2` (forward to `(4, 2)` + `EN_PASSANT` to `(5, 2)`)
+
+---
+
+## Method: `isInCheck(PieceColor color)` — attack-type coverage
+
+Scope: `isSquareAttackedBy` paths for pawn, knight, bishop, queen, king; missing-king guard.
+
+### Step 4: Test Cases
+
+- **MG-TC41: IsInCheck_WhenNoKingForColor_ReturnsFalse** ( :white_check_mark: )
+  - **Method(s) under test**: `isInCheck(PieceColor)`
+  - **State of the system**: board with no white king
+  - **Expected output**: `isInCheck(PieceColor.WHITE)` is `false`
+- **MG-TC42: IsInCheck_WhenPawnAttacksKing_ReturnsTrue** ( :white_check_mark: )
+  - **Method(s) under test**: `isInCheck(PieceColor)` (via `isPawnAttacking`)
+  - **State of the system**: black king at `(4, 4)`; white pawn at `(3, 5)`
+  - **Expected output**: `isInCheck(PieceColor.BLACK)` is `true`
+- **MG-TC43: IsInCheck_WhenKnightAttacksKing_ReturnsTrue** ( :white_check_mark: )
+  - **Method(s) under test**: `isInCheck(PieceColor)` (via `isKnightAttacking`)
+  - **State of the system**: white king at `(4, 4)`; black knight at `(6, 5)`
+  - **Expected output**: `isInCheck(PieceColor.WHITE)` is `true`
+- **MG-TC44: IsInCheck_WhenBishopAttacksKing_ReturnsTrue** ( :white_check_mark: )
+  - **Method(s) under test**: `isInCheck(PieceColor)` (via `isSliderAttacking`)
+  - **State of the system**: white king at `(4, 4)`; black bishop at `(0, 0)`
+  - **Expected output**: `isInCheck(PieceColor.WHITE)` is `true`
+- **MG-TC45: IsInCheck_WhenQueenAttacksKing_ReturnsTrue** ( :white_check_mark: )
+  - **Method(s) under test**: `isInCheck(PieceColor)` (via `isSliderAttacking`)
+  - **State of the system**: white king at `(4, 4)`; black queen at `(4, 0)`
+  - **Expected output**: `isInCheck(PieceColor.WHITE)` is `true`
+- **MG-TC46: IsInCheck_WhenAdjacentEnemyKingAttacksKing_ReturnsTrue** ( :white_check_mark: )
+  - **Method(s) under test**: `isInCheck(PieceColor)` (via `isKingAttacking`)
+  - **State of the system**: white king at `(4, 4)`; black king at `(5, 5)`
+  - **Expected output**: `isInCheck(PieceColor.WHITE)` is `true`
+
+---
+
+## Method: `createPiece(PieceType type, PieceColor color)` (package-private static)
+
+### Step 4: Test Cases
+
+- **MG-TC47: CreatePiece_OnRookType_ReturnsRook** ( :white_check_mark: )
+  - **Method(s) under test**: `createPiece(PieceType, PieceColor)`
+  - **State of the system**: `PieceType.ROOK`, `PieceColor.WHITE`
+  - **Expected output**: returned piece type is `ROOK`
+- **MG-TC48: CreatePiece_OnBishopType_ReturnsBishop** ( :white_check_mark: )
+  - **Method(s) under test**: `createPiece(PieceType, PieceColor)`
+  - **State of the system**: `PieceType.BISHOP`, `PieceColor.WHITE`
+  - **Expected output**: returned piece type is `BISHOP`
+- **MG-TC49: CreatePiece_OnKnightType_ReturnsKnight** ( :white_check_mark: )
+  - **Method(s) under test**: `createPiece(PieceType, PieceColor)`
+  - **State of the system**: `PieceType.KNIGHT`, `PieceColor.WHITE`
+  - **Expected output**: returned piece type is `KNIGHT`
+- **MG-TC50: CreatePiece_OnPawnType_ReturnsPawn** ( :white_check_mark: )
+  - **Method(s) under test**: `createPiece(PieceType, PieceColor)`
+  - **State of the system**: `PieceType.PAWN`, `PieceColor.WHITE`
+  - **Expected output**: returned piece type is `PAWN`
+- **MG-TC51: CreatePiece_OnKingType_ReturnsKing** ( :white_check_mark: )
+  - **Method(s) under test**: `createPiece(PieceType, PieceColor)`
+  - **State of the system**: `PieceType.KING`, `PieceColor.WHITE`
+  - **Expected output**: returned piece type is `KING`
+- **MG-TC52: CreatePiece_OnNoneType_ReturnsNonePiece** ( :white_check_mark: )
+  - **Method(s) under test**: `createPiece(PieceType, PieceColor)`
+  - **State of the system**: `PieceType.NONE`, `PieceColor.WHITE`
+  - **Expected output**: returned piece type is `NONE`
+
+---
+
+## Method / behavior: friendly-piece blocking and castling path blockers
+
+### Step 4: Test Cases
+
+- **MG-TC53: GenerateLegalMoves_OnEmptySquare_ReturnsMutableEmptyList** ( :white_check_mark: )
+  - **Method(s) under test**: `generateLegalMoves(Location)`
+  - **State of the system**: `from` `(3, 3)` holds `NonePiece`
+  - **Expected output**: returned list accepts an added move (mutable `ArrayList`)
+- **MG-TC54: GenerateLegalMoves_OnKnightBlockedByFriendly_ExcludesBlockedSquare** ( :white_check_mark: )
+  - **Method(s) under test**: `generateLegalMoves(Location)` (via `generateKnightMoves`)
+  - **State of the system**: white knight at `(4, 4)`; white pawn at `(5, 6)`
+  - **Expected output**: no returned move has destination `(5, 6)`
+- **MG-TC55: GenerateLegalMoves_OnRookBlockedByFriendly_ExcludesSquareBeyondFriendly** ( :white_check_mark: )
+  - **Method(s) under test**: `generateLegalMoves(Location)` (via `generateSlidingMoves`)
+  - **State of the system**: white rook at `(4, 4)`; white pawn at `(4, 6)`
+  - **Expected output**: no returned move has destination `(4, 6)` or `(4, 7)`
+- **MG-TC56: GenerateLegalMoves_OnKingBlockedByFriendly_ExcludesFriendlySquare** ( :white_check_mark: )
+  - **Method(s) under test**: `generateLegalMoves(Location)` (via `generateKingMoves`)
+  - **State of the system**: white king at `(4, 4)`; white pawn at `(5, 5)`
+  - **Expected output**: no returned move has destination `(5, 5)`
+- **MG-TC57: GenerateLegalMoves_OnKingsideCastlingWithBlockingPiece_ExcludesKingsideCastling** ( :white_check_mark: )
+  - **Method(s) under test**: `generateLegalMoves(Location)` (via `isPathClearForCastling`)
+  - **State of the system**: white king `(4, 7)`, rook `(7, 7)`; white bishop at `(5, 7)`
+  - **Expected output**: no returned move has `MoveType.CASTLING_KINGSIDE`
+- **MG-TC58: GenerateLegalMoves_OnQueensideCastlingWithBlockingPiece_ExcludesQueensideCastling** ( :white_check_mark: )
+  - **Method(s) under test**: `generateLegalMoves(Location)` (via `isPathClearForCastling`)
+  - **State of the system**: white king `(4, 7)`, rook `(0, 7)`; white knight at `(1, 7)`
+  - **Expected output**: no returned move has `MoveType.CASTLING_QUEENSIDE`
+- **MG-TC59: GenerateLegalMoves_OnMovedQueensideRook_ExcludesQueensideCastling** ( :white_check_mark: )
+  - **Method(s) under test**: `generateLegalMoves(Location)` (via `findUnmovedRookFileIn`)
+  - **State of the system**: white king `(4, 7)` unmoved; rook `(0, 7)` with `hasMoved() == true`
+  - **Expected output**: no returned move has `MoveType.CASTLING_QUEENSIDE`
+- **MG-TC60: GenerateLegalMoves_OnEnPassantTargetSameFile_ExcludesEnPassantMove** ( :white_check_mark: )
+  - **Method(s) under test**: `generateLegalMoves(Location)` (via `addEnPassantMoves`)
+  - **State of the system**: white pawn at `(4, 3)`; `enPassantTarget` at `(4, 2)` (same file)
+  - **Expected output**: no returned move has `MoveType.EN_PASSANT`
+- **MG-TC61: GenerateLegalMoves_OnWhitePawnAtStart_IncludesTwoStepDestination** ( :white_check_mark: )
+  - **Method(s) under test**: `generateLegalMoves(Location)` (via `addPawnForwardMoves`)
+  - **State of the system**: white pawn at `(4, 6)`; squares ahead empty
+  - **Expected output**: returned moves include destination `(4, 4)`
+- **MG-TC62: GenerateLegalMoves_OnWhitePawnAtStartWithBlockerAtTwoAhead_ExcludesTwoStep** ( :white_check_mark: )
+  - **Method(s) under test**: `generateLegalMoves(Location)` (via `addPawnForwardMoves`)
+  - **State of the system**: white pawn at `(4, 6)`; blocker at `(4, 4)`; `(4, 5)` empty
+  - **Expected output**: no returned move has destination `(4, 4)`
+- **MG-TC63: GenerateLegalMoves_OnWhitePawnWithFriendlyDiagonal_SkipsDiagonalCapture** ( :white_check_mark: )
+  - **Method(s) under test**: `generateLegalMoves(Location)` (via `addPawnCaptureMoves`)
+  - **State of the system**: white pawn at `(4, 4)`; white pawn at `(5, 3)`; `(4, 3)` empty
+  - **Expected output**: returned move list size is `1` (forward only)
+- **MG-TC64: ApplyMoveToBoard_OnPromotionRook_DestinationHasRook** ( :white_check_mark: )
+  - **Method(s) under test**: `applyMoveToBoard(Piece[][], Move)` (via `createPiece`)
+  - **State of the system**: white pawn `(4, 1)`; `PROMOTION` to `(4, 0)` with `PieceType.ROOK`
+  - **Expected output**: returned board at `(4, 0)` has type `ROOK`
+- **MG-TC65: ApplyMoveToBoard_OnPromotionBishop_DestinationHasBishop** ( :white_check_mark: )
+  - **Method(s) under test**: `applyMoveToBoard(Piece[][], Move)`
+  - **State of the system**: white pawn `(4, 1)`; `PROMOTION` to `(4, 0)` with `PieceType.BISHOP`
+  - **Expected output**: returned board at `(4, 0)` has type `BISHOP`
+- **MG-TC66: ApplyMoveToBoard_OnPromotionKnight_DestinationHasKnight** ( :white_check_mark: )
+  - **Method(s) under test**: `applyMoveToBoard(Piece[][], Move)`
+  - **State of the system**: white pawn `(4, 1)`; `PROMOTION` to `(4, 0)` with `PieceType.KNIGHT`
+  - **Expected output**: returned board at `(4, 0)` has type `KNIGHT`
+- **MG-TC67: GenerateLegalMoves_OnBlackPawnAtStart_ReturnsOneAndTwoStepMoves** ( :white_check_mark: )
+  - **Method(s) under test**: `generateLegalMoves(Location)` (via `generatePawnMoves`)
+  - **State of the system**: black pawn at `(4, 1)`; squares ahead empty
+  - **Expected output**: returned move list size is `2`
+- **MG-TC68: GenerateLegalMoves_OnBlackPawnWithEnPassantTarget_IncludesEnPassantMove** ( :white_check_mark: )
+  - **Method(s) under test**: `generateLegalMoves(Location)` (via `addEnPassantMoves`)
+  - **State of the system**: black pawn at `(4, 4)`; `enPassantTarget` at `(3, 5)`
+  - **Expected output**: returned moves include destination `(3, 5)` with `MoveType.EN_PASSANT`
+- **MG-TC69: GenerateLegalMoves_OnKingAtCenter_IncludesNorthEastDestination** ( :white_check_mark: )
+  - **Method(s) under test**: `generateLegalMoves(Location)` (via `generateKingMoves`)
+  - **State of the system**: white king at `(4, 4)`; board otherwise empty
+  - **Expected output**: returned moves include destination `(5, 3)`

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -581,6 +581,19 @@ class MoveGeneratorTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void IsInCheck_WhenPawnAttacksKing_ReturnsTrue() {
+        Piece[][] board = emptyBoard();
+        board[4][4] = new King(PieceColor.BLACK);
+        board[5][3] = new Pawn(PieceColor.WHITE);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = true;
+        boolean actual = moveGenerator.isInCheck(PieceColor.BLACK);
+
+        assertEquals(expected, actual);
+    }
+
     private static boolean hasMoveToWithType(
             java.util.List<Move> moves, int file, int rank, MoveType type) {
         for (Move move : moves) {

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -952,6 +952,20 @@ class MoveGeneratorTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void GenerateLegalMoves_OnRookFacingEnemy_IncludesCaptureDestination() {
+        Piece[][] board = emptyBoard();
+        board[4][4] = new Rook(PieceColor.WHITE);
+        board[4][6] = new Rook(PieceColor.BLACK);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = true;
+        boolean actual = hasMoveTo(
+                moveGenerator.generateLegalMoves(new Location(4, 4)), 4, 6);
+
+        assertEquals(expected, actual);
+    }
+
     private static boolean hasMoveToWithType(
             java.util.List<Move> moves, int file, int rank, MoveType type) {
         for (Move move : moves) {

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -1162,6 +1162,19 @@ class MoveGeneratorTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void IsInCheck_WhenPawnOneFileOffAttackLine_ReturnsFalse() {
+        Piece[][] board = emptyBoard();
+        board[3][4] = new King(PieceColor.WHITE);
+        board[2][4] = new Pawn(PieceColor.BLACK);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = false;
+        boolean actual = moveGenerator.isInCheck(PieceColor.WHITE);
+
+        assertEquals(expected, actual);
+    }
+
     private static boolean hasMoveToWithType(
             java.util.List<Move> moves, int file, int rank, MoveType type) {
         for (Move move : moves) {

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -1149,6 +1149,19 @@ class MoveGeneratorTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void IsInCheck_WhenKnightOneSquareOffAttackLine_ReturnsFalse() {
+        Piece[][] board = emptyBoard();
+        board[4][4] = new King(PieceColor.WHITE);
+        board[2][6] = new Knight(PieceColor.BLACK);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = false;
+        boolean actual = moveGenerator.isInCheck(PieceColor.WHITE);
+
+        assertEquals(expected, actual);
+    }
+
     private static boolean hasMoveToWithType(
             java.util.List<Move> moves, int file, int rank, MoveType type) {
         for (Move move : moves) {

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -814,6 +814,19 @@ class MoveGeneratorTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void GenerateLegalMoves_OnWhitePawnAtStart_IncludesTwoStepDestination() {
+        Piece[][] board = emptyBoard();
+        board[6][4] = new Pawn(PieceColor.WHITE);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = true;
+        boolean actual = hasMoveTo(
+                moveGenerator.generateLegalMoves(new Location(4, 6)), 4, 4);
+
+        assertEquals(expected, actual);
+    }
+
     private static boolean hasMoveToWithType(
             java.util.List<Move> moves, int file, int rank, MoveType type) {
         for (Move move : moves) {

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -607,6 +607,19 @@ class MoveGeneratorTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void IsInCheck_WhenBishopAttacksKing_ReturnsTrue() {
+        Piece[][] board = emptyBoard();
+        board[4][4] = new King(PieceColor.WHITE);
+        board[0][0] = new Bishop(PieceColor.BLACK);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = true;
+        boolean actual = moveGenerator.isInCheck(PieceColor.WHITE);
+
+        assertEquals(expected, actual);
+    }
+
     private static boolean hasMoveToWithType(
             java.util.List<Move> moves, int file, int rank, MoveType type) {
         for (Move move : moves) {

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -46,6 +46,149 @@ class MoveGeneratorTest {
 
         assertEquals(expected, actual);
     }
+    @Test
+    void IsInCheck_WhenNoKingForColor_ReturnsFalse() {
+        Piece[][] board = emptyBoard();
+        board[4][4] = new Rook(PieceColor.WHITE);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = false;
+        boolean actual = moveGenerator.isInCheck(PieceColor.WHITE);
+
+        assertEquals(expected, actual);
+    }
+    @Test
+    void IsInCheck_WhenPawnAttacksKing_ReturnsTrue() {
+        Piece[][] board = emptyBoard();
+        board[4][4] = new King(PieceColor.BLACK);
+        board[5][3] = new Pawn(PieceColor.WHITE);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = true;
+        boolean actual = moveGenerator.isInCheck(PieceColor.BLACK);
+
+        assertEquals(expected, actual);
+    }
+    @Test
+    void IsInCheck_WhenKnightAttacksKing_ReturnsTrue() {
+        Piece[][] board = emptyBoard();
+        board[4][4] = new King(PieceColor.WHITE);
+        board[5][6] = new Knight(PieceColor.BLACK);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = true;
+        boolean actual = moveGenerator.isInCheck(PieceColor.WHITE);
+
+        assertEquals(expected, actual);
+    }
+    @Test
+    void IsInCheck_WhenBishopAttacksKing_ReturnsTrue() {
+        Piece[][] board = emptyBoard();
+        board[4][4] = new King(PieceColor.WHITE);
+        board[0][0] = new Bishop(PieceColor.BLACK);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = true;
+        boolean actual = moveGenerator.isInCheck(PieceColor.WHITE);
+
+        assertEquals(expected, actual);
+    }
+    @Test
+    void IsInCheck_WhenQueenAttacksKing_ReturnsTrue() {
+        Piece[][] board = emptyBoard();
+        board[4][4] = new King(PieceColor.WHITE);
+        board[0][4] = new Queen(PieceColor.BLACK);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = true;
+        boolean actual = moveGenerator.isInCheck(PieceColor.WHITE);
+
+        assertEquals(expected, actual);
+    }
+    @Test
+    void IsInCheck_WhenAdjacentEnemyKingAttacksKing_ReturnsTrue() {
+        Piece[][] board = emptyBoard();
+        board[4][4] = new King(PieceColor.WHITE);
+        board[5][5] = new King(PieceColor.BLACK);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = true;
+        boolean actual = moveGenerator.isInCheck(PieceColor.WHITE);
+
+        assertEquals(expected, actual);
+    }
+    @Test
+    void IsInCheck_WhenKnightOnExactAttackSquare_ReturnsTrue() {
+        Piece[][] board = emptyBoard();
+        board[4][4] = new King(PieceColor.WHITE);
+        board[2][5] = new Knight(PieceColor.BLACK);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = true;
+        boolean actual = moveGenerator.isInCheck(PieceColor.WHITE);
+
+        assertEquals(expected, actual);
+    }
+    @Test
+    void IsInCheck_WhenPawnOnExactAttackSquare_ReturnsTrue() {
+        Piece[][] board = emptyBoard();
+        board[3][4] = new King(PieceColor.WHITE);
+        board[2][3] = new Pawn(PieceColor.BLACK);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = true;
+        boolean actual = moveGenerator.isInCheck(PieceColor.WHITE);
+
+        assertEquals(expected, actual);
+    }
+    @Test
+    void IsInCheck_WhenKingOnExactAdjacentSquare_ReturnsTrue() {
+        Piece[][] board = emptyBoard();
+        board[4][4] = new King(PieceColor.WHITE);
+        board[3][3] = new King(PieceColor.BLACK);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = true;
+        boolean actual = moveGenerator.isInCheck(PieceColor.WHITE);
+
+        assertEquals(expected, actual);
+    }
+    @Test
+    void IsInCheck_WhenKnightOneSquareOffAttackLine_ReturnsFalse() {
+        Piece[][] board = emptyBoard();
+        board[4][4] = new King(PieceColor.WHITE);
+        board[2][6] = new Knight(PieceColor.BLACK);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = false;
+        boolean actual = moveGenerator.isInCheck(PieceColor.WHITE);
+
+        assertEquals(expected, actual);
+    }
+    @Test
+    void IsInCheck_WhenPawnOneFileOffAttackLine_ReturnsFalse() {
+        Piece[][] board = emptyBoard();
+        board[3][4] = new King(PieceColor.WHITE);
+        board[2][4] = new Pawn(PieceColor.BLACK);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = false;
+        boolean actual = moveGenerator.isInCheck(PieceColor.WHITE);
+
+        assertEquals(expected, actual);
+    }
+    @Test
+    void IsInCheck_WhenKingTwoSquaresAway_ReturnsFalse() {
+        Piece[][] board = emptyBoard();
+        board[4][4] = new King(PieceColor.WHITE);
+        board[6][6] = new King(PieceColor.BLACK);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = false;
+        boolean actual = moveGenerator.isInCheck(PieceColor.WHITE);
+
+        assertEquals(expected, actual);
+    }
 
     @Test
     void IsInCheck_WhenRookAttacksKing_ReturnsTrue() {
@@ -165,6 +308,42 @@ class MoveGeneratorTest {
 
         assertEquals(expected, actual);
     }
+    @Test
+    void GenerateLegalMoves_OnWhitePawnAtStart_IncludesTwoStepDestination() {
+        Piece[][] board = emptyBoard();
+        board[6][4] = new Pawn(PieceColor.WHITE);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = true;
+        boolean actual = hasMoveTo(
+                moveGenerator.generateLegalMoves(new Location(4, 6)), 4, 4);
+
+        assertEquals(expected, actual);
+    }
+    @Test
+    void GenerateLegalMoves_OnWhitePawnAtStartWithBlockerAtTwoAhead_ExcludesTwoStep() {
+        Piece[][] board = emptyBoard();
+        board[6][4] = new Pawn(PieceColor.WHITE);
+        board[4][4] = new Rook(PieceColor.BLACK);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = false;
+        boolean actual = hasMoveTo(
+                moveGenerator.generateLegalMoves(new Location(4, 6)), 4, 4);
+
+        assertEquals(expected, actual);
+    }
+    @Test
+    void GenerateLegalMoves_OnBlackPawnAtStart_ReturnsOneAndTwoStepMoves() {
+        Piece[][] board = emptyBoard();
+        board[1][4] = new Pawn(PieceColor.BLACK);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        int expected = 2;
+        int actual = moveGenerator.generateLegalMoves(new Location(4, 1)).size();
+
+        assertEquals(expected, actual);
+    }
 
     @Test
     void GenerateLegalMoves_OnKingAtCenter_ReturnsEightMoves() {
@@ -174,6 +353,43 @@ class MoveGeneratorTest {
 
         int expected = 8;
         int actual = moveGenerator.generateLegalMoves(new Location(4, 4)).size();
+
+        assertEquals(expected, actual);
+    }
+    @Test
+    void GenerateLegalMoves_OnKingBlockedByFriendly_ExcludesFriendlySquare() {
+        Piece[][] board = emptyBoard();
+        board[4][4] = new King(PieceColor.WHITE);
+        board[5][5] = new Pawn(PieceColor.WHITE);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = false;
+        boolean actual = hasMoveTo(
+                moveGenerator.generateLegalMoves(new Location(4, 4)), 5, 5);
+
+        assertEquals(expected, actual);
+    }
+    @Test
+    void GenerateLegalMoves_OnKingAtCenter_IncludesNorthEastDestination() {
+        Piece[][] board = emptyBoard();
+        board[4][4] = new King(PieceColor.WHITE);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = true;
+        boolean actual = hasMoveTo(
+                moveGenerator.generateLegalMoves(new Location(4, 4)), 5, 3);
+
+        assertEquals(expected, actual);
+    }
+    @Test
+    void GenerateLegalMoves_OnKingAtCenter_IncludesSouthWestDestination() {
+        Piece[][] board = emptyBoard();
+        board[4][4] = new King(PieceColor.WHITE);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = true;
+        boolean actual = hasMoveTo(
+                moveGenerator.generateLegalMoves(new Location(4, 4)), 3, 5);
 
         assertEquals(expected, actual);
     }
@@ -201,6 +417,44 @@ class MoveGeneratorTest {
 
         assertEquals(expected, actual);
     }
+    @Test
+    void GenerateLegalMoves_OnRookBlockedByFriendly_ExcludesSquareBeyondFriendly() {
+        Piece[][] board = emptyBoard();
+        board[4][4] = new Rook(PieceColor.WHITE);
+        board[6][4] = new Pawn(PieceColor.WHITE);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = false;
+        boolean actual = hasMoveTo(
+                moveGenerator.generateLegalMoves(new Location(4, 4)), 4, 7);
+
+        assertEquals(expected, actual);
+    }
+    @Test
+    void GenerateLegalMoves_OnRookFacingEnemy_IncludesCaptureDestination() {
+        Piece[][] board = emptyBoard();
+        board[4][4] = new Rook(PieceColor.WHITE);
+        board[4][6] = new Rook(PieceColor.BLACK);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = true;
+        boolean actual = hasMoveTo(
+                moveGenerator.generateLegalMoves(new Location(4, 4)), 4, 6);
+
+        assertEquals(expected, actual);
+    }
+    @Test
+    void GenerateLegalMoves_OnRookFacingEnemy_ReturnsThirteenMoves() {
+        Piece[][] board = emptyBoard();
+        board[4][4] = new Rook(PieceColor.WHITE);
+        board[4][6] = new Rook(PieceColor.BLACK);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        int expected = 13;
+        int actual = moveGenerator.generateLegalMoves(new Location(4, 4)).size();
+
+        assertEquals(expected, actual);
+    }
 
     @Test
     void GenerateLegalMoves_OnBishopAtCenter_ReturnsThirteenMoves() {
@@ -222,6 +476,42 @@ class MoveGeneratorTest {
 
         int expected = 8;
         int actual = moveGenerator.generateLegalMoves(new Location(4, 4)).size();
+
+        assertEquals(expected, actual);
+    }
+    @Test
+    void GenerateLegalMoves_OnKnightAtCorner_ReturnsTwoMoves() {
+        Piece[][] board = emptyBoard();
+        board[0][0] = new Knight(PieceColor.WHITE);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        int expected = 2;
+        int actual = moveGenerator.generateLegalMoves(new Location(0, 0)).size();
+
+        assertEquals(expected, actual);
+    }
+    @Test
+    void GenerateLegalMoves_OnKnightAtCorner_IncludesDestinationOneTwo() {
+        Piece[][] board = emptyBoard();
+        board[0][0] = new Knight(PieceColor.WHITE);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = true;
+        boolean actual = hasMoveTo(
+                moveGenerator.generateLegalMoves(new Location(0, 0)), 1, 2);
+
+        assertEquals(expected, actual);
+    }
+    @Test
+    void GenerateLegalMoves_OnKnightBlockedByFriendly_ExcludesBlockedSquare() {
+        Piece[][] board = emptyBoard();
+        board[4][4] = new Knight(PieceColor.WHITE);
+        board[6][5] = new Pawn(PieceColor.WHITE);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = false;
+        boolean actual = hasMoveTo(
+                moveGenerator.generateLegalMoves(new Location(4, 4)), 5, 6);
 
         assertEquals(expected, actual);
     }
@@ -315,6 +605,101 @@ class MoveGeneratorTest {
         PieceType actual = result[0][4].getType();
         assertEquals(expected, actual);
     }
+    @Test
+    void ApplyMoveToBoard_OnPromotionRook_DestinationHasRook() {
+        Piece[][] board = emptyBoard();
+        board[1][4] = new Pawn(PieceColor.WHITE);
+        Move move = new Move(
+                new Location(4, 1), new Location(4, 0), MoveType.PROMOTION, PieceType.ROOK);
+
+        Piece[][] result = MoveGenerator.applyMoveToBoard(board, move);
+
+        PieceType expected = PieceType.ROOK;
+        PieceType actual = result[0][4].getType();
+        assertEquals(expected, actual);
+    }
+    @Test
+    void ApplyMoveToBoard_OnPromotionBishop_DestinationHasBishop() {
+        Piece[][] board = emptyBoard();
+        board[1][4] = new Pawn(PieceColor.WHITE);
+        Move move = new Move(
+                new Location(4, 1), new Location(4, 0), MoveType.PROMOTION, PieceType.BISHOP);
+
+        Piece[][] result = MoveGenerator.applyMoveToBoard(board, move);
+
+        PieceType expected = PieceType.BISHOP;
+        PieceType actual = result[0][4].getType();
+        assertEquals(expected, actual);
+    }
+    @Test
+    void ApplyMoveToBoard_OnPromotionKnight_DestinationHasKnight() {
+        Piece[][] board = emptyBoard();
+        board[1][4] = new Pawn(PieceColor.WHITE);
+        Move move = new Move(
+                new Location(4, 1), new Location(4, 0), MoveType.PROMOTION, PieceType.KNIGHT);
+
+        Piece[][] result = MoveGenerator.applyMoveToBoard(board, move);
+
+        PieceType expected = PieceType.KNIGHT;
+        PieceType actual = result[0][4].getType();
+        assertEquals(expected, actual);
+    }
+    @Test
+    void GenerateLegalMoves_OnUnmovedQueensideRookAtAFile_FindsRookAtFileZero() {
+        Piece[][] board = emptyBoard();
+        board[7][4] = new King(PieceColor.WHITE);
+        board[7][0] = new Rook(PieceColor.WHITE);
+        Move move = new Move(
+                new Location(4, 7), new Location(2, 7), MoveType.CASTLING_QUEENSIDE);
+
+        Piece[][] result = MoveGenerator.applyMoveToBoard(board, move);
+
+        PieceType expected = PieceType.ROOK;
+        PieceType actual = result[7][3].getType();
+        assertEquals(expected, actual);
+    }
+    @Test
+    void CreatePiece_OnRookType_ReturnsRook() {
+        PieceType expected = PieceType.ROOK;
+        PieceType actual = MoveGenerator.createPiece(PieceType.ROOK, PieceColor.WHITE).getType();
+
+        assertEquals(expected, actual);
+    }
+    @Test
+    void CreatePiece_OnBishopType_ReturnsBishop() {
+        PieceType expected = PieceType.BISHOP;
+        PieceType actual = MoveGenerator.createPiece(PieceType.BISHOP, PieceColor.WHITE).getType();
+
+        assertEquals(expected, actual);
+    }
+    @Test
+    void CreatePiece_OnKnightType_ReturnsKnight() {
+        PieceType expected = PieceType.KNIGHT;
+        PieceType actual = MoveGenerator.createPiece(PieceType.KNIGHT, PieceColor.WHITE).getType();
+
+        assertEquals(expected, actual);
+    }
+    @Test
+    void CreatePiece_OnPawnType_ReturnsPawn() {
+        PieceType expected = PieceType.PAWN;
+        PieceType actual = MoveGenerator.createPiece(PieceType.PAWN, PieceColor.WHITE).getType();
+
+        assertEquals(expected, actual);
+    }
+    @Test
+    void CreatePiece_OnKingType_ReturnsKing() {
+        PieceType expected = PieceType.KING;
+        PieceType actual = MoveGenerator.createPiece(PieceType.KING, PieceColor.WHITE).getType();
+
+        assertEquals(expected, actual);
+    }
+    @Test
+    void CreatePiece_OnNoneType_ReturnsNonePiece() {
+        PieceType expected = PieceType.NONE;
+        PieceType actual = MoveGenerator.createPiece(PieceType.NONE, PieceColor.WHITE).getType();
+
+        assertEquals(expected, actual);
+    }
 
     @Test
     void ApplyMoveToBoard_OnQueensideCastling_RelocatesKingAndRook() {
@@ -391,6 +776,54 @@ class MoveGeneratorTest {
 
         assertEquals(expected, actual);
     }
+    @Test
+    void GenerateLegalMoves_OnEmptySquare_ReturnsMutableEmptyList() {
+        Piece[][] board = emptyBoard();
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        java.util.List<Move> moves = moveGenerator.generateLegalMoves(new Location(3, 3));
+        int sizeBefore = moves.size();
+        moves.add(new Move(new Location(0, 0), new Location(1, 1)));
+
+        int expected = sizeBefore + 1;
+        int actual = moves.size();
+
+        assertEquals(expected, actual);
+    }
+    @Test
+    void GeneratePseudoLegalMoves_OnNonePiece_ReturnsEmptyList() throws Exception {
+        Piece[][] board = emptyBoard();
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+        Method generatePseudoLegalMoves = MoveGenerator.class.getDeclaredMethod(
+                "generatePseudoLegalMoves", Location.class, Piece.class);
+        generatePseudoLegalMoves.setAccessible(true);
+
+        @SuppressWarnings("unchecked")
+        List<Move> moves = (List<Move>) generatePseudoLegalMoves.invoke(
+                moveGenerator, new Location(3, 3), new NonePiece());
+
+        int expected = 0;
+        int actual = moves.size();
+        assertEquals(expected, actual);
+    }
+    @Test
+    void GeneratePseudoLegalMoves_OnNonePiece_ReturnsMutableEmptyList() throws Exception {
+        Piece[][] board = emptyBoard();
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+        Method generatePseudoLegalMoves = MoveGenerator.class.getDeclaredMethod(
+                "generatePseudoLegalMoves", Location.class, Piece.class);
+        generatePseudoLegalMoves.setAccessible(true);
+
+        @SuppressWarnings("unchecked")
+        List<Move> moves = (List<Move>) generatePseudoLegalMoves.invoke(
+                moveGenerator, new Location(3, 3), new NonePiece());
+        int sizeBefore = moves.size();
+        moves.add(new Move(new Location(0, 0), new Location(1, 1)));
+
+        int expected = sizeBefore + 1;
+        int actual = moves.size();
+        assertEquals(expected, actual);
+    }
 
     @Test
     void GenerateLegalMoves_OnWhitePawnWithEnPassantTarget_IncludesEnPassantMove() {
@@ -446,6 +879,36 @@ class MoveGeneratorTest {
         boolean expected = false;
         boolean actual = hasMoveType(
                 moveGenerator.generateLegalMoves(new Location(4, 3)),
+                MoveType.EN_PASSANT);
+
+        assertEquals(expected, actual);
+    }
+    @Test
+    void GenerateLegalMoves_OnEnPassantTargetSameFile_ExcludesEnPassantMove() {
+        Piece[][] board = emptyBoard();
+        board[3][4] = new Pawn(PieceColor.WHITE);
+        MoveGenerator moveGenerator =
+                new MoveGenerator(board, Optional.of(new Location(4, 2)));
+
+        boolean expected = false;
+        boolean actual = hasMoveType(
+                moveGenerator.generateLegalMoves(new Location(4, 3)),
+                MoveType.EN_PASSANT);
+
+        assertEquals(expected, actual);
+    }
+    @Test
+    void GenerateLegalMoves_OnBlackPawnWithEnPassantTarget_IncludesEnPassantMove() {
+        Piece[][] board = emptyBoard();
+        board[4][4] = new Pawn(PieceColor.BLACK);
+        MoveGenerator moveGenerator =
+                new MoveGenerator(board, Optional.of(new Location(3, 5)));
+
+        boolean expected = true;
+        boolean actual = hasMoveToWithType(
+                moveGenerator.generateLegalMoves(new Location(4, 4)),
+                3,
+                5,
                 MoveType.EN_PASSANT);
 
         assertEquals(expected, actual);
@@ -516,6 +979,78 @@ class MoveGeneratorTest {
 
         assertEquals(expected, actual);
     }
+    @Test
+    void GenerateLegalMoves_OnKingsideCastlingWithBlockingPiece_ExcludesKingsideCastling() {
+        Piece[][] board = emptyBoard();
+        board[7][4] = new King(PieceColor.WHITE);
+        board[7][7] = new Rook(PieceColor.WHITE);
+        board[7][5] = new Bishop(PieceColor.WHITE);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = false;
+        boolean actual = hasMoveType(
+                moveGenerator.generateLegalMoves(new Location(4, 7)),
+                MoveType.CASTLING_KINGSIDE);
+
+        assertEquals(expected, actual);
+    }
+    @Test
+    void GenerateLegalMoves_OnQueensideCastlingWithBlockingPiece_ExcludesQueensideCastling() {
+        Piece[][] board = emptyBoard();
+        board[7][4] = new King(PieceColor.WHITE);
+        board[7][0] = new Rook(PieceColor.WHITE);
+        board[7][1] = new Knight(PieceColor.WHITE);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = false;
+        boolean actual = hasMoveType(
+                moveGenerator.generateLegalMoves(new Location(4, 7)),
+                MoveType.CASTLING_QUEENSIDE);
+
+        assertEquals(expected, actual);
+    }
+    @Test
+    void GenerateLegalMoves_OnMovedQueensideRook_ExcludesQueensideCastling() {
+        Piece[][] board = emptyBoard();
+        board[7][4] = new King(PieceColor.WHITE);
+        board[7][0] = new Rook(PieceColor.WHITE);
+        board[7][0].changeToMoved();
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = false;
+        boolean actual = hasMoveType(
+                moveGenerator.generateLegalMoves(new Location(4, 7)),
+                MoveType.CASTLING_QUEENSIDE);
+
+        assertEquals(expected, actual);
+    }
+    @Test
+    void GenerateLegalMoves_OnKingWithOnlyKingsideRook_ExcludesQueensideCastling() {
+        Piece[][] board = emptyBoard();
+        board[7][4] = new King(PieceColor.WHITE);
+        board[7][7] = new Rook(PieceColor.WHITE);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = false;
+        boolean actual = hasMoveType(
+                moveGenerator.generateLegalMoves(new Location(4, 7)),
+                MoveType.CASTLING_QUEENSIDE);
+
+        assertEquals(expected, actual);
+    }
+    @Test
+    void GenerateLegalMoves_OnKingWithoutRooks_ExcludesAllCastling() {
+        Piece[][] board = emptyBoard();
+        board[7][4] = new King(PieceColor.WHITE);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = false;
+        boolean actual = hasMoveType(
+                moveGenerator.generateLegalMoves(new Location(4, 7)),
+                MoveType.CASTLING_KINGSIDE);
+
+        assertEquals(expected, actual);
+    }
 
     @Test
     void GenerateLegalMoves_OnKingsidePathSquareUnderAttack_ExcludesKingsideCastling() {
@@ -545,6 +1080,68 @@ class MoveGeneratorTest {
 
         assertEquals(expected, actual);
     }
+    @Test
+    void GenerateLegalMoves_OnWhitePawnWithFriendlyDiagonal_SkipsDiagonalCapture() {
+        Piece[][] board = emptyBoard();
+        board[4][4] = new Pawn(PieceColor.WHITE);
+        board[3][5] = new Pawn(PieceColor.WHITE);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        int expected = 1;
+        int actual = moveGenerator.generateLegalMoves(new Location(4, 4)).size();
+
+        assertEquals(expected, actual);
+    }
+    @Test
+    void GenerateLegalMoves_OnWhitePawnWithEnemyDiagonal_IncludesCaptureDestination() {
+        Piece[][] board = emptyBoard();
+        board[4][4] = new Pawn(PieceColor.WHITE);
+        board[3][5] = new Rook(PieceColor.BLACK);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = true;
+        boolean actual = hasMoveTo(
+                moveGenerator.generateLegalMoves(new Location(4, 4)), 5, 3);
+
+        assertEquals(expected, actual);
+    }
+    @Test
+    void GenerateLegalMoves_OnWhitePawnWithLeftDiagonalEnemy_IncludesLeftCaptureOnly() {
+        Piece[][] board = emptyBoard();
+        board[4][4] = new Pawn(PieceColor.WHITE);
+        board[3][3] = new Rook(PieceColor.BLACK);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = true;
+        boolean actual = hasMoveTo(
+                moveGenerator.generateLegalMoves(new Location(4, 4)), 3, 3);
+
+        assertEquals(expected, actual);
+    }
+    @Test
+    void GenerateLegalMoves_OnWhitePawnWithLeftDiagonalEnemy_ExcludesRightCapture() {
+        Piece[][] board = emptyBoard();
+        board[4][4] = new Pawn(PieceColor.WHITE);
+        board[3][3] = new Rook(PieceColor.BLACK);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = false;
+        boolean actual = hasMoveTo(
+                moveGenerator.generateLegalMoves(new Location(4, 4)), 5, 3);
+
+        assertEquals(expected, actual);
+    }
+    @Test
+    void GenerateLegalMoves_OnWhitePawnAtBackRankWithNoCaptures_ReturnsEmptyList() {
+        Piece[][] board = emptyBoard();
+        board[0][4] = new Pawn(PieceColor.WHITE);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        int expected = 0;
+        int actual = moveGenerator.generateLegalMoves(new Location(4, 0)).size();
+
+        assertEquals(expected, actual);
+    }
 
     @Test
     void GenerateLegalMoves_OnWhitePawnOneStepFromBackRank_ReturnsFourMoves() {
@@ -568,652 +1165,6 @@ class MoveGeneratorTest {
         int expected = 2;
         int actual = moveGenerator.generateLegalMoves(new Location(4, 3)).size();
 
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void IsInCheck_WhenNoKingForColor_ReturnsFalse() {
-        Piece[][] board = emptyBoard();
-        board[4][4] = new Rook(PieceColor.WHITE);
-        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
-
-        boolean expected = false;
-        boolean actual = moveGenerator.isInCheck(PieceColor.WHITE);
-
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void IsInCheck_WhenPawnAttacksKing_ReturnsTrue() {
-        Piece[][] board = emptyBoard();
-        board[4][4] = new King(PieceColor.BLACK);
-        board[5][3] = new Pawn(PieceColor.WHITE);
-        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
-
-        boolean expected = true;
-        boolean actual = moveGenerator.isInCheck(PieceColor.BLACK);
-
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void IsInCheck_WhenKnightAttacksKing_ReturnsTrue() {
-        Piece[][] board = emptyBoard();
-        board[4][4] = new King(PieceColor.WHITE);
-        board[5][6] = new Knight(PieceColor.BLACK);
-        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
-
-        boolean expected = true;
-        boolean actual = moveGenerator.isInCheck(PieceColor.WHITE);
-
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void IsInCheck_WhenBishopAttacksKing_ReturnsTrue() {
-        Piece[][] board = emptyBoard();
-        board[4][4] = new King(PieceColor.WHITE);
-        board[0][0] = new Bishop(PieceColor.BLACK);
-        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
-
-        boolean expected = true;
-        boolean actual = moveGenerator.isInCheck(PieceColor.WHITE);
-
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void IsInCheck_WhenQueenAttacksKing_ReturnsTrue() {
-        Piece[][] board = emptyBoard();
-        board[4][4] = new King(PieceColor.WHITE);
-        board[0][4] = new Queen(PieceColor.BLACK);
-        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
-
-        boolean expected = true;
-        boolean actual = moveGenerator.isInCheck(PieceColor.WHITE);
-
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void IsInCheck_WhenAdjacentEnemyKingAttacksKing_ReturnsTrue() {
-        Piece[][] board = emptyBoard();
-        board[4][4] = new King(PieceColor.WHITE);
-        board[5][5] = new King(PieceColor.BLACK);
-        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
-
-        boolean expected = true;
-        boolean actual = moveGenerator.isInCheck(PieceColor.WHITE);
-
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void CreatePiece_OnRookType_ReturnsRook() {
-        PieceType expected = PieceType.ROOK;
-        PieceType actual = MoveGenerator.createPiece(PieceType.ROOK, PieceColor.WHITE).getType();
-
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void CreatePiece_OnBishopType_ReturnsBishop() {
-        PieceType expected = PieceType.BISHOP;
-        PieceType actual = MoveGenerator.createPiece(PieceType.BISHOP, PieceColor.WHITE).getType();
-
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void CreatePiece_OnKnightType_ReturnsKnight() {
-        PieceType expected = PieceType.KNIGHT;
-        PieceType actual = MoveGenerator.createPiece(PieceType.KNIGHT, PieceColor.WHITE).getType();
-
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void CreatePiece_OnPawnType_ReturnsPawn() {
-        PieceType expected = PieceType.PAWN;
-        PieceType actual = MoveGenerator.createPiece(PieceType.PAWN, PieceColor.WHITE).getType();
-
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void CreatePiece_OnKingType_ReturnsKing() {
-        PieceType expected = PieceType.KING;
-        PieceType actual = MoveGenerator.createPiece(PieceType.KING, PieceColor.WHITE).getType();
-
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void CreatePiece_OnNoneType_ReturnsNonePiece() {
-        PieceType expected = PieceType.NONE;
-        PieceType actual = MoveGenerator.createPiece(PieceType.NONE, PieceColor.WHITE).getType();
-
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void GenerateLegalMoves_OnEmptySquare_ReturnsMutableEmptyList() {
-        Piece[][] board = emptyBoard();
-        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
-
-        java.util.List<Move> moves = moveGenerator.generateLegalMoves(new Location(3, 3));
-        int sizeBefore = moves.size();
-        moves.add(new Move(new Location(0, 0), new Location(1, 1)));
-
-        int expected = sizeBefore + 1;
-        int actual = moves.size();
-
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void GenerateLegalMoves_OnKnightBlockedByFriendly_ExcludesBlockedSquare() {
-        Piece[][] board = emptyBoard();
-        board[4][4] = new Knight(PieceColor.WHITE);
-        board[6][5] = new Pawn(PieceColor.WHITE);
-        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
-
-        boolean expected = false;
-        boolean actual = hasMoveTo(
-                moveGenerator.generateLegalMoves(new Location(4, 4)), 5, 6);
-
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void GenerateLegalMoves_OnRookBlockedByFriendly_ExcludesSquareBeyondFriendly() {
-        Piece[][] board = emptyBoard();
-        board[4][4] = new Rook(PieceColor.WHITE);
-        board[6][4] = new Pawn(PieceColor.WHITE);
-        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
-
-        boolean expected = false;
-        boolean actual = hasMoveTo(
-                moveGenerator.generateLegalMoves(new Location(4, 4)), 4, 7);
-
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void GenerateLegalMoves_OnKingBlockedByFriendly_ExcludesFriendlySquare() {
-        Piece[][] board = emptyBoard();
-        board[4][4] = new King(PieceColor.WHITE);
-        board[5][5] = new Pawn(PieceColor.WHITE);
-        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
-
-        boolean expected = false;
-        boolean actual = hasMoveTo(
-                moveGenerator.generateLegalMoves(new Location(4, 4)), 5, 5);
-
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void GenerateLegalMoves_OnKingsideCastlingWithBlockingPiece_ExcludesKingsideCastling() {
-        Piece[][] board = emptyBoard();
-        board[7][4] = new King(PieceColor.WHITE);
-        board[7][7] = new Rook(PieceColor.WHITE);
-        board[7][5] = new Bishop(PieceColor.WHITE);
-        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
-
-        boolean expected = false;
-        boolean actual = hasMoveType(
-                moveGenerator.generateLegalMoves(new Location(4, 7)),
-                MoveType.CASTLING_KINGSIDE);
-
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void GenerateLegalMoves_OnQueensideCastlingWithBlockingPiece_ExcludesQueensideCastling() {
-        Piece[][] board = emptyBoard();
-        board[7][4] = new King(PieceColor.WHITE);
-        board[7][0] = new Rook(PieceColor.WHITE);
-        board[7][1] = new Knight(PieceColor.WHITE);
-        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
-
-        boolean expected = false;
-        boolean actual = hasMoveType(
-                moveGenerator.generateLegalMoves(new Location(4, 7)),
-                MoveType.CASTLING_QUEENSIDE);
-
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void GenerateLegalMoves_OnMovedQueensideRook_ExcludesQueensideCastling() {
-        Piece[][] board = emptyBoard();
-        board[7][4] = new King(PieceColor.WHITE);
-        board[7][0] = new Rook(PieceColor.WHITE);
-        board[7][0].changeToMoved();
-        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
-
-        boolean expected = false;
-        boolean actual = hasMoveType(
-                moveGenerator.generateLegalMoves(new Location(4, 7)),
-                MoveType.CASTLING_QUEENSIDE);
-
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void GenerateLegalMoves_OnEnPassantTargetSameFile_ExcludesEnPassantMove() {
-        Piece[][] board = emptyBoard();
-        board[3][4] = new Pawn(PieceColor.WHITE);
-        MoveGenerator moveGenerator =
-                new MoveGenerator(board, Optional.of(new Location(4, 2)));
-
-        boolean expected = false;
-        boolean actual = hasMoveType(
-                moveGenerator.generateLegalMoves(new Location(4, 3)),
-                MoveType.EN_PASSANT);
-
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void GenerateLegalMoves_OnWhitePawnAtStart_IncludesTwoStepDestination() {
-        Piece[][] board = emptyBoard();
-        board[6][4] = new Pawn(PieceColor.WHITE);
-        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
-
-        boolean expected = true;
-        boolean actual = hasMoveTo(
-                moveGenerator.generateLegalMoves(new Location(4, 6)), 4, 4);
-
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void GenerateLegalMoves_OnWhitePawnAtStartWithBlockerAtTwoAhead_ExcludesTwoStep() {
-        Piece[][] board = emptyBoard();
-        board[6][4] = new Pawn(PieceColor.WHITE);
-        board[4][4] = new Rook(PieceColor.BLACK);
-        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
-
-        boolean expected = false;
-        boolean actual = hasMoveTo(
-                moveGenerator.generateLegalMoves(new Location(4, 6)), 4, 4);
-
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void GenerateLegalMoves_OnWhitePawnWithFriendlyDiagonal_SkipsDiagonalCapture() {
-        Piece[][] board = emptyBoard();
-        board[4][4] = new Pawn(PieceColor.WHITE);
-        board[3][5] = new Pawn(PieceColor.WHITE);
-        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
-
-        int expected = 1;
-        int actual = moveGenerator.generateLegalMoves(new Location(4, 4)).size();
-
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void ApplyMoveToBoard_OnPromotionRook_DestinationHasRook() {
-        Piece[][] board = emptyBoard();
-        board[1][4] = new Pawn(PieceColor.WHITE);
-        Move move = new Move(
-                new Location(4, 1), new Location(4, 0), MoveType.PROMOTION, PieceType.ROOK);
-
-        Piece[][] result = MoveGenerator.applyMoveToBoard(board, move);
-
-        PieceType expected = PieceType.ROOK;
-        PieceType actual = result[0][4].getType();
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void ApplyMoveToBoard_OnPromotionBishop_DestinationHasBishop() {
-        Piece[][] board = emptyBoard();
-        board[1][4] = new Pawn(PieceColor.WHITE);
-        Move move = new Move(
-                new Location(4, 1), new Location(4, 0), MoveType.PROMOTION, PieceType.BISHOP);
-
-        Piece[][] result = MoveGenerator.applyMoveToBoard(board, move);
-
-        PieceType expected = PieceType.BISHOP;
-        PieceType actual = result[0][4].getType();
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void ApplyMoveToBoard_OnPromotionKnight_DestinationHasKnight() {
-        Piece[][] board = emptyBoard();
-        board[1][4] = new Pawn(PieceColor.WHITE);
-        Move move = new Move(
-                new Location(4, 1), new Location(4, 0), MoveType.PROMOTION, PieceType.KNIGHT);
-
-        Piece[][] result = MoveGenerator.applyMoveToBoard(board, move);
-
-        PieceType expected = PieceType.KNIGHT;
-        PieceType actual = result[0][4].getType();
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void GenerateLegalMoves_OnBlackPawnAtStart_ReturnsOneAndTwoStepMoves() {
-        Piece[][] board = emptyBoard();
-        board[1][4] = new Pawn(PieceColor.BLACK);
-        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
-
-        int expected = 2;
-        int actual = moveGenerator.generateLegalMoves(new Location(4, 1)).size();
-
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void GenerateLegalMoves_OnBlackPawnWithEnPassantTarget_IncludesEnPassantMove() {
-        Piece[][] board = emptyBoard();
-        board[4][4] = new Pawn(PieceColor.BLACK);
-        MoveGenerator moveGenerator =
-                new MoveGenerator(board, Optional.of(new Location(3, 5)));
-
-        boolean expected = true;
-        boolean actual = hasMoveToWithType(
-                moveGenerator.generateLegalMoves(new Location(4, 4)),
-                3,
-                5,
-                MoveType.EN_PASSANT);
-
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void GenerateLegalMoves_OnKingAtCenter_IncludesNorthEastDestination() {
-        Piece[][] board = emptyBoard();
-        board[4][4] = new King(PieceColor.WHITE);
-        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
-
-        boolean expected = true;
-        boolean actual = hasMoveTo(
-                moveGenerator.generateLegalMoves(new Location(4, 4)), 5, 3);
-
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void GenerateLegalMoves_OnWhitePawnWithEnemyDiagonal_IncludesCaptureDestination() {
-        Piece[][] board = emptyBoard();
-        board[4][4] = new Pawn(PieceColor.WHITE);
-        board[3][5] = new Rook(PieceColor.BLACK);
-        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
-
-        boolean expected = true;
-        boolean actual = hasMoveTo(
-                moveGenerator.generateLegalMoves(new Location(4, 4)), 5, 3);
-
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void GenerateLegalMoves_OnRookFacingEnemy_IncludesCaptureDestination() {
-        Piece[][] board = emptyBoard();
-        board[4][4] = new Rook(PieceColor.WHITE);
-        board[4][6] = new Rook(PieceColor.BLACK);
-        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
-
-        boolean expected = true;
-        boolean actual = hasMoveTo(
-                moveGenerator.generateLegalMoves(new Location(4, 4)), 4, 6);
-
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void GenerateLegalMoves_OnKnightAtCorner_ReturnsTwoMoves() {
-        Piece[][] board = emptyBoard();
-        board[0][0] = new Knight(PieceColor.WHITE);
-        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
-
-        int expected = 2;
-        int actual = moveGenerator.generateLegalMoves(new Location(0, 0)).size();
-
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void GenerateLegalMoves_OnKnightAtCorner_IncludesDestinationOneTwo() {
-        Piece[][] board = emptyBoard();
-        board[0][0] = new Knight(PieceColor.WHITE);
-        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
-
-        boolean expected = true;
-        boolean actual = hasMoveTo(
-                moveGenerator.generateLegalMoves(new Location(0, 0)), 1, 2);
-
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void GenerateLegalMoves_OnWhitePawnAtBackRankWithNoCaptures_ReturnsEmptyList() {
-        Piece[][] board = emptyBoard();
-        board[0][4] = new Pawn(PieceColor.WHITE);
-        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
-
-        int expected = 0;
-        int actual = moveGenerator.generateLegalMoves(new Location(4, 0)).size();
-
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void GenerateLegalMoves_OnKingWithOnlyKingsideRook_ExcludesQueensideCastling() {
-        Piece[][] board = emptyBoard();
-        board[7][4] = new King(PieceColor.WHITE);
-        board[7][7] = new Rook(PieceColor.WHITE);
-        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
-
-        boolean expected = false;
-        boolean actual = hasMoveType(
-                moveGenerator.generateLegalMoves(new Location(4, 7)),
-                MoveType.CASTLING_QUEENSIDE);
-
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void GenerateLegalMoves_OnKingAtCenter_IncludesSouthWestDestination() {
-        Piece[][] board = emptyBoard();
-        board[4][4] = new King(PieceColor.WHITE);
-        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
-
-        boolean expected = true;
-        boolean actual = hasMoveTo(
-                moveGenerator.generateLegalMoves(new Location(4, 4)), 3, 5);
-
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void IsInCheck_WhenKnightOnExactAttackSquare_ReturnsTrue() {
-        Piece[][] board = emptyBoard();
-        board[4][4] = new King(PieceColor.WHITE);
-        board[2][5] = new Knight(PieceColor.BLACK);
-        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
-
-        boolean expected = true;
-        boolean actual = moveGenerator.isInCheck(PieceColor.WHITE);
-
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void IsInCheck_WhenPawnOnExactAttackSquare_ReturnsTrue() {
-        Piece[][] board = emptyBoard();
-        board[3][4] = new King(PieceColor.WHITE);
-        board[2][3] = new Pawn(PieceColor.BLACK);
-        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
-
-        boolean expected = true;
-        boolean actual = moveGenerator.isInCheck(PieceColor.WHITE);
-
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void IsInCheck_WhenKingOnExactAdjacentSquare_ReturnsTrue() {
-        Piece[][] board = emptyBoard();
-        board[4][4] = new King(PieceColor.WHITE);
-        board[3][3] = new King(PieceColor.BLACK);
-        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
-
-        boolean expected = true;
-        boolean actual = moveGenerator.isInCheck(PieceColor.WHITE);
-
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void GeneratePseudoLegalMoves_OnNonePiece_ReturnsEmptyList() throws Exception {
-        Piece[][] board = emptyBoard();
-        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
-        Method generatePseudoLegalMoves = MoveGenerator.class.getDeclaredMethod(
-                "generatePseudoLegalMoves", Location.class, Piece.class);
-        generatePseudoLegalMoves.setAccessible(true);
-
-        @SuppressWarnings("unchecked")
-        List<Move> moves = (List<Move>) generatePseudoLegalMoves.invoke(
-                moveGenerator, new Location(3, 3), new NonePiece());
-
-        int expected = 0;
-        int actual = moves.size();
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void GeneratePseudoLegalMoves_OnNonePiece_ReturnsMutableEmptyList() throws Exception {
-        Piece[][] board = emptyBoard();
-        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
-        Method generatePseudoLegalMoves = MoveGenerator.class.getDeclaredMethod(
-                "generatePseudoLegalMoves", Location.class, Piece.class);
-        generatePseudoLegalMoves.setAccessible(true);
-
-        @SuppressWarnings("unchecked")
-        List<Move> moves = (List<Move>) generatePseudoLegalMoves.invoke(
-                moveGenerator, new Location(3, 3), new NonePiece());
-        int sizeBefore = moves.size();
-        moves.add(new Move(new Location(0, 0), new Location(1, 1)));
-
-        int expected = sizeBefore + 1;
-        int actual = moves.size();
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void GenerateLegalMoves_OnWhitePawnWithLeftDiagonalEnemy_IncludesLeftCaptureOnly() {
-        Piece[][] board = emptyBoard();
-        board[4][4] = new Pawn(PieceColor.WHITE);
-        board[3][3] = new Rook(PieceColor.BLACK);
-        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
-
-        boolean expected = true;
-        boolean actual = hasMoveTo(
-                moveGenerator.generateLegalMoves(new Location(4, 4)), 3, 3);
-
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void GenerateLegalMoves_OnWhitePawnWithLeftDiagonalEnemy_ExcludesRightCapture() {
-        Piece[][] board = emptyBoard();
-        board[4][4] = new Pawn(PieceColor.WHITE);
-        board[3][3] = new Rook(PieceColor.BLACK);
-        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
-
-        boolean expected = false;
-        boolean actual = hasMoveTo(
-                moveGenerator.generateLegalMoves(new Location(4, 4)), 5, 3);
-
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void GenerateLegalMoves_OnRookFacingEnemy_ReturnsThirteenMoves() {
-        Piece[][] board = emptyBoard();
-        board[4][4] = new Rook(PieceColor.WHITE);
-        board[4][6] = new Rook(PieceColor.BLACK);
-        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
-
-        int expected = 13;
-        int actual = moveGenerator.generateLegalMoves(new Location(4, 4)).size();
-
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void IsInCheck_WhenKnightOneSquareOffAttackLine_ReturnsFalse() {
-        Piece[][] board = emptyBoard();
-        board[4][4] = new King(PieceColor.WHITE);
-        board[2][6] = new Knight(PieceColor.BLACK);
-        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
-
-        boolean expected = false;
-        boolean actual = moveGenerator.isInCheck(PieceColor.WHITE);
-
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void IsInCheck_WhenPawnOneFileOffAttackLine_ReturnsFalse() {
-        Piece[][] board = emptyBoard();
-        board[3][4] = new King(PieceColor.WHITE);
-        board[2][4] = new Pawn(PieceColor.BLACK);
-        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
-
-        boolean expected = false;
-        boolean actual = moveGenerator.isInCheck(PieceColor.WHITE);
-
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void IsInCheck_WhenKingTwoSquaresAway_ReturnsFalse() {
-        Piece[][] board = emptyBoard();
-        board[4][4] = new King(PieceColor.WHITE);
-        board[6][6] = new King(PieceColor.BLACK);
-        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
-
-        boolean expected = false;
-        boolean actual = moveGenerator.isInCheck(PieceColor.WHITE);
-
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void GenerateLegalMoves_OnKingWithoutRooks_ExcludesAllCastling() {
-        Piece[][] board = emptyBoard();
-        board[7][4] = new King(PieceColor.WHITE);
-        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
-
-        boolean expected = false;
-        boolean actual = hasMoveType(
-                moveGenerator.generateLegalMoves(new Location(4, 7)),
-                MoveType.CASTLING_KINGSIDE);
-
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void GenerateLegalMoves_OnUnmovedQueensideRookAtAFile_FindsRookAtFileZero() {
-        Piece[][] board = emptyBoard();
-        board[7][4] = new King(PieceColor.WHITE);
-        board[7][0] = new Rook(PieceColor.WHITE);
-        Move move = new Move(
-                new Location(4, 7), new Location(2, 7), MoveType.CASTLING_QUEENSIDE);
-
-        Piece[][] result = MoveGenerator.applyMoveToBoard(board, move);
-
-        PieceType expected = PieceType.ROOK;
-        PieceType actual = result[7][3].getType();
         assertEquals(expected, actual);
     }
 

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -854,6 +854,20 @@ class MoveGeneratorTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void ApplyMoveToBoard_OnPromotionRook_DestinationHasRook() {
+        Piece[][] board = emptyBoard();
+        board[1][4] = new Pawn(PieceColor.WHITE);
+        Move move = new Move(
+                new Location(4, 1), new Location(4, 0), MoveType.PROMOTION, PieceType.ROOK);
+
+        Piece[][] result = MoveGenerator.applyMoveToBoard(board, move);
+
+        PieceType expected = PieceType.ROOK;
+        PieceType actual = result[0][4].getType();
+        assertEquals(expected, actual);
+    }
+
     private static boolean hasMoveToWithType(
             java.util.List<Move> moves, int file, int rank, MoveType type) {
         for (Move move : moves) {

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -978,6 +978,19 @@ class MoveGeneratorTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void GenerateLegalMoves_OnKnightAtCorner_IncludesDestinationOneTwo() {
+        Piece[][] board = emptyBoard();
+        board[0][0] = new Knight(PieceColor.WHITE);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = true;
+        boolean actual = hasMoveTo(
+                moveGenerator.generateLegalMoves(new Location(0, 0)), 1, 2);
+
+        assertEquals(expected, actual);
+    }
+
     private static boolean hasMoveToWithType(
             java.util.List<Move> moves, int file, int rank, MoveType type) {
         for (Move move : moves) {

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -723,6 +723,20 @@ class MoveGeneratorTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void GenerateLegalMoves_OnRookBlockedByFriendly_ExcludesSquareBeyondFriendly() {
+        Piece[][] board = emptyBoard();
+        board[4][4] = new Rook(PieceColor.WHITE);
+        board[6][4] = new Pawn(PieceColor.WHITE);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = false;
+        boolean actual = hasMoveTo(
+                moveGenerator.generateLegalMoves(new Location(4, 4)), 4, 7);
+
+        assertEquals(expected, actual);
+    }
+
     private static boolean hasMoveToWithType(
             java.util.List<Move> moves, int file, int rank, MoveType type) {
         for (Move move : moves) {

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -709,6 +709,20 @@ class MoveGeneratorTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void GenerateLegalMoves_OnKnightBlockedByFriendly_ExcludesBlockedSquare() {
+        Piece[][] board = emptyBoard();
+        board[4][4] = new Knight(PieceColor.WHITE);
+        board[6][5] = new Pawn(PieceColor.WHITE);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = false;
+        boolean actual = hasMoveTo(
+                moveGenerator.generateLegalMoves(new Location(4, 4)), 5, 6);
+
+        assertEquals(expected, actual);
+    }
+
     private static boolean hasMoveToWithType(
             java.util.List<Move> moves, int file, int rank, MoveType type) {
         for (Move move : moves) {

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -1188,6 +1188,20 @@ class MoveGeneratorTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void GenerateLegalMoves_OnKingWithoutRooks_ExcludesAllCastling() {
+        Piece[][] board = emptyBoard();
+        board[7][4] = new King(PieceColor.WHITE);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = false;
+        boolean actual = hasMoveType(
+                moveGenerator.generateLegalMoves(new Location(4, 7)),
+                MoveType.CASTLING_KINGSIDE);
+
+        assertEquals(expected, actual);
+    }
+
     private static boolean hasMoveToWithType(
             java.util.List<Move> moves, int file, int rank, MoveType type) {
         for (Move move : moves) {

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -569,6 +569,18 @@ class MoveGeneratorTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void IsInCheck_WhenNoKingForColor_ReturnsFalse() {
+        Piece[][] board = emptyBoard();
+        board[4][4] = new Rook(PieceColor.WHITE);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = false;
+        boolean actual = moveGenerator.isInCheck(PieceColor.WHITE);
+
+        assertEquals(expected, actual);
+    }
+
     private static boolean hasMoveToWithType(
             java.util.List<Move> moves, int file, int rank, MoveType type) {
         for (Move move : moves) {

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -633,6 +633,19 @@ class MoveGeneratorTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void IsInCheck_WhenAdjacentEnemyKingAttacksKing_ReturnsTrue() {
+        Piece[][] board = emptyBoard();
+        board[4][4] = new King(PieceColor.WHITE);
+        board[5][5] = new King(PieceColor.BLACK);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = true;
+        boolean actual = moveGenerator.isInCheck(PieceColor.WHITE);
+
+        assertEquals(expected, actual);
+    }
+
     private static boolean hasMoveToWithType(
             java.util.List<Move> moves, int file, int rank, MoveType type) {
         for (Move move : moves) {

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -1018,6 +1018,19 @@ class MoveGeneratorTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void GenerateLegalMoves_OnKingAtCenter_IncludesSouthWestDestination() {
+        Piece[][] board = emptyBoard();
+        board[4][4] = new King(PieceColor.WHITE);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = true;
+        boolean actual = hasMoveTo(
+                moveGenerator.generateLegalMoves(new Location(4, 4)), 3, 5);
+
+        assertEquals(expected, actual);
+    }
+
     private static boolean hasMoveToWithType(
             java.util.List<Move> moves, int file, int rank, MoveType type) {
         for (Move move : moves) {

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -1031,6 +1031,19 @@ class MoveGeneratorTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void IsInCheck_WhenKnightOnExactAttackSquare_ReturnsTrue() {
+        Piece[][] board = emptyBoard();
+        board[4][4] = new King(PieceColor.WHITE);
+        board[2][5] = new Knight(PieceColor.BLACK);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = true;
+        boolean actual = moveGenerator.isInCheck(PieceColor.WHITE);
+
+        assertEquals(expected, actual);
+    }
+
     private static boolean hasMoveToWithType(
             java.util.List<Move> moves, int file, int rank, MoveType type) {
         for (Move move : moves) {

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -882,6 +882,20 @@ class MoveGeneratorTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void ApplyMoveToBoard_OnPromotionKnight_DestinationHasKnight() {
+        Piece[][] board = emptyBoard();
+        board[1][4] = new Pawn(PieceColor.WHITE);
+        Move move = new Move(
+                new Location(4, 1), new Location(4, 0), MoveType.PROMOTION, PieceType.KNIGHT);
+
+        Piece[][] result = MoveGenerator.applyMoveToBoard(board, move);
+
+        PieceType expected = PieceType.KNIGHT;
+        PieceType actual = result[0][4].getType();
+        assertEquals(expected, actual);
+    }
+
     private static boolean hasMoveToWithType(
             java.util.List<Move> moves, int file, int rank, MoveType type) {
         for (Move move : moves) {

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -991,6 +991,18 @@ class MoveGeneratorTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void GenerateLegalMoves_OnWhitePawnAtBackRankWithNoCaptures_ReturnsEmptyList() {
+        Piece[][] board = emptyBoard();
+        board[0][4] = new Pawn(PieceColor.WHITE);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        int expected = 0;
+        int actual = moveGenerator.generateLegalMoves(new Location(4, 0)).size();
+
+        assertEquals(expected, actual);
+    }
+
     private static boolean hasMoveToWithType(
             java.util.List<Move> moves, int file, int rank, MoveType type) {
         for (Move move : moves) {

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -686,6 +686,14 @@ class MoveGeneratorTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void CreatePiece_OnNoneType_ReturnsNonePiece() {
+        PieceType expected = PieceType.NONE;
+        PieceType actual = MoveGenerator.createPiece(PieceType.NONE, PieceColor.WHITE).getType();
+
+        assertEquals(expected, actual);
+    }
+
     private static boolean hasMoveToWithType(
             java.util.List<Move> moves, int file, int rank, MoveType type) {
         for (Move move : moves) {

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -620,6 +620,19 @@ class MoveGeneratorTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void IsInCheck_WhenQueenAttacksKing_ReturnsTrue() {
+        Piece[][] board = emptyBoard();
+        board[4][4] = new King(PieceColor.WHITE);
+        board[0][4] = new Queen(PieceColor.BLACK);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = true;
+        boolean actual = moveGenerator.isInCheck(PieceColor.WHITE);
+
+        assertEquals(expected, actual);
+    }
+
     private static boolean hasMoveToWithType(
             java.util.List<Move> moves, int file, int rank, MoveType type) {
         for (Move move : moves) {

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -670,6 +670,14 @@ class MoveGeneratorTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void CreatePiece_OnPawnType_ReturnsPawn() {
+        PieceType expected = PieceType.PAWN;
+        PieceType actual = MoveGenerator.createPiece(PieceType.PAWN, PieceColor.WHITE).getType();
+
+        assertEquals(expected, actual);
+    }
+
     private static boolean hasMoveToWithType(
             java.util.List<Move> moves, int file, int rank, MoveType type) {
         for (Move move : moves) {

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -737,6 +737,20 @@ class MoveGeneratorTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void GenerateLegalMoves_OnKingBlockedByFriendly_ExcludesFriendlySquare() {
+        Piece[][] board = emptyBoard();
+        board[4][4] = new King(PieceColor.WHITE);
+        board[5][5] = new Pawn(PieceColor.WHITE);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = false;
+        boolean actual = hasMoveTo(
+                moveGenerator.generateLegalMoves(new Location(4, 4)), 5, 5);
+
+        assertEquals(expected, actual);
+    }
+
     private static boolean hasMoveToWithType(
             java.util.List<Move> moves, int file, int rank, MoveType type) {
         for (Move move : moves) {

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -662,6 +662,14 @@ class MoveGeneratorTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void CreatePiece_OnKnightType_ReturnsKnight() {
+        PieceType expected = PieceType.KNIGHT;
+        PieceType actual = MoveGenerator.createPiece(PieceType.KNIGHT, PieceColor.WHITE).getType();
+
+        assertEquals(expected, actual);
+    }
+
     private static boolean hasMoveToWithType(
             java.util.List<Move> moves, int file, int rank, MoveType type) {
         for (Move move : moves) {

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -966,6 +966,18 @@ class MoveGeneratorTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void GenerateLegalMoves_OnKnightAtCorner_ReturnsTwoMoves() {
+        Piece[][] board = emptyBoard();
+        board[0][0] = new Knight(PieceColor.WHITE);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        int expected = 2;
+        int actual = moveGenerator.generateLegalMoves(new Location(0, 0)).size();
+
+        assertEquals(expected, actual);
+    }
+
     private static boolean hasMoveToWithType(
             java.util.List<Move> moves, int file, int rank, MoveType type) {
         for (Move move : moves) {

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -1089,6 +1089,25 @@ class MoveGeneratorTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void GeneratePseudoLegalMoves_OnNonePiece_ReturnsMutableEmptyList() throws Exception {
+        Piece[][] board = emptyBoard();
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+        Method generatePseudoLegalMoves = MoveGenerator.class.getDeclaredMethod(
+                "generatePseudoLegalMoves", Location.class, Piece.class);
+        generatePseudoLegalMoves.setAccessible(true);
+
+        @SuppressWarnings("unchecked")
+        List<Move> moves = (List<Move>) generatePseudoLegalMoves.invoke(
+                moveGenerator, new Location(3, 3), new NonePiece());
+        int sizeBefore = moves.size();
+        moves.add(new Move(new Location(0, 0), new Location(1, 1)));
+
+        int expected = sizeBefore + 1;
+        int actual = moves.size();
+        assertEquals(expected, actual);
+    }
+
     private static boolean hasMoveToWithType(
             java.util.List<Move> moves, int file, int rank, MoveType type) {
         for (Move move : moves) {

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -594,6 +594,19 @@ class MoveGeneratorTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void IsInCheck_WhenKnightAttacksKing_ReturnsTrue() {
+        Piece[][] board = emptyBoard();
+        board[4][4] = new King(PieceColor.WHITE);
+        board[5][6] = new Knight(PieceColor.BLACK);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = true;
+        boolean actual = moveGenerator.isInCheck(PieceColor.WHITE);
+
+        assertEquals(expected, actual);
+    }
+
     private static boolean hasMoveToWithType(
             java.util.List<Move> moves, int file, int rank, MoveType type) {
         for (Move move : moves) {

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -1003,6 +1003,21 @@ class MoveGeneratorTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void GenerateLegalMoves_OnKingWithOnlyKingsideRook_ExcludesQueensideCastling() {
+        Piece[][] board = emptyBoard();
+        board[7][4] = new King(PieceColor.WHITE);
+        board[7][7] = new Rook(PieceColor.WHITE);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = false;
+        boolean actual = hasMoveType(
+                moveGenerator.generateLegalMoves(new Location(4, 7)),
+                MoveType.CASTLING_QUEENSIDE);
+
+        assertEquals(expected, actual);
+    }
+
     private static boolean hasMoveToWithType(
             java.util.List<Move> moves, int file, int rank, MoveType type) {
         for (Move move : moves) {

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -938,6 +938,20 @@ class MoveGeneratorTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void GenerateLegalMoves_OnWhitePawnWithEnemyDiagonal_IncludesCaptureDestination() {
+        Piece[][] board = emptyBoard();
+        board[4][4] = new Pawn(PieceColor.WHITE);
+        board[3][5] = new Rook(PieceColor.BLACK);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = true;
+        boolean actual = hasMoveTo(
+                moveGenerator.generateLegalMoves(new Location(4, 4)), 5, 3);
+
+        assertEquals(expected, actual);
+    }
+
     private static boolean hasMoveToWithType(
             java.util.List<Move> moves, int file, int rank, MoveType type) {
         for (Move move : moves) {

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -751,6 +751,22 @@ class MoveGeneratorTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void GenerateLegalMoves_OnKingsideCastlingWithBlockingPiece_ExcludesKingsideCastling() {
+        Piece[][] board = emptyBoard();
+        board[7][4] = new King(PieceColor.WHITE);
+        board[7][7] = new Rook(PieceColor.WHITE);
+        board[7][5] = new Bishop(PieceColor.WHITE);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = false;
+        boolean actual = hasMoveType(
+                moveGenerator.generateLegalMoves(new Location(4, 7)),
+                MoveType.CASTLING_KINGSIDE);
+
+        assertEquals(expected, actual);
+    }
+
     private static boolean hasMoveToWithType(
             java.util.List<Move> moves, int file, int rank, MoveType type) {
         for (Move move : moves) {

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -896,6 +896,18 @@ class MoveGeneratorTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void GenerateLegalMoves_OnBlackPawnAtStart_ReturnsOneAndTwoStepMoves() {
+        Piece[][] board = emptyBoard();
+        board[1][4] = new Pawn(PieceColor.BLACK);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        int expected = 2;
+        int actual = moveGenerator.generateLegalMoves(new Location(4, 1)).size();
+
+        assertEquals(expected, actual);
+    }
+
     private static boolean hasMoveToWithType(
             java.util.List<Move> moves, int file, int rank, MoveType type) {
         for (Move move : moves) {

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -783,6 +783,22 @@ class MoveGeneratorTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void GenerateLegalMoves_OnMovedQueensideRook_ExcludesQueensideCastling() {
+        Piece[][] board = emptyBoard();
+        board[7][4] = new King(PieceColor.WHITE);
+        board[7][0] = new Rook(PieceColor.WHITE);
+        board[7][0].changeToMoved();
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = false;
+        boolean actual = hasMoveType(
+                moveGenerator.generateLegalMoves(new Location(4, 7)),
+                MoveType.CASTLING_QUEENSIDE);
+
+        assertEquals(expected, actual);
+    }
+
     private static boolean hasMoveToWithType(
             java.util.List<Move> moves, int file, int rank, MoveType type) {
         for (Move move : moves) {

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -908,6 +908,23 @@ class MoveGeneratorTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void GenerateLegalMoves_OnBlackPawnWithEnPassantTarget_IncludesEnPassantMove() {
+        Piece[][] board = emptyBoard();
+        board[4][4] = new Pawn(PieceColor.BLACK);
+        MoveGenerator moveGenerator =
+                new MoveGenerator(board, Optional.of(new Location(3, 5)));
+
+        boolean expected = true;
+        boolean actual = hasMoveToWithType(
+                moveGenerator.generateLegalMoves(new Location(4, 4)),
+                3,
+                5,
+                MoveType.EN_PASSANT);
+
+        assertEquals(expected, actual);
+    }
+
     private static boolean hasMoveToWithType(
             java.util.List<Move> moves, int file, int rank, MoveType type) {
         for (Move move : moves) {

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -925,6 +925,19 @@ class MoveGeneratorTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void GenerateLegalMoves_OnKingAtCenter_IncludesNorthEastDestination() {
+        Piece[][] board = emptyBoard();
+        board[4][4] = new King(PieceColor.WHITE);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = true;
+        boolean actual = hasMoveTo(
+                moveGenerator.generateLegalMoves(new Location(4, 4)), 5, 3);
+
+        assertEquals(expected, actual);
+    }
+
     private static boolean hasMoveToWithType(
             java.util.List<Move> moves, int file, int rank, MoveType type) {
         for (Move move : moves) {

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -16,6 +16,8 @@ import domain.piece.PieceColor;
 import domain.piece.PieceType;
 import domain.piece.Queen;
 import domain.piece.Rook;
+import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
@@ -1067,6 +1069,23 @@ class MoveGeneratorTest {
         boolean expected = true;
         boolean actual = moveGenerator.isInCheck(PieceColor.WHITE);
 
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void GeneratePseudoLegalMoves_OnNonePiece_ReturnsEmptyList() throws Exception {
+        Piece[][] board = emptyBoard();
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+        Method generatePseudoLegalMoves = MoveGenerator.class.getDeclaredMethod(
+                "generatePseudoLegalMoves", Location.class, Piece.class);
+        generatePseudoLegalMoves.setAccessible(true);
+
+        @SuppressWarnings("unchecked")
+        List<Move> moves = (List<Move>) generatePseudoLegalMoves.invoke(
+                moveGenerator, new Location(3, 3), new NonePiece());
+
+        int expected = 0;
+        int actual = moves.size();
         assertEquals(expected, actual);
     }
 

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -827,6 +827,20 @@ class MoveGeneratorTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void GenerateLegalMoves_OnWhitePawnAtStartWithBlockerAtTwoAhead_ExcludesTwoStep() {
+        Piece[][] board = emptyBoard();
+        board[6][4] = new Pawn(PieceColor.WHITE);
+        board[4][4] = new Rook(PieceColor.BLACK);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = false;
+        boolean actual = hasMoveTo(
+                moveGenerator.generateLegalMoves(new Location(4, 6)), 4, 4);
+
+        assertEquals(expected, actual);
+    }
+
     private static boolean hasMoveToWithType(
             java.util.List<Move> moves, int file, int rank, MoveType type) {
         for (Move move : moves) {

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -1044,6 +1044,19 @@ class MoveGeneratorTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void IsInCheck_WhenPawnOnExactAttackSquare_ReturnsTrue() {
+        Piece[][] board = emptyBoard();
+        board[3][4] = new King(PieceColor.WHITE);
+        board[2][3] = new Pawn(PieceColor.BLACK);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = true;
+        boolean actual = moveGenerator.isInCheck(PieceColor.WHITE);
+
+        assertEquals(expected, actual);
+    }
+
     private static boolean hasMoveToWithType(
             java.util.List<Move> moves, int file, int rank, MoveType type) {
         for (Move move : moves) {

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -654,6 +654,14 @@ class MoveGeneratorTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void CreatePiece_OnBishopType_ReturnsBishop() {
+        PieceType expected = PieceType.BISHOP;
+        PieceType actual = MoveGenerator.createPiece(PieceType.BISHOP, PieceColor.WHITE).getType();
+
+        assertEquals(expected, actual);
+    }
+
     private static boolean hasMoveToWithType(
             java.util.List<Move> moves, int file, int rank, MoveType type) {
         for (Move move : moves) {

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -646,6 +646,14 @@ class MoveGeneratorTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void CreatePiece_OnRookType_ReturnsRook() {
+        PieceType expected = PieceType.ROOK;
+        PieceType actual = MoveGenerator.createPiece(PieceType.ROOK, PieceColor.WHITE).getType();
+
+        assertEquals(expected, actual);
+    }
+
     private static boolean hasMoveToWithType(
             java.util.List<Move> moves, int file, int rank, MoveType type) {
         for (Move move : moves) {

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -841,6 +841,19 @@ class MoveGeneratorTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void GenerateLegalMoves_OnWhitePawnWithFriendlyDiagonal_SkipsDiagonalCapture() {
+        Piece[][] board = emptyBoard();
+        board[4][4] = new Pawn(PieceColor.WHITE);
+        board[3][5] = new Pawn(PieceColor.WHITE);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        int expected = 1;
+        int actual = moveGenerator.generateLegalMoves(new Location(4, 4)).size();
+
+        assertEquals(expected, actual);
+    }
+
     private static boolean hasMoveToWithType(
             java.util.List<Move> moves, int file, int rank, MoveType type) {
         for (Move move : moves) {

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -1136,6 +1136,19 @@ class MoveGeneratorTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void GenerateLegalMoves_OnRookFacingEnemy_ReturnsThirteenMoves() {
+        Piece[][] board = emptyBoard();
+        board[4][4] = new Rook(PieceColor.WHITE);
+        board[4][6] = new Rook(PieceColor.BLACK);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        int expected = 13;
+        int actual = moveGenerator.generateLegalMoves(new Location(4, 4)).size();
+
+        assertEquals(expected, actual);
+    }
+
     private static boolean hasMoveToWithType(
             java.util.List<Move> moves, int file, int rank, MoveType type) {
         for (Move move : moves) {

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -799,6 +799,21 @@ class MoveGeneratorTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void GenerateLegalMoves_OnEnPassantTargetSameFile_ExcludesEnPassantMove() {
+        Piece[][] board = emptyBoard();
+        board[3][4] = new Pawn(PieceColor.WHITE);
+        MoveGenerator moveGenerator =
+                new MoveGenerator(board, Optional.of(new Location(4, 2)));
+
+        boolean expected = false;
+        boolean actual = hasMoveType(
+                moveGenerator.generateLegalMoves(new Location(4, 3)),
+                MoveType.EN_PASSANT);
+
+        assertEquals(expected, actual);
+    }
+
     private static boolean hasMoveToWithType(
             java.util.List<Move> moves, int file, int rank, MoveType type) {
         for (Move move : moves) {

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -767,6 +767,22 @@ class MoveGeneratorTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void GenerateLegalMoves_OnQueensideCastlingWithBlockingPiece_ExcludesQueensideCastling() {
+        Piece[][] board = emptyBoard();
+        board[7][4] = new King(PieceColor.WHITE);
+        board[7][0] = new Rook(PieceColor.WHITE);
+        board[7][1] = new Knight(PieceColor.WHITE);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = false;
+        boolean actual = hasMoveType(
+                moveGenerator.generateLegalMoves(new Location(4, 7)),
+                MoveType.CASTLING_QUEENSIDE);
+
+        assertEquals(expected, actual);
+    }
+
     private static boolean hasMoveToWithType(
             java.util.List<Move> moves, int file, int rank, MoveType type) {
         for (Move move : moves) {

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -694,6 +694,21 @@ class MoveGeneratorTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void GenerateLegalMoves_OnEmptySquare_ReturnsMutableEmptyList() {
+        Piece[][] board = emptyBoard();
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        java.util.List<Move> moves = moveGenerator.generateLegalMoves(new Location(3, 3));
+        int sizeBefore = moves.size();
+        moves.add(new Move(new Location(0, 0), new Location(1, 1)));
+
+        int expected = sizeBefore + 1;
+        int actual = moves.size();
+
+        assertEquals(expected, actual);
+    }
+
     private static boolean hasMoveToWithType(
             java.util.List<Move> moves, int file, int rank, MoveType type) {
         for (Move move : moves) {

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -1202,6 +1202,21 @@ class MoveGeneratorTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void GenerateLegalMoves_OnUnmovedQueensideRookAtAFile_FindsRookAtFileZero() {
+        Piece[][] board = emptyBoard();
+        board[7][4] = new King(PieceColor.WHITE);
+        board[7][0] = new Rook(PieceColor.WHITE);
+        Move move = new Move(
+                new Location(4, 7), new Location(2, 7), MoveType.CASTLING_QUEENSIDE);
+
+        Piece[][] result = MoveGenerator.applyMoveToBoard(board, move);
+
+        PieceType expected = PieceType.ROOK;
+        PieceType actual = result[7][3].getType();
+        assertEquals(expected, actual);
+    }
+
     private static boolean hasMoveToWithType(
             java.util.List<Move> moves, int file, int rank, MoveType type) {
         for (Move move : moves) {

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -868,6 +868,20 @@ class MoveGeneratorTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void ApplyMoveToBoard_OnPromotionBishop_DestinationHasBishop() {
+        Piece[][] board = emptyBoard();
+        board[1][4] = new Pawn(PieceColor.WHITE);
+        Move move = new Move(
+                new Location(4, 1), new Location(4, 0), MoveType.PROMOTION, PieceType.BISHOP);
+
+        Piece[][] result = MoveGenerator.applyMoveToBoard(board, move);
+
+        PieceType expected = PieceType.BISHOP;
+        PieceType actual = result[0][4].getType();
+        assertEquals(expected, actual);
+    }
+
     private static boolean hasMoveToWithType(
             java.util.List<Move> moves, int file, int rank, MoveType type) {
         for (Move move : moves) {

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -645,7 +645,7 @@ class MoveGeneratorTest {
         assertEquals(expected, actual);
     }
     @Test
-    void GenerateLegalMoves_OnUnmovedQueensideRookAtAFile_FindsRookAtFileZero() {
+    void GenerateLegalMoves_OnUnmovedQueensideRookAtFileZero_FindsRookAtFileThree() {
         Piece[][] board = emptyBoard();
         board[7][4] = new King(PieceColor.WHITE);
         board[7][0] = new Rook(PieceColor.WHITE);

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -1057,6 +1057,19 @@ class MoveGeneratorTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void IsInCheck_WhenKingOnExactAdjacentSquare_ReturnsTrue() {
+        Piece[][] board = emptyBoard();
+        board[4][4] = new King(PieceColor.WHITE);
+        board[3][3] = new King(PieceColor.BLACK);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = true;
+        boolean actual = moveGenerator.isInCheck(PieceColor.WHITE);
+
+        assertEquals(expected, actual);
+    }
+
     private static boolean hasMoveToWithType(
             java.util.List<Move> moves, int file, int rank, MoveType type) {
         for (Move move : moves) {

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -1108,6 +1108,20 @@ class MoveGeneratorTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void GenerateLegalMoves_OnWhitePawnWithLeftDiagonalEnemy_IncludesLeftCaptureOnly() {
+        Piece[][] board = emptyBoard();
+        board[4][4] = new Pawn(PieceColor.WHITE);
+        board[3][3] = new Rook(PieceColor.BLACK);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = true;
+        boolean actual = hasMoveTo(
+                moveGenerator.generateLegalMoves(new Location(4, 4)), 3, 3);
+
+        assertEquals(expected, actual);
+    }
+
     private static boolean hasMoveToWithType(
             java.util.List<Move> moves, int file, int rank, MoveType type) {
         for (Move move : moves) {

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -678,6 +678,14 @@ class MoveGeneratorTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void CreatePiece_OnKingType_ReturnsKing() {
+        PieceType expected = PieceType.KING;
+        PieceType actual = MoveGenerator.createPiece(PieceType.KING, PieceColor.WHITE).getType();
+
+        assertEquals(expected, actual);
+    }
+
     private static boolean hasMoveToWithType(
             java.util.List<Move> moves, int file, int rank, MoveType type) {
         for (Move move : moves) {

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -1175,6 +1175,19 @@ class MoveGeneratorTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void IsInCheck_WhenKingTwoSquaresAway_ReturnsFalse() {
+        Piece[][] board = emptyBoard();
+        board[4][4] = new King(PieceColor.WHITE);
+        board[6][6] = new King(PieceColor.BLACK);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = false;
+        boolean actual = moveGenerator.isInCheck(PieceColor.WHITE);
+
+        assertEquals(expected, actual);
+    }
+
     private static boolean hasMoveToWithType(
             java.util.List<Move> moves, int file, int rank, MoveType type) {
         for (Move move : moves) {

--- a/src/test/java/domain/MoveGeneratorTest.java
+++ b/src/test/java/domain/MoveGeneratorTest.java
@@ -1122,6 +1122,20 @@ class MoveGeneratorTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    void GenerateLegalMoves_OnWhitePawnWithLeftDiagonalEnemy_ExcludesRightCapture() {
+        Piece[][] board = emptyBoard();
+        board[4][4] = new Pawn(PieceColor.WHITE);
+        board[3][3] = new Rook(PieceColor.BLACK);
+        MoveGenerator moveGenerator = new MoveGenerator(board, Optional.empty());
+
+        boolean expected = false;
+        boolean actual = hasMoveTo(
+                moveGenerator.generateLegalMoves(new Location(4, 4)), 5, 3);
+
+        assertEquals(expected, actual);
+    }
+
     private static boolean hasMoveToWithType(
             java.util.List<Move> moves, int file, int rank, MoveType type) {
         for (Move move : moves) {


### PR DESCRIPTION
## Description

Adds BVA and unit tests for `MoveGenerator` to reach **100% line coverage** and **92% mutation coverage** (196/213 mutants killed). No production code changes — coverage gaps are closed through new test scenarios for attack detection, castling blockers, friendly-piece blocking, pawn promotion paths, black-pawn movement, and `createPiece` / `applyMoveToBoard` branches.

## Type of Change

- [ ] Feature (new functionality)
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactor
- [x] Test addition/update

## Related Work

Related to `docs/bva/MoveGenerator.md`

## Changes Made

- [x] Extended `docs/bva/MoveGenerator.md` with MG-TC41–69 (attack types, `createPiece`, friendly blocking, castling path blockers, black pawns, exact destinations)
- [x] Added 49 new tests in `MoveGeneratorTest` (90 total), one commit per passing TC
- [x] Exercised previously uncovered paths: missing-king guard, all attacker types, sliding captures, knight off-board, pawn back-rank early return, `generatePseudoLegalMoves` fallback via reflection

## BVA & Testing

- BVA documented in: `docs/bva/MoveGenerator.md`
- Test cases implemented: MG-TC1–40 (pre-existing) + MG-TC41–69 (new); 49 additional JUnit methods beyond the numbered BVA slice where needed for mutants
- All tests passing: [x] `./gradlew test`
- Quality gates: [x] `./gradlew check pitest`

**MoveGenerator PIT results:**

| Metric | Value |
|--------|-------|
| Line coverage | 100% (304/304) |
| Mutation coverage | 92% (196/213) |
| Test strength | 92% |

17 surviving mutants are mostly equivalent (e.g. `2 * direction` vs `2 / direction` when `direction` is ±1) or loop-boundary tweaks that do not change behavior on realistic boards.

## Design Alignment

- [x] Changes align with `docs/design/chess-full-design.puml`
- [x] No breaking changes to existing methods
- [x] New methods follow the established patterns (tests only; no new production APIs)

## Implementation Notes

- Tests-only PR — `MoveGenerator.java` unchanged.
- Commit workflow: `Update MoveGenerator BVA for coverage and mutants`, then 49 commits named `<TestMethodName> passes`.
- `GeneratePseudoLegalMoves_OnNonePiece_*` uses reflection to hit the defensive `NONE` fallback in `generatePseudoLegalMoves` (unreachable through public `generateLegalMoves`).

## Checklist

- [x] BVA analysis is documented
- [x] TDD workflow followed (tests before code; no production changes required)
- [x] Code compiles and all tests pass
- [x] No new compiler warnings
- [x] Documentation updated (if applicable)
- [x] Commit messages are clear and follow TDD workflow