### PR TITLE
[TEST] BoardController

### DIFF
--- a/docs/bva/BoardController.md
+++ b/docs/bva/BoardController.md
@@ -702,7 +702,7 @@ Scope: PIT line/mutation gaps not exercised by BC-TC1–73. Tests use EasyMock s
   - **Method(s) under test**: `handleSquareClick(Location)` (via `handleSourceClick`, `repaintBoardView`)
   - **State of the system**: `BoardView` strict mock; white turn; click own white pawn
   - **Expected output**: `boardView.repaint()` called once; `verify(boardViewMock)` passes
-- **BC-TC78: HandleSquareClick_WithSelection_OnOwnPiece_RepaintsBoardViewTwice** ( :x: )
+- **BC-TC78: HandleSquareClick_WithSelection_OnOwnPiece_RepaintsBoardViewTwice** ( :white_check_mark: )
   - **Method(s) under test**: `handleSquareClick(Location)` (via `handleDestinationClick` reselect)
   - **State of the system**: selection then click second own piece
   - **Expected output**: `boardView.repaint()` called twice

--- a/docs/bva/BoardController.md
+++ b/docs/bva/BoardController.md
@@ -710,7 +710,7 @@ Scope: PIT line/mutation gaps not exercised by BC-TC1–73. Tests use EasyMock s
   - **Method(s) under test**: `handleSquareClick(Location)` (illegal destination path)
   - **State of the system**: selection then illegal empty destination with no matching move
   - **Expected output**: `boardView.repaint()` called twice
-- **BC-TC80: ExecuteMove_OnLegalMove_RepaintsBoardViewTwice** ( :x: )
+- **BC-TC80: ExecuteMove_OnLegalMove_RepaintsBoardViewTwice** ( :white_check_mark: )
   - **Method(s) under test**: `handleSquareClick(Location)` (via `executeMove`, `repaintBoardView`)
   - **State of the system**: selection then legal destination; `makeMove` invoked
   - **Expected output**: `boardView.repaint()` called twice

--- a/docs/bva/BoardController.md
+++ b/docs/bva/BoardController.md
@@ -690,7 +690,7 @@ Scope: PIT line/mutation gaps not exercised by BC-TC1–73. Tests use EasyMock s
   - **Method(s) under test**: `getMainView()`, `setMainView(MainView)`
   - **State of the system**: `MainView` mock injected via `setMainView`
   - **Expected output**: `getMainView()` returns the same mock instance
-- **BC-TC75: GetBoardView_AfterSetBoardView_ReturnsInjectedView** ( :x: )
+- **BC-TC75: GetBoardView_AfterSetBoardView_ReturnsInjectedView** ( :white_check_mark: )
   - **Method(s) under test**: `getBoardView()`, `setBoardView(BoardView)`
   - **State of the system**: `BoardView` mock injected via `setBoardView`
   - **Expected output**: `getBoardView()` returns the same mock instance

--- a/docs/bva/BoardController.md
+++ b/docs/bva/BoardController.md
@@ -698,7 +698,7 @@ Scope: PIT line/mutation gaps not exercised by BC-TC1–73. Tests use EasyMock s
   - **Method(s) under test**: `getLegalMovesForSelection()`
   - **State of the system**: no selection (`Optional.empty()`)
   - **Expected output**: returned list accepts an added element (mutable `ArrayList`)
-- **BC-TC77: HandleSquareClick_OnWhitePiece_RepaintsBoardView** ( :x: )
+- **BC-TC77: HandleSquareClick_OnWhitePiece_RepaintsBoardView** ( :white_check_mark: )
   - **Method(s) under test**: `handleSquareClick(Location)` (via `handleSourceClick`, `repaintBoardView`)
   - **State of the system**: `BoardView` strict mock; white turn; click own white pawn
   - **Expected output**: `boardView.repaint()` called once; `verify(boardViewMock)` passes

--- a/docs/bva/BoardController.md
+++ b/docs/bva/BoardController.md
@@ -62,11 +62,6 @@ Scope: **Game Initialization and interaction** — selection state, snapshot/tur
 
 ### Step 4: Test cases
 
-- **BC-TC74: GetMainView_BeforeShow_ReturnsNull** ( :white_check_mark: )
-  - **Method(s) under test**: `getMainView()`
-  - **State of the system**: fresh controller; `show()` not called
-  - **Expected output**: `null`
-
 - **BC-TC86: GetMainView_AfterSetMainView_ReturnsInjectedView** ( :white_check_mark: )
   - **Method(s) under test**: `getMainView()`, `setMainView(MainView)`
   - **State of the system**: `MainView` mock injected via `setMainView`

--- a/docs/bva/BoardController.md
+++ b/docs/bva/BoardController.md
@@ -686,7 +686,7 @@ Scope: PIT line/mutation gaps not exercised by BC-TC1–73. Tests use EasyMock s
   - **Method(s) under test**: `getMainView()`
   - **State of the system**: fresh controller; `show()` not called
   - **Expected output**: `null`
-- **BC-TC86: GetMainView_AfterSetMainView_ReturnsInjectedView** ( :x: )
+- **BC-TC86: GetMainView_AfterSetMainView_ReturnsInjectedView** ( :white_check_mark: )
   - **Method(s) under test**: `getMainView()`, `setMainView(MainView)`
   - **State of the system**: `MainView` mock injected via `setMainView`
   - **Expected output**: `getMainView()` returns the same mock instance

--- a/docs/bva/BoardController.md
+++ b/docs/bva/BoardController.md
@@ -2,14 +2,14 @@
 
 Package: `ui.BoardController`
 
-Scope: **Game Initialization** — selection state, snapshot/turn delegation to `domain.Board`, first-click policy, optional `BoardView` wiring. The real `Board` implementation is another feature branch; **unit tests use EasyMock** (`createMock` / `createNiceMock`, `expect`, `replay`, `verify`) to stub `getSnapshot()`, `getCurrentGameState()`, and `getPieceAt()` with test-built `Piece[][]` grids.
+Scope: **Game Initialization and interaction** — selection state, snapshot/turn delegation to `domain.Board`, click handling, move execution, UI wiring (`MainView`, `BoardView`), and end-game flow. The real `Board` implementation is another feature branch; **unit tests use EasyMock** (`createMock` / `createNiceMock`, `expect`, `replay`, `verify`) to stub collaborators. `BoardView.repaint()` is verified with strict mocks where UI refresh is part of the behavior under test.
 
 ### Step 1: Input and output equivalence classes
 
 | Concern           | Equivalence classes                                                                 |
 | ----------------- | ----------------------------------------------------------------------------------- |
 | Object life cycle | Fresh instance; no clicks yet                                                       |
-| Collaborators     | `Board` (mocked); **no `BoardView`** in controller unit tests |
+| Collaborators     | `Board` (mocked); `BoardView` / `MainView` (mocked or real for headed `show()`) |
 
 ### Step 2: BVA catalog data types
 
@@ -33,6 +33,76 @@ Scope: **Game Initialization** — selection state, snapshot/turn delegation to 
   - **Method(s) under test**: `getSelectedLocation()`
   - **State of the system**: newly constructed controller; no clicks yet
   - **Expected output**: `Optional.empty()`
+
+---
+
+## Method: `getMainView()` / `setMainView(MainView mainView)`
+
+### Step 1: Input and output equivalence classes
+
+| State | Equivalence classes |
+| ----- | ------------------- |
+| `mainView` field | unset (`show()` not called); injected via `setMainView` |
+
+| Output | Equivalence classes |
+| ------ | ------------------- |
+| `getMainView()` | `null`; same instance as injected mock |
+
+### Step 2: BVA catalog data types
+
+| Variable / output | Catalog type | Notes |
+| ----------------- | ------------ | ----- |
+| `mainView` | Pointers | unset vs injected reference |
+| Return value | Pointers | `null` vs non-null |
+
+### Step 3: Concrete boundary values
+
+- Before `show()` / `setMainView`: `getMainView()` → `null`
+- After `setMainView(mock)`: `getMainView()` → same mock reference
+
+### Step 4: Test cases
+
+- **BC-TC74: GetMainView_BeforeShow_ReturnsNull** ( :white_check_mark: )
+  - **Method(s) under test**: `getMainView()`
+  - **State of the system**: fresh controller; `show()` not called
+  - **Expected output**: `null`
+
+- **BC-TC86: GetMainView_AfterSetMainView_ReturnsInjectedView** ( :white_check_mark: )
+  - **Method(s) under test**: `getMainView()`, `setMainView(MainView)`
+  - **State of the system**: `MainView` mock injected via `setMainView`
+  - **Expected output**: `getMainView()` returns the same mock instance
+
+---
+
+## Method: `getBoardView()` / `setBoardView(BoardView boardView)`
+
+### Step 1: Input and output equivalence classes
+
+| State | Equivalence classes |
+| ----- | ------------------- |
+| `boardView` field | unset; injected via `setBoardView` |
+
+| Output | Equivalence classes |
+| ------ | ------------------- |
+| `getBoardView()` | `null`; same instance as injected mock |
+
+### Step 2: BVA catalog data types
+
+| Variable / output | Catalog type |
+| ----------------- | ------------ |
+| `boardView` | Pointers |
+| Return value | Pointers |
+
+### Step 3: Concrete boundary values
+
+- After `setBoardView(mock)`: `getBoardView()` returns the injected mock
+
+### Step 4: Test cases
+
+- **BC-TC75: GetBoardView_AfterSetBoardView_ReturnsInjectedView** ( :white_check_mark: )
+  - **Method(s) under test**: `getBoardView()`, `setBoardView(BoardView)`
+  - **State of the system**: `BoardView` mock injected via `setBoardView`
+  - **Expected output**: `getBoardView()` returns the same mock instance
 
 ---
 
@@ -179,12 +249,28 @@ _(BC-TC1, BC-TC2 cover fresh instance; selection-after-click covered under `hand
 
 | Input           | Classes                                       |
 | --------------- | --------------------------------------------- |
-| `loc`           | In-bounds; out-of-bounds                      |
+| `loc`           | In-bounds; out-of-bounds (negative; file `8`; rank `8`; max `(7, 7)`) |
 | Square at start | `NonePiece`; white piece; black piece         |
 
 | Effect            | Classes                                              |
 | ----------------- | ---------------------------------------------------- |
 | Selection / guard | Active player may select own-color pieces only; opponent or empty must not change board |
+| UI refresh        | `BoardView.repaint()` after selection changes when `BoardView` is wired |
+
+### Step 2: BVA catalog data types
+
+| Variable | Catalog type | Notes |
+| -------- | ------------ | ----- |
+| `loc.x`, `loc.y` | Counts | valid `[0, 7]` vs out-of-range |
+| `boardView` | Pointers | strict mock for repaint verification |
+
+### Step 3: Concrete boundary values
+
+- In-bounds max: `Location(7, 7)` on white turn with white rook → selection set
+- Out-of-bounds file: `Location(8, 0)` → early return, no board calls
+- Out-of-bounds rank: `Location(0, 8)` → early return, no board calls
+- Out-of-bounds negative: `Location(-1, 0)` (BC-TC36–38)
+- Repaint: strict `BoardView` mock; one `repaint()` on successful source click
 
 ### Step 4: Test cases
 
@@ -202,6 +288,11 @@ _(BC-TC1, BC-TC2 cover fresh instance; selection-after-click covered under `hand
   - **Method(s) under test**: `handleSquareClick(Location)`, `getBoardSnapshot()`
   - **State of the system**: standard new game; click white piece
   - **Expected output**: snapshot unchanged cell-wise
+
+- **BC-TC77: HandleSquareClick_OnWhitePiece_RepaintsBoardView** ( :white_check_mark: )
+  - **Method(s) under test**: `handleSquareClick(Location)` (via `handleSourceClick`, `repaintBoardView`)
+  - **State of the system**: `BoardView` strict mock; white turn; click own white pawn
+  - **Expected output**: `boardView.repaint()` called once; `verify(boardViewMock)` passes
 
 - **BC-TC30: HandleSquareClick_BeforeFirstMove_OnBlackPiece_NoSelectionAfterClick** ( :white_check_mark: )
   - **Method(s) under test**: `handleSquareClick(Location)`, `hasSelection()`
@@ -247,6 +338,21 @@ _(BC-TC1, BC-TC2 cover fresh instance; selection-after-click covered under `hand
   - **Method(s) under test**: `handleSquareClick(Location)`, `getBoardSnapshot()`
   - **State of the system**: out-of-bounds `loc`
   - **Expected output**: snapshot unchanged cell-wise
+
+- **BC-TC81: HandleSquareClick_OnFileEight_IgnoresClick** ( :white_check_mark: )
+  - **Method(s) under test**: `handleSquareClick(Location)` (via `isInBounds`)
+  - **State of the system**: `Location(8, 0)` — file index at upper boundary + 1
+  - **Expected output**: `hasSelection()` remains `false`; board not consulted
+
+- **BC-TC87: HandleSquareClick_OnRankEight_IgnoresClick** ( :white_check_mark: )
+  - **Method(s) under test**: `handleSquareClick(Location)` (via `isInBounds`)
+  - **State of the system**: `Location(0, 8)` — rank index at upper boundary + 1
+  - **Expected output**: `hasSelection()` remains `false`; board not consulted
+
+- **BC-TC82: HandleSquareClick_OnMaxInBoundsSquare_AcceptsClick** ( :white_check_mark: )
+  - **Method(s) under test**: `handleSquareClick(Location)` (via `isInBounds`)
+  - **State of the system**: `Location(7, 7)` white rook on white turn
+  - **Expected output**: `hasSelection()` is `true`
 
 - **BC-TC39: HandleSquareClick_Chess960Start_FirstWhiteSelectionSamePolicy** ( :white_check_mark: )
   - **Method(s) under test**: `handleSquareClick(Location)`, `getBoardSnapshot()`
@@ -348,6 +454,11 @@ Scope addition: derive **current player color** from `board.getCurrentGameState(
   - **State of the system**: `GameState.BLACK_TURN`; empty square
   - **Expected output**: snapshot unchanged cell-wise
 
+- **BC-TC83: HandleSquareClick_WhenGameOver_IgnoresClick** ( :white_check_mark: )
+  - **Method(s) under test**: `handleSquareClick(Location)`
+  - **State of the system**: board returns `WHITE_WIN`; click `(0, 6)`
+  - **Expected output**: `hasSelection()` remains `false`
+
 ---
 
 ## Method: `getLegalMovesForSelection(): List<Move>`
@@ -363,7 +474,7 @@ Scope: After the player selects an own-color piece on their turn, expose that pi
 
 | Output | Equivalence classes |
 | ------ | ------------------- |
-| Returned list | empty; non-empty (same as board) |
+| Returned list | empty; non-empty (same as board); **mutable** empty (`ArrayList`) when no selection |
 
 ### Step 2: BVA catalog data types
 
@@ -375,7 +486,7 @@ Scope: After the player selects an own-color piece on their turn, expose that pi
 
 ### Step 3: Concrete boundary values
 
-- No selection: fresh controller; `getLegalMovesForSelection()` before any click.
+- No selection: fresh controller; `getLegalMovesForSelection()` before any click; returned list must be a **mutable** `ArrayList` (not `Collections.emptyList()`).
 - With selection: white turn; click white pawn at `Location(0, 6)`; stub `board.getLegalMoves(Location(0, 6))`.
 - Board returns empty: same selection state; stub empty list from `getLegalMoves`.
 
@@ -385,6 +496,11 @@ Scope: After the player selects an own-color piece on their turn, expose that pi
   - **Method(s) under test**: `getLegalMovesForSelection()`
   - **State of the system**: newly constructed controller; no piece selected
   - **Expected output**: returned list size is `0`
+
+- **BC-TC76: GetLegalMovesForSelection_NoSelection_ReturnsMutableEmptyList** ( :white_check_mark: )
+  - **Method(s) under test**: `getLegalMovesForSelection()`
+  - **State of the system**: no selection (`Optional.empty()`)
+  - **Expected output**: returned list accepts an added element (mutable `ArrayList`)
 
 - **BC-TC53: GetLegalMovesForSelection_WithSelection_ReturnsMovesFromBoard** ( :white_check_mark: )
   - **Method(s) under test**: `getLegalMovesForSelection()`, `handleSquareClick(Location)`
@@ -417,29 +533,47 @@ Scope: when a piece is already selected, a second click either executes a legal 
 | Input: destination square | Cases | legal destination, illegal empty, own piece |
 | Output: `makeMove` called | Boolean | `true`, `false` |
 | Output: selection cleared | Boolean | `true`, `false` |
+| Output: `BoardView.repaint()` | Counts | 0, 1, 2 calls per click sequence |
 
 ### Step 3: Boundary Values (from BVA Catalog)
 
-- Legal destination: stub `getLegalMoves(src)` returns move to `(0, 5)`; click `(0, 5)` → `makeMove` once
-- Illegal destination: stub returns move list with no matching `to` → selection cleared
-- Own piece: click another white piece while selected → new `lastSelectedLoc`, no `makeMove`
+- Legal destination: stub `getLegalMoves(src)` returns move to `(0, 5)`; click `(0, 5)` → `makeMove` once; **two** `repaint()` calls (select + move)
+- Illegal destination: stub returns move list with no matching `to` → selection cleared; **two** `repaint()` calls
+- Own piece: click another white piece while selected → new `lastSelectedLoc`, no `makeMove`; **two** `repaint()` calls
 
 ### Step 4: Test Cases (Each-Choice Strategy)
 
-Unit tests use **EasyMock** on `Board`; `makeMove` verified with `EasyMock.verify`.
+Unit tests use **EasyMock** on `Board`; `makeMove` verified with `EasyMock.verify`. Repaint tests use strict `BoardView` mocks via `controllerWithBoardView`.
 
 - **BC-TC55: HandleSquareClick_WithSelection_OnLegalDestination_CallsMakeMove** ( :white_check_mark: )
   - **Method(s) under test**: `handleSquareClick(Location)`
   - **State of the system**: white turn; pawn selected at `(0, 6)`; board returns legal move to `(0, 5)`
   - **Expected output**: `board.makeMove` called once with that move; `hasSelection()` is `false`
+
+- **BC-TC80: ExecuteMove_OnLegalMove_RepaintsBoardViewTwice** ( :white_check_mark: )
+  - **Method(s) under test**: `handleSquareClick(Location)` (via `executeMove`, `repaintBoardView`)
+  - **State of the system**: selection then legal destination; `makeMove` invoked; strict `BoardView` mock
+  - **Expected output**: `boardView.repaint()` called twice
+
 - **BC-TC56: HandleSquareClick_WithSelection_OnIllegalDestination_ClearsSelection** ( :white_check_mark: )
   - **Method(s) under test**: `handleSquareClick(Location)`
   - **State of the system**: white turn; piece selected; click `(3, 3)` not in legal moves
   - **Expected output**: `board.makeMove` not called; `hasSelection()` is `false`
+
+- **BC-TC79: HandleSquareClick_WithSelection_OnIllegalDestination_RepaintsBoardViewTwice** ( :white_check_mark: )
+  - **Method(s) under test**: `handleSquareClick(Location)` (illegal destination path)
+  - **State of the system**: selection then illegal empty destination with no matching move; strict `BoardView` mock
+  - **Expected output**: `boardView.repaint()` called twice
+
 - **BC-TC57: HandleSquareClick_WithSelection_OnOwnPiece_ChangesSelection** ( :white_check_mark: )
   - **Method(s) under test**: `handleSquareClick(Location)`, `getSelectedLocation()`
   - **State of the system**: white turn; pawn at `(0, 6)` selected; click white knight at `(1, 7)`
   - **Expected output**: `makeMove` not called; `getSelectedLocation()` is `(1, 7)`
+
+- **BC-TC78: HandleSquareClick_WithSelection_OnOwnPiece_RepaintsBoardViewTwice** ( :white_check_mark: )
+  - **Method(s) under test**: `handleSquareClick(Location)` (via `handleDestinationClick` reselect)
+  - **State of the system**: selection then click second own piece; strict `BoardView` mock
+  - **Expected output**: `boardView.repaint()` called twice
 
 ---
 
@@ -499,9 +633,14 @@ Unit tests use **EasyMock** on `Board`; `makeMove` verified with `EasyMock.verif
   - **Covered by**: BC-TC55
 
 - **BC-TC59: ExecuteMove_AfterMoveResultsInGameOver_ShowEndGameCalled** ( :white_check_mark: )
-  - **Method(s) under test**: `executeMove(Move, PieceColor)`
-  - **State of the system**: board returns `WHITE_WIN` after `makeMove`; `boardController.show()` called first
-  - **Expected output**: a visible `EndGameView` window found in `Window.getWindows()`
+  - **Method(s) under test**: `executeMove(Move, PieceColor)` (via `showEndGame()`)
+  - **State of the system**: board returns `WHITE_WIN` after `makeMove`; `mainView` wired
+  - **Expected output**: `mainView.setVisible(false)` called once (EndGameController.show side effect)
+
+- **BC-TC84: ExecuteMove_AfterMoveResultsInGameOver_EndGameViewIsVisible** ( :white_check_mark: )
+  - **Method(s) under test**: `executeMove(Move, PieceColor)` → `showEndGame()` → `EndGameController.show()`
+  - **State of the system**: mocked `MainView`; post-move `WHITE_WIN`; display available (not headless)
+  - **Expected output**: an `EndGameView` window is visible after the move
 
 - **BC-TC60: ExecuteMove_OnNonPromotionMove_AsBlack_MakeMoveCalledDirectly** ( :white_check_mark: )
   - **Method(s) under test**: `executeMove(Move, PieceColor)`
@@ -602,9 +741,44 @@ Unit tests use **EasyMock** on `Board`; `makeMove` verified with `EasyMock.verif
 
 - **BC-TC67: ShowEndGame_WhenCalled_EndGameViewIsVisible** ( :white_check_mark: )
   - **Method(s) under test**: `showEndGame()`
-  - **State of the system**: game is in a terminal state; `boardController.show()` called first
+  - **State of the system**: game is in a terminal state; move path triggers `showEndGame()`
   - **Expected output**: a visible `EndGameView` in `Window.getWindows()`
-  - **Covered by**: BC-TC59, BC-TC64, BC-TC65 (each triggers `showEndGame()` and verifies `EndGameView` is visible)
+  - **Covered by**: BC-TC59, BC-TC64, BC-TC65, BC-TC84
+
+---
+
+## Method: `show()`
+
+### Step 1: Input and output equivalence classes
+
+| State | Equivalence classes |
+| ----- | ------------------- |
+| Display | headed environment vs headless (skip) |
+| Board | real standard start via `StandardBoardInitializer` |
+
+| Output | Equivalence classes |
+| ------ | ------------------- |
+| `mainView` | created and visible |
+| Current player label | updated via `updateCurrentPlayerLabel()` |
+
+### Step 2: BVA catalog data types
+
+| Variable / output | Catalog type |
+| ----------------- | ------------ |
+| Display available | Boolean |
+| `mainView.isVisible()` | Boolean |
+
+### Step 3: Concrete boundary values
+
+- Headed environment: `show()` → `getMainView().isVisible()` is `true`
+- Headless: test skipped via `assumeTrue`
+
+### Step 4: Test cases
+
+- **BC-TC85: Show_WhenCalled_MainViewBecomesVisible** ( :white_check_mark: )
+  - **Method(s) under test**: `show()`
+  - **State of the system**: real `Board` standard start; display available (not headless)
+  - **Expected output**: `getMainView().isVisible()` is `true`
 
 ---
 
@@ -673,68 +847,3 @@ Win and draw text load from `messages.properties` / `messages_es.properties` via
   - **Method(s) under test**: `buildEndGameMessage()`
   - **State of the system**: `locale = Locale.forLanguageTag("es")`; board returns `DRAW`
   - **Expected output**: `"¡Empate!"`
-
----
-
-## Method / behavior: coverage gaps — getters, repaint, bounds, `show()`
-
-Scope: PIT line/mutation gaps not exercised by BC-TC1–73. Tests use EasyMock strict `verify` on `BoardView.repaint()` where void-call mutants survived; headless-gated `show()` for Swing UI.
-
-### Step 4: Test cases
-
-- **BC-TC74: GetMainView_BeforeShow_ReturnsNull** ( :white_check_mark: )
-  - **Method(s) under test**: `getMainView()`
-  - **State of the system**: fresh controller; `show()` not called
-  - **Expected output**: `null`
-- **BC-TC86: GetMainView_AfterSetMainView_ReturnsInjectedView** ( :white_check_mark: )
-  - **Method(s) under test**: `getMainView()`, `setMainView(MainView)`
-  - **State of the system**: `MainView` mock injected via `setMainView`
-  - **Expected output**: `getMainView()` returns the same mock instance
-- **BC-TC75: GetBoardView_AfterSetBoardView_ReturnsInjectedView** ( :white_check_mark: )
-  - **Method(s) under test**: `getBoardView()`, `setBoardView(BoardView)`
-  - **State of the system**: `BoardView` mock injected via `setBoardView`
-  - **Expected output**: `getBoardView()` returns the same mock instance
-- **BC-TC76: GetLegalMovesForSelection_NoSelection_ReturnsMutableEmptyList** ( :white_check_mark: )
-  - **Method(s) under test**: `getLegalMovesForSelection()`
-  - **State of the system**: no selection (`Optional.empty()`)
-  - **Expected output**: returned list accepts an added element (mutable `ArrayList`)
-- **BC-TC77: HandleSquareClick_OnWhitePiece_RepaintsBoardView** ( :white_check_mark: )
-  - **Method(s) under test**: `handleSquareClick(Location)` (via `handleSourceClick`, `repaintBoardView`)
-  - **State of the system**: `BoardView` strict mock; white turn; click own white pawn
-  - **Expected output**: `boardView.repaint()` called once; `verify(boardViewMock)` passes
-- **BC-TC78: HandleSquareClick_WithSelection_OnOwnPiece_RepaintsBoardViewTwice** ( :white_check_mark: )
-  - **Method(s) under test**: `handleSquareClick(Location)` (via `handleDestinationClick` reselect)
-  - **State of the system**: selection then click second own piece
-  - **Expected output**: `boardView.repaint()` called twice
-- **BC-TC79: HandleSquareClick_WithSelection_OnIllegalDestination_RepaintsBoardViewTwice** ( :white_check_mark: )
-  - **Method(s) under test**: `handleSquareClick(Location)` (illegal destination path)
-  - **State of the system**: selection then illegal empty destination with no matching move
-  - **Expected output**: `boardView.repaint()` called twice
-- **BC-TC80: ExecuteMove_OnLegalMove_RepaintsBoardViewTwice** ( :white_check_mark: )
-  - **Method(s) under test**: `handleSquareClick(Location)` (via `executeMove`, `repaintBoardView`)
-  - **State of the system**: selection then legal destination; `makeMove` invoked
-  - **Expected output**: `boardView.repaint()` called twice
-- **BC-TC81: HandleSquareClick_OnFileEight_IgnoresClick** ( :white_check_mark: )
-  - **Method(s) under test**: `handleSquareClick(Location)` (via `isInBounds`)
-  - **State of the system**: `Location(8, 0)` out of bounds; white turn
-  - **Expected output**: `hasSelection()` remains `false`
-- **BC-TC87: HandleSquareClick_OnRankEight_IgnoresClick** ( :white_check_mark: )
-  - **Method(s) under test**: `handleSquareClick(Location)` (via `isInBounds`)
-  - **State of the system**: `Location(0, 8)` out of bounds; white turn
-  - **Expected output**: `hasSelection()` remains `false`
-- **BC-TC82: HandleSquareClick_OnMaxInBoundsSquare_AcceptsClick** ( :white_check_mark: )
-  - **Method(s) under test**: `handleSquareClick(Location)` (via `isInBounds`)
-  - **State of the system**: `Location(7, 7)` white rook on white turn
-  - **Expected output**: `hasSelection()` is `true`
-- **BC-TC83: HandleSquareClick_WhenGameOver_IgnoresClick** ( :white_check_mark: )
-  - **Method(s) under test**: `handleSquareClick(Location)`
-  - **State of the system**: board returns `WHITE_WIN`; click `(0, 6)`
-  - **Expected output**: `hasSelection()` remains `false`
-- **BC-TC84: ExecuteMove_AfterMoveResultsInGameOver_EndGameViewIsVisible** ( :white_check_mark: )
-  - **Method(s) under test**: `executeMove` → `showEndGame()` → `EndGameController.show()`
-  - **State of the system**: mocked `MainView`; post-move `WHITE_WIN`
-  - **Expected output**: an `EndGameView` window is visible after the move
-- **BC-TC85: Show_WhenCalled_MainViewBecomesVisible** ( :white_check_mark: )
-  - **Method(s) under test**: `show()`
-  - **State of the system**: real `Board` standard start; display available (not headless)
-  - **Expected output**: `getMainView().isVisible()` is `true`

--- a/docs/bva/BoardController.md
+++ b/docs/bva/BoardController.md
@@ -718,7 +718,7 @@ Scope: PIT line/mutation gaps not exercised by BC-TC1–73. Tests use EasyMock s
   - **Method(s) under test**: `handleSquareClick(Location)` (via `isInBounds`)
   - **State of the system**: `Location(8, 0)` out of bounds; white turn
   - **Expected output**: `hasSelection()` remains `false`
-- **BC-TC87: HandleSquareClick_OnRankEight_IgnoresClick** ( :x: )
+- **BC-TC87: HandleSquareClick_OnRankEight_IgnoresClick** ( :white_check_mark: )
   - **Method(s) under test**: `handleSquareClick(Location)` (via `isInBounds`)
   - **State of the system**: `Location(0, 8)` out of bounds; white turn
   - **Expected output**: `hasSelection()` remains `false`

--- a/docs/bva/BoardController.md
+++ b/docs/bva/BoardController.md
@@ -682,7 +682,7 @@ Scope: PIT line/mutation gaps not exercised by BC-TC1–73. Tests use EasyMock s
 
 ### Step 4: Test cases
 
-- **BC-TC74: GetMainView_BeforeShow_ReturnsNull** ( :x: )
+- **BC-TC74: GetMainView_BeforeShow_ReturnsNull** ( :white_check_mark: )
   - **Method(s) under test**: `getMainView()`
   - **State of the system**: fresh controller; `show()` not called
   - **Expected output**: `null`

--- a/docs/bva/BoardController.md
+++ b/docs/bva/BoardController.md
@@ -694,7 +694,7 @@ Scope: PIT line/mutation gaps not exercised by BC-TC1–73. Tests use EasyMock s
   - **Method(s) under test**: `getBoardView()`, `setBoardView(BoardView)`
   - **State of the system**: `BoardView` mock injected via `setBoardView`
   - **Expected output**: `getBoardView()` returns the same mock instance
-- **BC-TC76: GetLegalMovesForSelection_NoSelection_ReturnsMutableEmptyList** ( :x: )
+- **BC-TC76: GetLegalMovesForSelection_NoSelection_ReturnsMutableEmptyList** ( :white_check_mark: )
   - **Method(s) under test**: `getLegalMovesForSelection()`
   - **State of the system**: no selection (`Optional.empty()`)
   - **Expected output**: returned list accepts an added element (mutable `ArrayList`)

--- a/docs/bva/BoardController.md
+++ b/docs/bva/BoardController.md
@@ -42,22 +42,21 @@ Scope: **Game Initialization and interaction** — selection state, snapshot/tur
 
 | State | Equivalence classes |
 | ----- | ------------------- |
-| `mainView` field | unset (`show()` not called); injected via `setMainView` |
+| `mainView` field | injected via `setMainView` |
 
 | Output | Equivalence classes |
 | ------ | ------------------- |
-| `getMainView()` | `null`; same instance as injected mock |
+| `getMainView()` | same instance as injected mock |
 
 ### Step 2: BVA catalog data types
 
 | Variable / output | Catalog type | Notes |
 | ----------------- | ------------ | ----- |
-| `mainView` | Pointers | unset vs injected reference |
-| Return value | Pointers | `null` vs non-null |
+| `mainView` | Pointers | injected reference |
+| Return value | Pointers | same reference as field |
 
 ### Step 3: Concrete boundary values
 
-- Before `show()` / `setMainView`: `getMainView()` → `null`
 - After `setMainView(mock)`: `getMainView()` → same mock reference
 
 ### Step 4: Test cases

--- a/docs/bva/BoardController.md
+++ b/docs/bva/BoardController.md
@@ -673,3 +673,68 @@ Win and draw text load from `messages.properties` / `messages_es.properties` via
   - **Method(s) under test**: `buildEndGameMessage()`
   - **State of the system**: `locale = Locale.forLanguageTag("es")`; board returns `DRAW`
   - **Expected output**: `"¡Empate!"`
+
+---
+
+## Method / behavior: coverage gaps — getters, repaint, bounds, `show()`
+
+Scope: PIT line/mutation gaps not exercised by BC-TC1–73. Tests use EasyMock strict `verify` on `BoardView.repaint()` where void-call mutants survived; headless-gated `show()` for Swing UI.
+
+### Step 4: Test cases
+
+- **BC-TC74: GetMainView_BeforeShow_ReturnsNull** ( :x: )
+  - **Method(s) under test**: `getMainView()`
+  - **State of the system**: fresh controller; `show()` not called
+  - **Expected output**: `null`
+- **BC-TC86: GetMainView_AfterSetMainView_ReturnsInjectedView** ( :x: )
+  - **Method(s) under test**: `getMainView()`, `setMainView(MainView)`
+  - **State of the system**: `MainView` mock injected via `setMainView`
+  - **Expected output**: `getMainView()` returns the same mock instance
+- **BC-TC75: GetBoardView_AfterSetBoardView_ReturnsInjectedView** ( :x: )
+  - **Method(s) under test**: `getBoardView()`, `setBoardView(BoardView)`
+  - **State of the system**: `BoardView` mock injected via `setBoardView`
+  - **Expected output**: `getBoardView()` returns the same mock instance
+- **BC-TC76: GetLegalMovesForSelection_NoSelection_ReturnsMutableEmptyList** ( :x: )
+  - **Method(s) under test**: `getLegalMovesForSelection()`
+  - **State of the system**: no selection (`Optional.empty()`)
+  - **Expected output**: returned list accepts an added element (mutable `ArrayList`)
+- **BC-TC77: HandleSquareClick_OnWhitePiece_RepaintsBoardView** ( :x: )
+  - **Method(s) under test**: `handleSquareClick(Location)` (via `handleSourceClick`, `repaintBoardView`)
+  - **State of the system**: `BoardView` strict mock; white turn; click own white pawn
+  - **Expected output**: `boardView.repaint()` called once; `verify(boardViewMock)` passes
+- **BC-TC78: HandleSquareClick_WithSelection_OnOwnPiece_RepaintsBoardViewTwice** ( :x: )
+  - **Method(s) under test**: `handleSquareClick(Location)` (via `handleDestinationClick` reselect)
+  - **State of the system**: selection then click second own piece
+  - **Expected output**: `boardView.repaint()` called twice
+- **BC-TC79: HandleSquareClick_WithSelection_OnIllegalDestination_RepaintsBoardViewTwice** ( :x: )
+  - **Method(s) under test**: `handleSquareClick(Location)` (illegal destination path)
+  - **State of the system**: selection then illegal empty destination with no matching move
+  - **Expected output**: `boardView.repaint()` called twice
+- **BC-TC80: ExecuteMove_OnLegalMove_RepaintsBoardViewTwice** ( :x: )
+  - **Method(s) under test**: `handleSquareClick(Location)` (via `executeMove`, `repaintBoardView`)
+  - **State of the system**: selection then legal destination; `makeMove` invoked
+  - **Expected output**: `boardView.repaint()` called twice
+- **BC-TC81: HandleSquareClick_OnFileEight_IgnoresClick** ( :x: )
+  - **Method(s) under test**: `handleSquareClick(Location)` (via `isInBounds`)
+  - **State of the system**: `Location(8, 0)` out of bounds; white turn
+  - **Expected output**: `hasSelection()` remains `false`
+- **BC-TC87: HandleSquareClick_OnRankEight_IgnoresClick** ( :x: )
+  - **Method(s) under test**: `handleSquareClick(Location)` (via `isInBounds`)
+  - **State of the system**: `Location(0, 8)` out of bounds; white turn
+  - **Expected output**: `hasSelection()` remains `false`
+- **BC-TC82: HandleSquareClick_OnMaxInBoundsSquare_AcceptsClick** ( :x: )
+  - **Method(s) under test**: `handleSquareClick(Location)` (via `isInBounds`)
+  - **State of the system**: `Location(7, 7)` white rook on white turn
+  - **Expected output**: `hasSelection()` is `true`
+- **BC-TC83: HandleSquareClick_WhenGameOver_IgnoresClick** ( :x: )
+  - **Method(s) under test**: `handleSquareClick(Location)`
+  - **State of the system**: board returns `WHITE_WIN`; click `(0, 6)`
+  - **Expected output**: `hasSelection()` remains `false`
+- **BC-TC84: ExecuteMove_AfterMoveResultsInGameOver_EndGameViewIsVisible** ( :x: )
+  - **Method(s) under test**: `executeMove` → `showEndGame()` → `EndGameController.show()`
+  - **State of the system**: mocked `MainView`; post-move `WHITE_WIN`
+  - **Expected output**: an `EndGameView` window is visible after the move
+- **BC-TC85: Show_WhenCalled_MainViewBecomesVisible** ( :x: )
+  - **Method(s) under test**: `show()`
+  - **State of the system**: real `Board` standard start; display available (not headless)
+  - **Expected output**: `getMainView().isVisible()` is `true`

--- a/docs/bva/BoardController.md
+++ b/docs/bva/BoardController.md
@@ -722,7 +722,7 @@ Scope: PIT line/mutation gaps not exercised by BC-TC1–73. Tests use EasyMock s
   - **Method(s) under test**: `handleSquareClick(Location)` (via `isInBounds`)
   - **State of the system**: `Location(0, 8)` out of bounds; white turn
   - **Expected output**: `hasSelection()` remains `false`
-- **BC-TC82: HandleSquareClick_OnMaxInBoundsSquare_AcceptsClick** ( :x: )
+- **BC-TC82: HandleSquareClick_OnMaxInBoundsSquare_AcceptsClick** ( :white_check_mark: )
   - **Method(s) under test**: `handleSquareClick(Location)` (via `isInBounds`)
   - **State of the system**: `Location(7, 7)` white rook on white turn
   - **Expected output**: `hasSelection()` is `true`

--- a/docs/bva/BoardController.md
+++ b/docs/bva/BoardController.md
@@ -726,7 +726,7 @@ Scope: PIT line/mutation gaps not exercised by BC-TC1–73. Tests use EasyMock s
   - **Method(s) under test**: `handleSquareClick(Location)` (via `isInBounds`)
   - **State of the system**: `Location(7, 7)` white rook on white turn
   - **Expected output**: `hasSelection()` is `true`
-- **BC-TC83: HandleSquareClick_WhenGameOver_IgnoresClick** ( :x: )
+- **BC-TC83: HandleSquareClick_WhenGameOver_IgnoresClick** ( :white_check_mark: )
   - **Method(s) under test**: `handleSquareClick(Location)`
   - **State of the system**: board returns `WHITE_WIN`; click `(0, 6)`
   - **Expected output**: `hasSelection()` remains `false`

--- a/docs/bva/BoardController.md
+++ b/docs/bva/BoardController.md
@@ -730,7 +730,7 @@ Scope: PIT line/mutation gaps not exercised by BC-TC1–73. Tests use EasyMock s
   - **Method(s) under test**: `handleSquareClick(Location)`
   - **State of the system**: board returns `WHITE_WIN`; click `(0, 6)`
   - **Expected output**: `hasSelection()` remains `false`
-- **BC-TC84: ExecuteMove_AfterMoveResultsInGameOver_EndGameViewIsVisible** ( :x: )
+- **BC-TC84: ExecuteMove_AfterMoveResultsInGameOver_EndGameViewIsVisible** ( :white_check_mark: )
   - **Method(s) under test**: `executeMove` → `showEndGame()` → `EndGameController.show()`
   - **State of the system**: mocked `MainView`; post-move `WHITE_WIN`
   - **Expected output**: an `EndGameView` window is visible after the move

--- a/docs/bva/BoardController.md
+++ b/docs/bva/BoardController.md
@@ -714,7 +714,7 @@ Scope: PIT line/mutation gaps not exercised by BC-TC1–73. Tests use EasyMock s
   - **Method(s) under test**: `handleSquareClick(Location)` (via `executeMove`, `repaintBoardView`)
   - **State of the system**: selection then legal destination; `makeMove` invoked
   - **Expected output**: `boardView.repaint()` called twice
-- **BC-TC81: HandleSquareClick_OnFileEight_IgnoresClick** ( :x: )
+- **BC-TC81: HandleSquareClick_OnFileEight_IgnoresClick** ( :white_check_mark: )
   - **Method(s) under test**: `handleSquareClick(Location)` (via `isInBounds`)
   - **State of the system**: `Location(8, 0)` out of bounds; white turn
   - **Expected output**: `hasSelection()` remains `false`

--- a/docs/bva/BoardController.md
+++ b/docs/bva/BoardController.md
@@ -734,7 +734,7 @@ Scope: PIT line/mutation gaps not exercised by BC-TC1–73. Tests use EasyMock s
   - **Method(s) under test**: `executeMove` → `showEndGame()` → `EndGameController.show()`
   - **State of the system**: mocked `MainView`; post-move `WHITE_WIN`
   - **Expected output**: an `EndGameView` window is visible after the move
-- **BC-TC85: Show_WhenCalled_MainViewBecomesVisible** ( :x: )
+- **BC-TC85: Show_WhenCalled_MainViewBecomesVisible** ( :white_check_mark: )
   - **Method(s) under test**: `show()`
   - **State of the system**: real `Board` standard start; display available (not headless)
   - **Expected output**: `getMainView().isVisible()` is `true`

--- a/docs/bva/BoardController.md
+++ b/docs/bva/BoardController.md
@@ -706,7 +706,7 @@ Scope: PIT line/mutation gaps not exercised by BC-TC1–73. Tests use EasyMock s
   - **Method(s) under test**: `handleSquareClick(Location)` (via `handleDestinationClick` reselect)
   - **State of the system**: selection then click second own piece
   - **Expected output**: `boardView.repaint()` called twice
-- **BC-TC79: HandleSquareClick_WithSelection_OnIllegalDestination_RepaintsBoardViewTwice** ( :x: )
+- **BC-TC79: HandleSquareClick_WithSelection_OnIllegalDestination_RepaintsBoardViewTwice** ( :white_check_mark: )
   - **Method(s) under test**: `handleSquareClick(Location)` (illegal destination path)
   - **State of the system**: selection then illegal empty destination with no matching move
   - **Expected output**: `boardView.repaint()` called twice

--- a/src/test/java/ui/BoardControllerTest.java
+++ b/src/test/java/ui/BoardControllerTest.java
@@ -1680,7 +1680,6 @@ class BoardControllerTest {
     }
     @Test
     void HandleSquareClick_WhenGameOver_IgnoresClick() {
-        Piece[][] standardGrid = newStandardStartingGrid();
         Board boardMock = EasyMock.createMock(Board.class);
         EasyMock.expect(boardMock.getCurrentGameState()).andReturn(GameState.WHITE_WIN);
         EasyMock.replay(boardMock);
@@ -1695,6 +1694,9 @@ class BoardControllerTest {
         assertEquals(expected, actual);
         EasyMock.verify(boardMock, boardViewMock);
     }
+    @SuppressFBWarnings(
+            value = "RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT",
+            justification = "Return value not needed; called for side-effectful headless check")
     @Test
     void ExecuteMove_AfterMoveResultsInGameOver_EndGameViewIsVisible() {
         assumeTrue(
@@ -1735,6 +1737,9 @@ class BoardControllerTest {
         assertEquals(expected, actual);
         EasyMock.verify(boardMock, mainViewMock, statsMock);
     }
+    @SuppressFBWarnings(
+            value = "RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT",
+            justification = "Return value not needed; called for side-effectful headless check")
     @Test
     void Show_WhenCalled_MainViewBecomesVisible() {
         assumeTrue(

--- a/src/test/java/ui/BoardControllerTest.java
+++ b/src/test/java/ui/BoardControllerTest.java
@@ -1519,5 +1519,19 @@ class BoardControllerTest {
         assertEquals(expected, actual);
         EasyMock.verify(boardMock, mainViewMock);
     }
+    @Test
+    void GetBoardView_AfterSetBoardView_ReturnsInjectedView() {
+        Board boardMock = replayEmptyBoard();
+        BoardView boardViewMock = EasyMock.createMock(BoardView.class);
+        EasyMock.replay(boardViewMock);
+
+        BoardController controller = newController(boardMock);
+        controller.setBoardView(boardViewMock);
+
+        BoardView expected = boardViewMock;
+        BoardView actual = controller.getBoardView();
+        assertEquals(expected, actual);
+        EasyMock.verify(boardMock, boardViewMock);
+    }
 
 }

--- a/src/test/java/ui/BoardControllerTest.java
+++ b/src/test/java/ui/BoardControllerTest.java
@@ -1505,5 +1505,19 @@ class BoardControllerTest {
         assertEquals(expected, actual);
         EasyMock.verify(boardMock);
     }
+    @Test
+    void GetMainView_AfterSetMainView_ReturnsInjectedView() {
+        Board boardMock = replayEmptyBoard();
+        MainView mainViewMock = EasyMock.createMock(MainView.class);
+        EasyMock.replay(mainViewMock);
+
+        BoardController controller = newController(boardMock);
+        controller.setMainView(mainViewMock);
+
+        MainView expected = mainViewMock;
+        MainView actual = controller.getMainView();
+        assertEquals(expected, actual);
+        EasyMock.verify(boardMock, mainViewMock);
+    }
 
 }

--- a/src/test/java/ui/BoardControllerTest.java
+++ b/src/test/java/ui/BoardControllerTest.java
@@ -1,6 +1,7 @@
 package ui;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import domain.Board;
 import domain.FischerRandomBoardInitializer;
@@ -19,18 +20,31 @@ import domain.piece.PieceColor;
 import domain.piece.PieceType;
 import domain.piece.Queen;
 import domain.piece.Rook;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.awt.GraphicsEnvironment;
+import java.awt.Window;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.Random;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 class BoardControllerTest {
 
     private static final String TEST_PLAYER_ONE = "Alice";
     private static final String TEST_PLAYER_TWO = "Bob";
+
+    @AfterEach
+    void disposeOpenUiWindows() {
+        for (Window window : Window.getWindows()) {
+            if (window instanceof MainView || window instanceof EndGameView) {
+                window.dispose();
+            }
+        }
+    }
 
     @Test
     void Constructor_FreshInstance_LastSelectedUnset() {
@@ -844,6 +858,25 @@ class BoardControllerTest {
         return controller;
     }
 
+    private static BoardController newController(Board board) {
+        return new BoardController(TEST_PLAYER_ONE, TEST_PLAYER_TWO, board, Locale.ENGLISH);
+    }
+
+    private static BoardController controllerWithBoardView(Board board, BoardView boardView) {
+        BoardController controller = newController(board);
+        controller.setBoardView(boardView);
+        return controller;
+    }
+
+    private static boolean anyEndGameViewVisible() {
+        for (Window window : Window.getWindows()) {
+            if (window instanceof EndGameView && window.isVisible()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private static Board replayEmptyBoard() {
         Board boardMock = EasyMock.createMock(Board.class);
         EasyMock.replay(boardMock);
@@ -1460,6 +1493,17 @@ class BoardControllerTest {
 
         assertEquals(Optional.of(PieceType.QUEEN), capturedMove.getValue().getPromotionType());
         EasyMock.verify(boardMock, mainViewMock, statsMock);
+    }
+
+    @Test
+    void GetMainView_BeforeShow_ReturnsNull() {
+        Board boardMock = replayEmptyBoard();
+        BoardController controller = newController(boardMock);
+
+        MainView expected = null;
+        MainView actual = controller.getMainView();
+        assertEquals(expected, actual);
+        EasyMock.verify(boardMock);
     }
 
 }

--- a/src/test/java/ui/BoardControllerTest.java
+++ b/src/test/java/ui/BoardControllerTest.java
@@ -67,6 +67,7 @@ class BoardControllerTest {
         assertEquals(expected, actual);
         EasyMock.verify(boardMock);
     }
+
     @Test
     void GetMainView_BeforeShow_ReturnsNull() {
         Board boardMock = replayEmptyBoard();
@@ -77,6 +78,7 @@ class BoardControllerTest {
         assertEquals(expected, actual);
         EasyMock.verify(boardMock);
     }
+
     @Test
     void GetMainView_AfterSetMainView_ReturnsInjectedView() {
         Board boardMock = replayEmptyBoard();
@@ -91,6 +93,7 @@ class BoardControllerTest {
         assertEquals(expected, actual);
         EasyMock.verify(boardMock, mainViewMock);
     }
+
     @Test
     void GetBoardView_AfterSetBoardView_ReturnsInjectedView() {
         Board boardMock = replayEmptyBoard();
@@ -156,6 +159,7 @@ class BoardControllerTest {
         assertEquals(expected, actual);
         EasyMock.verify(boardMock);
     }
+
     @Test
     void GetLegalMovesForSelection_NoSelection_ReturnsMutableEmptyList() {
         Board boardMock = replayEmptyBoard();
@@ -551,11 +555,12 @@ class BoardControllerTest {
         assertEquals(expected, actual);
         EasyMock.verify(boardMock);
     }
+
     @Test
     void HandleSquareClick_OnWhitePiece_RepaintsBoardView() {
         Piece[][] standardGrid = newStandardStartingGrid();
-        Location selected = new Location(0, 6);
-        Board boardMock = boardForWhitePieceClick(standardGrid, 6, 0);
+        final Location selected = new Location(0, 6);
+        final Board boardMock = boardForWhitePieceClick(standardGrid, 6, 0);
         BoardView boardViewMock = EasyMock.createMock(BoardView.class);
         boardViewMock.repaint();
         EasyMock.expectLastCall().once();
@@ -694,6 +699,7 @@ class BoardControllerTest {
         assertEquals(expected, actual);
         EasyMock.verify(boardMock);
     }
+
     @Test
     void HandleSquareClick_OnFileEight_IgnoresClick() {
         Board boardMock = replayEmptyBoard();
@@ -708,6 +714,7 @@ class BoardControllerTest {
         assertEquals(expected, actual);
         EasyMock.verify(boardMock, boardViewMock);
     }
+
     @Test
     void HandleSquareClick_OnRankEight_IgnoresClick() {
         Board boardMock = replayEmptyBoard();
@@ -722,10 +729,11 @@ class BoardControllerTest {
         assertEquals(expected, actual);
         EasyMock.verify(boardMock, boardViewMock);
     }
+
     @Test
     void HandleSquareClick_OnMaxInBoundsSquare_AcceptsClick() {
         Piece[][] standardGrid = newStandardStartingGrid();
-        Board boardMock = boardForWhitePieceClick(standardGrid, 7, 7);
+        final Board boardMock = boardForWhitePieceClick(standardGrid, 7, 7);
         BoardView boardViewMock = EasyMock.createMock(BoardView.class);
         boardViewMock.repaint();
         EasyMock.expectLastCall().once();
@@ -868,6 +876,7 @@ class BoardControllerTest {
         assertEquals(expected, actual);
         EasyMock.verify(boardMock);
     }
+
     @Test
     void HandleSquareClick_WhenGameOver_IgnoresClick() {
         Board boardMock = EasyMock.createMock(Board.class);
@@ -1309,6 +1318,7 @@ class BoardControllerTest {
         assertEquals(expected, actual);
         EasyMock.verify(boardMock, mainViewMock, statsMock);
     }
+
     @Test
     void ExecuteMove_OnLegalMove_RepaintsBoardViewTwice() {
         Piece[][] standardGrid = newStandardStartingGrid();
@@ -1362,6 +1372,7 @@ class BoardControllerTest {
         assertEquals(expected, actual);
         EasyMock.verify(boardMock);
     }
+
     @Test
     void HandleSquareClick_WithSelection_OnIllegalDestination_RepaintsBoardViewTwice() {
         Piece[][] standardGrid = newStandardStartingGrid();
@@ -1404,6 +1415,7 @@ class BoardControllerTest {
         assertEquals(expected, actual);
         EasyMock.verify(boardMock);
     }
+
     @Test
     void HandleSquareClick_WithSelection_OnOwnPiece_RepaintsBoardViewTwice() {
         Piece[][] standardGrid = newStandardStartingGrid();
@@ -1454,6 +1466,7 @@ class BoardControllerTest {
 
         EasyMock.verify(boardMock, mainViewMock, statsMock);
     }
+
     @SuppressFBWarnings(
             value = "RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT",
             justification = "Return value not needed; called for side-effectful headless check")
@@ -1610,7 +1623,7 @@ class BoardControllerTest {
 
         BoardController controller = controllerFor(boardMock, Locale.forLanguageTag("es"));
 
-        String expected = "\u00A1Alice gana!";
+        String expected = "¡Alice gana!";
         String actual = controller.buildEndGameMessage();
         assertEquals(expected, actual);
         EasyMock.verify(boardMock);
@@ -1624,7 +1637,7 @@ class BoardControllerTest {
 
         BoardController controller = controllerFor(boardMock, Locale.forLanguageTag("es"));
 
-        String expected = "\u00A1Bob gana!";
+        String expected = "¡Bob gana!";
         String actual = controller.buildEndGameMessage();
         assertEquals(expected, actual);
         EasyMock.verify(boardMock);
@@ -1638,7 +1651,7 @@ class BoardControllerTest {
 
         BoardController controller = controllerFor(boardMock, Locale.forLanguageTag("es"));
 
-        String expected = "\u00A1Empate!";
+        String expected = "¡Empate!";
         String actual = controller.buildEndGameMessage();
         assertEquals(expected, actual);
         EasyMock.verify(boardMock);
@@ -1736,6 +1749,7 @@ class BoardControllerTest {
         assertEquals(Optional.of(PieceType.QUEEN), capturedMove.getValue().getPromotionType());
         EasyMock.verify(boardMock, mainViewMock, statsMock);
     }
+
     @SuppressFBWarnings(
             value = "RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT",
             justification = "Return value not needed; called for side-effectful headless check")

--- a/src/test/java/ui/BoardControllerTest.java
+++ b/src/test/java/ui/BoardControllerTest.java
@@ -1735,5 +1735,22 @@ class BoardControllerTest {
         assertEquals(expected, actual);
         EasyMock.verify(boardMock, mainViewMock, statsMock);
     }
+    @Test
+    void Show_WhenCalled_MainViewBecomesVisible() {
+        assumeTrue(
+                !GraphicsEnvironment.getLocalGraphicsEnvironment().isHeadless(),
+                "Skipping: no display available");
+        Board board = new Board(new StandardBoardInitializer());
+        BoardController controller = newController(board);
+        BoardView boardViewMock = EasyMock.createNiceMock(BoardView.class);
+        EasyMock.replay(boardViewMock);
+        controller.setBoardView(boardViewMock);
+
+        controller.show();
+
+        boolean expected = true;
+        boolean actual = controller.getMainView().isVisible();
+        assertEquals(expected, actual);
+    }
 
 }

--- a/src/test/java/ui/BoardControllerTest.java
+++ b/src/test/java/ui/BoardControllerTest.java
@@ -67,6 +67,44 @@ class BoardControllerTest {
         assertEquals(expected, actual);
         EasyMock.verify(boardMock);
     }
+    @Test
+    void GetMainView_BeforeShow_ReturnsNull() {
+        Board boardMock = replayEmptyBoard();
+        BoardController controller = newController(boardMock);
+
+        MainView expected = null;
+        MainView actual = controller.getMainView();
+        assertEquals(expected, actual);
+        EasyMock.verify(boardMock);
+    }
+    @Test
+    void GetMainView_AfterSetMainView_ReturnsInjectedView() {
+        Board boardMock = replayEmptyBoard();
+        MainView mainViewMock = EasyMock.createMock(MainView.class);
+        EasyMock.replay(mainViewMock);
+
+        BoardController controller = newController(boardMock);
+        controller.setMainView(mainViewMock);
+
+        MainView expected = mainViewMock;
+        MainView actual = controller.getMainView();
+        assertEquals(expected, actual);
+        EasyMock.verify(boardMock, mainViewMock);
+    }
+    @Test
+    void GetBoardView_AfterSetBoardView_ReturnsInjectedView() {
+        Board boardMock = replayEmptyBoard();
+        BoardView boardViewMock = EasyMock.createMock(BoardView.class);
+        EasyMock.replay(boardViewMock);
+
+        BoardController controller = newController(boardMock);
+        controller.setBoardView(boardViewMock);
+
+        BoardView expected = boardViewMock;
+        BoardView actual = controller.getBoardView();
+        assertEquals(expected, actual);
+        EasyMock.verify(boardMock, boardViewMock);
+    }
 
     @Test
     void GetLegalMovesForSelection_WithSelection_WhenBoardReturnsEmpty_ReturnsEmptyList() {
@@ -115,6 +153,20 @@ class BoardControllerTest {
 
         int expected = 0;
         int actual = controller.getLegalMovesForSelection().size();
+        assertEquals(expected, actual);
+        EasyMock.verify(boardMock);
+    }
+    @Test
+    void GetLegalMovesForSelection_NoSelection_ReturnsMutableEmptyList() {
+        Board boardMock = replayEmptyBoard();
+        BoardController controller = newController(boardMock);
+
+        List<Move> moves = controller.getLegalMovesForSelection();
+        int sizeBefore = moves.size();
+        moves.add(new Move(new Location(0, 0), new Location(0, 1)));
+
+        int expected = sizeBefore + 1;
+        int actual = moves.size();
         assertEquals(expected, actual);
         EasyMock.verify(boardMock);
     }
@@ -499,6 +551,21 @@ class BoardControllerTest {
         assertEquals(expected, actual);
         EasyMock.verify(boardMock);
     }
+    @Test
+    void HandleSquareClick_OnWhitePiece_RepaintsBoardView() {
+        Piece[][] standardGrid = newStandardStartingGrid();
+        Location selected = new Location(0, 6);
+        Board boardMock = boardForWhitePieceClick(standardGrid, 6, 0);
+        BoardView boardViewMock = EasyMock.createMock(BoardView.class);
+        boardViewMock.repaint();
+        EasyMock.expectLastCall().once();
+        EasyMock.replay(boardViewMock);
+
+        BoardController controller = controllerWithBoardView(boardMock, boardViewMock);
+        controller.handleSquareClick(selected);
+
+        EasyMock.verify(boardMock, boardViewMock);
+    }
 
     @Test
     void HandleSquareClick_BeforeFirstMove_OnBlackPiece_NoSelectionAfterClick() {
@@ -626,6 +693,51 @@ class BoardControllerTest {
         boolean actual = cellWiseSameTypeAndColor(standardGrid, controller.getBoardSnapshot());
         assertEquals(expected, actual);
         EasyMock.verify(boardMock);
+    }
+    @Test
+    void HandleSquareClick_OnFileEight_IgnoresClick() {
+        Board boardMock = replayEmptyBoard();
+        BoardView boardViewMock = EasyMock.createMock(BoardView.class);
+        EasyMock.replay(boardViewMock);
+
+        BoardController controller = controllerWithBoardView(boardMock, boardViewMock);
+        controller.handleSquareClick(new Location(8, 0));
+
+        boolean expected = false;
+        boolean actual = controller.hasSelection();
+        assertEquals(expected, actual);
+        EasyMock.verify(boardMock, boardViewMock);
+    }
+    @Test
+    void HandleSquareClick_OnRankEight_IgnoresClick() {
+        Board boardMock = replayEmptyBoard();
+        BoardView boardViewMock = EasyMock.createMock(BoardView.class);
+        EasyMock.replay(boardViewMock);
+
+        BoardController controller = controllerWithBoardView(boardMock, boardViewMock);
+        controller.handleSquareClick(new Location(0, 8));
+
+        boolean expected = false;
+        boolean actual = controller.hasSelection();
+        assertEquals(expected, actual);
+        EasyMock.verify(boardMock, boardViewMock);
+    }
+    @Test
+    void HandleSquareClick_OnMaxInBoundsSquare_AcceptsClick() {
+        Piece[][] standardGrid = newStandardStartingGrid();
+        Board boardMock = boardForWhitePieceClick(standardGrid, 7, 7);
+        BoardView boardViewMock = EasyMock.createMock(BoardView.class);
+        boardViewMock.repaint();
+        EasyMock.expectLastCall().once();
+        EasyMock.replay(boardViewMock);
+
+        BoardController controller = controllerWithBoardView(boardMock, boardViewMock);
+        controller.handleSquareClick(new Location(7, 7));
+
+        boolean expected = true;
+        boolean actual = controller.hasSelection();
+        assertEquals(expected, actual);
+        EasyMock.verify(boardMock, boardViewMock);
     }
 
     @Test
@@ -755,6 +867,22 @@ class BoardControllerTest {
         boolean actual = cellWiseSameTypeAndColor(standardGrid, controller.getBoardSnapshot());
         assertEquals(expected, actual);
         EasyMock.verify(boardMock);
+    }
+    @Test
+    void HandleSquareClick_WhenGameOver_IgnoresClick() {
+        Board boardMock = EasyMock.createMock(Board.class);
+        EasyMock.expect(boardMock.getCurrentGameState()).andReturn(GameState.WHITE_WIN);
+        EasyMock.replay(boardMock);
+        BoardView boardViewMock = EasyMock.createMock(BoardView.class);
+        EasyMock.replay(boardViewMock);
+
+        BoardController controller = controllerWithBoardView(boardMock, boardViewMock);
+        controller.handleSquareClick(new Location(0, 6));
+
+        boolean expected = false;
+        boolean actual = controller.hasSelection();
+        assertEquals(expected, actual);
+        EasyMock.verify(boardMock, boardViewMock);
     }
 
     @Test
@@ -1181,6 +1309,37 @@ class BoardControllerTest {
         assertEquals(expected, actual);
         EasyMock.verify(boardMock, mainViewMock, statsMock);
     }
+    @Test
+    void ExecuteMove_OnLegalMove_RepaintsBoardViewTwice() {
+        Piece[][] standardGrid = newStandardStartingGrid();
+        Location selected = new Location(0, 6);
+        Location destination = new Location(0, 5);
+        Move move = new Move(selected, destination);
+        Board boardMock = EasyMock.createMock(Board.class);
+        final MainView mainViewMock = EasyMock.createMock(MainView.class);
+        final GameStatsView statsMock = EasyMock.createMock(GameStatsView.class);
+        EasyMock.expect(boardMock.getCurrentGameState()).andReturn(GameState.WHITE_TURN).times(4);
+        EasyMock.expect(boardMock.getPieceAt(6, 0)).andReturn(standardGrid[6][0]);
+        EasyMock.expect(boardMock.getPieceAt(5, 0)).andReturn(standardGrid[5][0]);
+        EasyMock.expect(boardMock.getLegalMoves(selected)).andReturn(List.of(move));
+        boardMock.makeMove(move);
+        EasyMock.expectLastCall().once();
+        EasyMock.expect(mainViewMock.getGameStatsView()).andReturn(statsMock);
+        statsMock.updateCurrentPlayerLabel(TEST_PLAYER_ONE);
+        EasyMock.expectLastCall().once();
+        EasyMock.replay(boardMock, mainViewMock, statsMock);
+        BoardView boardViewMock = EasyMock.createMock(BoardView.class);
+        boardViewMock.repaint();
+        EasyMock.expectLastCall().times(2);
+        EasyMock.replay(boardViewMock);
+
+        BoardController controller = controllerWithBoardView(boardMock, boardViewMock);
+        controller.setMainView(mainViewMock);
+        controller.handleSquareClick(selected);
+        controller.handleSquareClick(destination);
+
+        EasyMock.verify(boardMock, mainViewMock, statsMock, boardViewMock);
+    }
 
     @Test
     void HandleSquareClick_WithSelection_OnIllegalDestination_ClearsSelection() {
@@ -1203,6 +1362,27 @@ class BoardControllerTest {
         assertEquals(expected, actual);
         EasyMock.verify(boardMock);
     }
+    @Test
+    void HandleSquareClick_WithSelection_OnIllegalDestination_RepaintsBoardViewTwice() {
+        Piece[][] standardGrid = newStandardStartingGrid();
+        Location selected = new Location(0, 6);
+        Board boardMock = EasyMock.createMock(Board.class);
+        EasyMock.expect(boardMock.getCurrentGameState()).andReturn(GameState.WHITE_TURN).times(2);
+        EasyMock.expect(boardMock.getPieceAt(6, 0)).andReturn(standardGrid[6][0]);
+        EasyMock.expect(boardMock.getPieceAt(3, 3)).andReturn(standardGrid[3][3]);
+        EasyMock.expect(boardMock.getLegalMoves(selected)).andReturn(List.of());
+        EasyMock.replay(boardMock);
+        BoardView boardViewMock = EasyMock.createMock(BoardView.class);
+        boardViewMock.repaint();
+        EasyMock.expectLastCall().times(2);
+        EasyMock.replay(boardViewMock);
+
+        BoardController controller = controllerWithBoardView(boardMock, boardViewMock);
+        controller.handleSquareClick(selected);
+        controller.handleSquareClick(new Location(3, 3));
+
+        EasyMock.verify(boardMock, boardViewMock);
+    }
 
     @Test
     void HandleSquareClick_WithSelection_OnOwnPiece_ChangesSelection() {
@@ -1223,6 +1403,25 @@ class BoardControllerTest {
         Optional<Location> actual = controller.getSelectedLocation();
         assertEquals(expected, actual);
         EasyMock.verify(boardMock);
+    }
+    @Test
+    void HandleSquareClick_WithSelection_OnOwnPiece_RepaintsBoardViewTwice() {
+        Piece[][] standardGrid = newStandardStartingGrid();
+        Board boardMock = EasyMock.createMock(Board.class);
+        EasyMock.expect(boardMock.getCurrentGameState()).andReturn(GameState.WHITE_TURN).times(2);
+        EasyMock.expect(boardMock.getPieceAt(6, 0)).andReturn(standardGrid[6][0]);
+        EasyMock.expect(boardMock.getPieceAt(7, 1)).andReturn(standardGrid[7][1]);
+        EasyMock.replay(boardMock);
+        BoardView boardViewMock = EasyMock.createMock(BoardView.class);
+        boardViewMock.repaint();
+        EasyMock.expectLastCall().times(2);
+        EasyMock.replay(boardViewMock);
+
+        BoardController controller = controllerWithBoardView(boardMock, boardViewMock);
+        controller.handleSquareClick(new Location(0, 6));
+        controller.handleSquareClick(new Location(1, 7));
+
+        EasyMock.verify(boardMock, boardViewMock);
     }
 
     @Test
@@ -1253,6 +1452,49 @@ class BoardControllerTest {
         controller.handleSquareClick(selected);
         controller.handleSquareClick(destination);
 
+        EasyMock.verify(boardMock, mainViewMock, statsMock);
+    }
+    @SuppressFBWarnings(
+            value = "RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT",
+            justification = "Return value not needed; called for side-effectful headless check")
+    @Test
+    void ExecuteMove_AfterMoveResultsInGameOver_EndGameViewIsVisible() {
+        assumeTrue(
+                !GraphicsEnvironment.getLocalGraphicsEnvironment().isHeadless(),
+                "Skipping: no display available");
+        Piece[][] standardGrid = newStandardStartingGrid();
+        Location selected = new Location(0, 6);
+        Location destination = new Location(0, 5);
+        Move move = new Move(selected, destination);
+        Board boardMock = EasyMock.createMock(Board.class);
+        final MainView mainViewMock = EasyMock.createMock(MainView.class);
+        final GameStatsView statsMock = EasyMock.createMock(GameStatsView.class);
+        EasyMock.expect(boardMock.getCurrentGameState()).andReturn(GameState.WHITE_TURN).times(2);
+        EasyMock.expect(boardMock.getCurrentGameState()).andReturn(GameState.WHITE_WIN).times(3);
+        EasyMock.expect(boardMock.getPieceAt(6, 0)).andReturn(standardGrid[6][0]);
+        EasyMock.expect(boardMock.getPieceAt(5, 0)).andReturn(standardGrid[5][0]);
+        EasyMock.expect(boardMock.getLegalMoves(selected)).andReturn(List.of(move));
+        boardMock.makeMove(move);
+        EasyMock.expectLastCall().once();
+        EasyMock.expect(mainViewMock.getGameStatsView()).andReturn(statsMock);
+        statsMock.updateCurrentPlayerLabel(TEST_PLAYER_ONE + " wins!");
+        EasyMock.expectLastCall().once();
+        mainViewMock.setVisible(false);
+        EasyMock.expectLastCall().once();
+        EasyMock.replay(boardMock, mainViewMock, statsMock);
+        BoardView boardViewMock = EasyMock.createMock(BoardView.class);
+        boardViewMock.repaint();
+        EasyMock.expectLastCall().anyTimes();
+        EasyMock.replay(boardViewMock);
+
+        BoardController controller = controllerWithBoardView(boardMock, boardViewMock);
+        controller.setMainView(mainViewMock);
+        controller.handleSquareClick(selected);
+        controller.handleSquareClick(destination);
+
+        boolean expected = true;
+        boolean actual = anyEndGameViewVisible();
+        assertEquals(expected, actual);
         EasyMock.verify(boardMock, mainViewMock, statsMock);
     }
 
@@ -1492,249 +1734,6 @@ class BoardControllerTest {
         controller.handleSquareClick(destination);
 
         assertEquals(Optional.of(PieceType.QUEEN), capturedMove.getValue().getPromotionType());
-        EasyMock.verify(boardMock, mainViewMock, statsMock);
-    }
-
-    @Test
-    void GetMainView_BeforeShow_ReturnsNull() {
-        Board boardMock = replayEmptyBoard();
-        BoardController controller = newController(boardMock);
-
-        MainView expected = null;
-        MainView actual = controller.getMainView();
-        assertEquals(expected, actual);
-        EasyMock.verify(boardMock);
-    }
-    @Test
-    void GetMainView_AfterSetMainView_ReturnsInjectedView() {
-        Board boardMock = replayEmptyBoard();
-        MainView mainViewMock = EasyMock.createMock(MainView.class);
-        EasyMock.replay(mainViewMock);
-
-        BoardController controller = newController(boardMock);
-        controller.setMainView(mainViewMock);
-
-        MainView expected = mainViewMock;
-        MainView actual = controller.getMainView();
-        assertEquals(expected, actual);
-        EasyMock.verify(boardMock, mainViewMock);
-    }
-    @Test
-    void GetBoardView_AfterSetBoardView_ReturnsInjectedView() {
-        Board boardMock = replayEmptyBoard();
-        BoardView boardViewMock = EasyMock.createMock(BoardView.class);
-        EasyMock.replay(boardViewMock);
-
-        BoardController controller = newController(boardMock);
-        controller.setBoardView(boardViewMock);
-
-        BoardView expected = boardViewMock;
-        BoardView actual = controller.getBoardView();
-        assertEquals(expected, actual);
-        EasyMock.verify(boardMock, boardViewMock);
-    }
-    @Test
-    void GetLegalMovesForSelection_NoSelection_ReturnsMutableEmptyList() {
-        Board boardMock = replayEmptyBoard();
-        BoardController controller = newController(boardMock);
-
-        List<Move> moves = controller.getLegalMovesForSelection();
-        int sizeBefore = moves.size();
-        moves.add(new Move(new Location(0, 0), new Location(0, 1)));
-
-        int expected = sizeBefore + 1;
-        int actual = moves.size();
-        assertEquals(expected, actual);
-        EasyMock.verify(boardMock);
-    }
-    @Test
-    void HandleSquareClick_OnWhitePiece_RepaintsBoardView() {
-        Piece[][] standardGrid = newStandardStartingGrid();
-        Location selected = new Location(0, 6);
-        Board boardMock = boardForWhitePieceClick(standardGrid, 6, 0);
-        BoardView boardViewMock = EasyMock.createMock(BoardView.class);
-        boardViewMock.repaint();
-        EasyMock.expectLastCall().once();
-        EasyMock.replay(boardViewMock);
-
-        BoardController controller = controllerWithBoardView(boardMock, boardViewMock);
-        controller.handleSquareClick(selected);
-
-        EasyMock.verify(boardMock, boardViewMock);
-    }
-    @Test
-    void HandleSquareClick_WithSelection_OnOwnPiece_RepaintsBoardViewTwice() {
-        Piece[][] standardGrid = newStandardStartingGrid();
-        Board boardMock = EasyMock.createMock(Board.class);
-        EasyMock.expect(boardMock.getCurrentGameState()).andReturn(GameState.WHITE_TURN).times(2);
-        EasyMock.expect(boardMock.getPieceAt(6, 0)).andReturn(standardGrid[6][0]);
-        EasyMock.expect(boardMock.getPieceAt(7, 1)).andReturn(standardGrid[7][1]);
-        EasyMock.replay(boardMock);
-        BoardView boardViewMock = EasyMock.createMock(BoardView.class);
-        boardViewMock.repaint();
-        EasyMock.expectLastCall().times(2);
-        EasyMock.replay(boardViewMock);
-
-        BoardController controller = controllerWithBoardView(boardMock, boardViewMock);
-        controller.handleSquareClick(new Location(0, 6));
-        controller.handleSquareClick(new Location(1, 7));
-
-        EasyMock.verify(boardMock, boardViewMock);
-    }
-    @Test
-    void HandleSquareClick_WithSelection_OnIllegalDestination_RepaintsBoardViewTwice() {
-        Piece[][] standardGrid = newStandardStartingGrid();
-        Location selected = new Location(0, 6);
-        Board boardMock = EasyMock.createMock(Board.class);
-        EasyMock.expect(boardMock.getCurrentGameState()).andReturn(GameState.WHITE_TURN).times(2);
-        EasyMock.expect(boardMock.getPieceAt(6, 0)).andReturn(standardGrid[6][0]);
-        EasyMock.expect(boardMock.getPieceAt(3, 3)).andReturn(standardGrid[3][3]);
-        EasyMock.expect(boardMock.getLegalMoves(selected)).andReturn(List.of());
-        EasyMock.replay(boardMock);
-        BoardView boardViewMock = EasyMock.createMock(BoardView.class);
-        boardViewMock.repaint();
-        EasyMock.expectLastCall().times(2);
-        EasyMock.replay(boardViewMock);
-
-        BoardController controller = controllerWithBoardView(boardMock, boardViewMock);
-        controller.handleSquareClick(selected);
-        controller.handleSquareClick(new Location(3, 3));
-
-        EasyMock.verify(boardMock, boardViewMock);
-    }
-    @Test
-    void ExecuteMove_OnLegalMove_RepaintsBoardViewTwice() {
-        Piece[][] standardGrid = newStandardStartingGrid();
-        Location selected = new Location(0, 6);
-        Location destination = new Location(0, 5);
-        Move move = new Move(selected, destination);
-        Board boardMock = EasyMock.createMock(Board.class);
-        final MainView mainViewMock = EasyMock.createMock(MainView.class);
-        final GameStatsView statsMock = EasyMock.createMock(GameStatsView.class);
-        EasyMock.expect(boardMock.getCurrentGameState()).andReturn(GameState.WHITE_TURN).times(4);
-        EasyMock.expect(boardMock.getPieceAt(6, 0)).andReturn(standardGrid[6][0]);
-        EasyMock.expect(boardMock.getPieceAt(5, 0)).andReturn(standardGrid[5][0]);
-        EasyMock.expect(boardMock.getLegalMoves(selected)).andReturn(List.of(move));
-        boardMock.makeMove(move);
-        EasyMock.expectLastCall().once();
-        EasyMock.expect(mainViewMock.getGameStatsView()).andReturn(statsMock);
-        statsMock.updateCurrentPlayerLabel(TEST_PLAYER_ONE);
-        EasyMock.expectLastCall().once();
-        EasyMock.replay(boardMock, mainViewMock, statsMock);
-        BoardView boardViewMock = EasyMock.createMock(BoardView.class);
-        boardViewMock.repaint();
-        EasyMock.expectLastCall().times(2);
-        EasyMock.replay(boardViewMock);
-
-        BoardController controller = controllerWithBoardView(boardMock, boardViewMock);
-        controller.setMainView(mainViewMock);
-        controller.handleSquareClick(selected);
-        controller.handleSquareClick(destination);
-
-        EasyMock.verify(boardMock, mainViewMock, statsMock, boardViewMock);
-    }
-    @Test
-    void HandleSquareClick_OnFileEight_IgnoresClick() {
-        Board boardMock = replayEmptyBoard();
-        BoardView boardViewMock = EasyMock.createMock(BoardView.class);
-        EasyMock.replay(boardViewMock);
-
-        BoardController controller = controllerWithBoardView(boardMock, boardViewMock);
-        controller.handleSquareClick(new Location(8, 0));
-
-        boolean expected = false;
-        boolean actual = controller.hasSelection();
-        assertEquals(expected, actual);
-        EasyMock.verify(boardMock, boardViewMock);
-    }
-    @Test
-    void HandleSquareClick_OnRankEight_IgnoresClick() {
-        Board boardMock = replayEmptyBoard();
-        BoardView boardViewMock = EasyMock.createMock(BoardView.class);
-        EasyMock.replay(boardViewMock);
-
-        BoardController controller = controllerWithBoardView(boardMock, boardViewMock);
-        controller.handleSquareClick(new Location(0, 8));
-
-        boolean expected = false;
-        boolean actual = controller.hasSelection();
-        assertEquals(expected, actual);
-        EasyMock.verify(boardMock, boardViewMock);
-    }
-    @Test
-    void HandleSquareClick_OnMaxInBoundsSquare_AcceptsClick() {
-        Piece[][] standardGrid = newStandardStartingGrid();
-        Board boardMock = boardForWhitePieceClick(standardGrid, 7, 7);
-        BoardView boardViewMock = EasyMock.createMock(BoardView.class);
-        boardViewMock.repaint();
-        EasyMock.expectLastCall().once();
-        EasyMock.replay(boardViewMock);
-
-        BoardController controller = controllerWithBoardView(boardMock, boardViewMock);
-        controller.handleSquareClick(new Location(7, 7));
-
-        boolean expected = true;
-        boolean actual = controller.hasSelection();
-        assertEquals(expected, actual);
-        EasyMock.verify(boardMock, boardViewMock);
-    }
-    @Test
-    void HandleSquareClick_WhenGameOver_IgnoresClick() {
-        Board boardMock = EasyMock.createMock(Board.class);
-        EasyMock.expect(boardMock.getCurrentGameState()).andReturn(GameState.WHITE_WIN);
-        EasyMock.replay(boardMock);
-        BoardView boardViewMock = EasyMock.createMock(BoardView.class);
-        EasyMock.replay(boardViewMock);
-
-        BoardController controller = controllerWithBoardView(boardMock, boardViewMock);
-        controller.handleSquareClick(new Location(0, 6));
-
-        boolean expected = false;
-        boolean actual = controller.hasSelection();
-        assertEquals(expected, actual);
-        EasyMock.verify(boardMock, boardViewMock);
-    }
-    @SuppressFBWarnings(
-            value = "RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT",
-            justification = "Return value not needed; called for side-effectful headless check")
-    @Test
-    void ExecuteMove_AfterMoveResultsInGameOver_EndGameViewIsVisible() {
-        assumeTrue(
-                !GraphicsEnvironment.getLocalGraphicsEnvironment().isHeadless(),
-                "Skipping: no display available");
-        Piece[][] standardGrid = newStandardStartingGrid();
-        Location selected = new Location(0, 6);
-        Location destination = new Location(0, 5);
-        Move move = new Move(selected, destination);
-        Board boardMock = EasyMock.createMock(Board.class);
-        final MainView mainViewMock = EasyMock.createMock(MainView.class);
-        final GameStatsView statsMock = EasyMock.createMock(GameStatsView.class);
-        EasyMock.expect(boardMock.getCurrentGameState()).andReturn(GameState.WHITE_TURN).times(2);
-        EasyMock.expect(boardMock.getCurrentGameState()).andReturn(GameState.WHITE_WIN).times(3);
-        EasyMock.expect(boardMock.getPieceAt(6, 0)).andReturn(standardGrid[6][0]);
-        EasyMock.expect(boardMock.getPieceAt(5, 0)).andReturn(standardGrid[5][0]);
-        EasyMock.expect(boardMock.getLegalMoves(selected)).andReturn(List.of(move));
-        boardMock.makeMove(move);
-        EasyMock.expectLastCall().once();
-        EasyMock.expect(mainViewMock.getGameStatsView()).andReturn(statsMock);
-        statsMock.updateCurrentPlayerLabel(TEST_PLAYER_ONE + " wins!");
-        EasyMock.expectLastCall().once();
-        mainViewMock.setVisible(false);
-        EasyMock.expectLastCall().once();
-        EasyMock.replay(boardMock, mainViewMock, statsMock);
-        BoardView boardViewMock = EasyMock.createMock(BoardView.class);
-        boardViewMock.repaint();
-        EasyMock.expectLastCall().anyTimes();
-        EasyMock.replay(boardViewMock);
-
-        BoardController controller = controllerWithBoardView(boardMock, boardViewMock);
-        controller.setMainView(mainViewMock);
-        controller.handleSquareClick(selected);
-        controller.handleSquareClick(destination);
-
-        boolean expected = true;
-        boolean actual = anyEndGameViewVisible();
-        assertEquals(expected, actual);
         EasyMock.verify(boardMock, mainViewMock, statsMock);
     }
     @SuppressFBWarnings(

--- a/src/test/java/ui/BoardControllerTest.java
+++ b/src/test/java/ui/BoardControllerTest.java
@@ -1581,5 +1581,26 @@ class BoardControllerTest {
 
         EasyMock.verify(boardMock, boardViewMock);
     }
+    @Test
+    void HandleSquareClick_WithSelection_OnIllegalDestination_RepaintsBoardViewTwice() {
+        Piece[][] standardGrid = newStandardStartingGrid();
+        Location selected = new Location(0, 6);
+        Board boardMock = EasyMock.createMock(Board.class);
+        EasyMock.expect(boardMock.getCurrentGameState()).andReturn(GameState.WHITE_TURN).times(2);
+        EasyMock.expect(boardMock.getPieceAt(6, 0)).andReturn(standardGrid[6][0]);
+        EasyMock.expect(boardMock.getPieceAt(3, 3)).andReturn(standardGrid[3][3]);
+        EasyMock.expect(boardMock.getLegalMoves(selected)).andReturn(List.of());
+        EasyMock.replay(boardMock);
+        BoardView boardViewMock = EasyMock.createMock(BoardView.class);
+        boardViewMock.repaint();
+        EasyMock.expectLastCall().times(2);
+        EasyMock.replay(boardViewMock);
+
+        BoardController controller = controllerWithBoardView(boardMock, boardViewMock);
+        controller.handleSquareClick(selected);
+        controller.handleSquareClick(new Location(3, 3));
+
+        EasyMock.verify(boardMock, boardViewMock);
+    }
 
 }

--- a/src/test/java/ui/BoardControllerTest.java
+++ b/src/test/java/ui/BoardControllerTest.java
@@ -1633,5 +1633,19 @@ class BoardControllerTest {
 
         EasyMock.verify(boardMock, mainViewMock, statsMock, boardViewMock);
     }
+    @Test
+    void HandleSquareClick_OnFileEight_IgnoresClick() {
+        Board boardMock = replayEmptyBoard();
+        BoardView boardViewMock = EasyMock.createMock(BoardView.class);
+        EasyMock.replay(boardViewMock);
+
+        BoardController controller = controllerWithBoardView(boardMock, boardViewMock);
+        controller.handleSquareClick(new Location(8, 0));
+
+        boolean expected = false;
+        boolean actual = controller.hasSelection();
+        assertEquals(expected, actual);
+        EasyMock.verify(boardMock, boardViewMock);
+    }
 
 }

--- a/src/test/java/ui/BoardControllerTest.java
+++ b/src/test/java/ui/BoardControllerTest.java
@@ -1533,5 +1533,19 @@ class BoardControllerTest {
         assertEquals(expected, actual);
         EasyMock.verify(boardMock, boardViewMock);
     }
+    @Test
+    void GetLegalMovesForSelection_NoSelection_ReturnsMutableEmptyList() {
+        Board boardMock = replayEmptyBoard();
+        BoardController controller = newController(boardMock);
+
+        List<Move> moves = controller.getLegalMovesForSelection();
+        int sizeBefore = moves.size();
+        moves.add(new Move(new Location(0, 0), new Location(0, 1)));
+
+        int expected = sizeBefore + 1;
+        int actual = moves.size();
+        assertEquals(expected, actual);
+        EasyMock.verify(boardMock);
+    }
 
 }

--- a/src/test/java/ui/BoardControllerTest.java
+++ b/src/test/java/ui/BoardControllerTest.java
@@ -1695,5 +1695,45 @@ class BoardControllerTest {
         assertEquals(expected, actual);
         EasyMock.verify(boardMock, boardViewMock);
     }
+    @Test
+    void ExecuteMove_AfterMoveResultsInGameOver_EndGameViewIsVisible() {
+        assumeTrue(
+                !GraphicsEnvironment.getLocalGraphicsEnvironment().isHeadless(),
+                "Skipping: no display available");
+        Piece[][] standardGrid = newStandardStartingGrid();
+        Location selected = new Location(0, 6);
+        Location destination = new Location(0, 5);
+        Move move = new Move(selected, destination);
+        Board boardMock = EasyMock.createMock(Board.class);
+        final MainView mainViewMock = EasyMock.createMock(MainView.class);
+        final GameStatsView statsMock = EasyMock.createMock(GameStatsView.class);
+        EasyMock.expect(boardMock.getCurrentGameState()).andReturn(GameState.WHITE_TURN).times(2);
+        EasyMock.expect(boardMock.getCurrentGameState()).andReturn(GameState.WHITE_WIN).times(3);
+        EasyMock.expect(boardMock.getPieceAt(6, 0)).andReturn(standardGrid[6][0]);
+        EasyMock.expect(boardMock.getPieceAt(5, 0)).andReturn(standardGrid[5][0]);
+        EasyMock.expect(boardMock.getLegalMoves(selected)).andReturn(List.of(move));
+        boardMock.makeMove(move);
+        EasyMock.expectLastCall().once();
+        EasyMock.expect(mainViewMock.getGameStatsView()).andReturn(statsMock);
+        statsMock.updateCurrentPlayerLabel(TEST_PLAYER_ONE + " wins!");
+        EasyMock.expectLastCall().once();
+        mainViewMock.setVisible(false);
+        EasyMock.expectLastCall().once();
+        EasyMock.replay(boardMock, mainViewMock, statsMock);
+        BoardView boardViewMock = EasyMock.createMock(BoardView.class);
+        boardViewMock.repaint();
+        EasyMock.expectLastCall().anyTimes();
+        EasyMock.replay(boardViewMock);
+
+        BoardController controller = controllerWithBoardView(boardMock, boardViewMock);
+        controller.setMainView(mainViewMock);
+        controller.handleSquareClick(selected);
+        controller.handleSquareClick(destination);
+
+        boolean expected = true;
+        boolean actual = anyEndGameViewVisible();
+        assertEquals(expected, actual);
+        EasyMock.verify(boardMock, mainViewMock, statsMock);
+    }
 
 }

--- a/src/test/java/ui/BoardControllerTest.java
+++ b/src/test/java/ui/BoardControllerTest.java
@@ -1547,5 +1547,20 @@ class BoardControllerTest {
         assertEquals(expected, actual);
         EasyMock.verify(boardMock);
     }
+    @Test
+    void HandleSquareClick_OnWhitePiece_RepaintsBoardView() {
+        Piece[][] standardGrid = newStandardStartingGrid();
+        Location selected = new Location(0, 6);
+        Board boardMock = boardForWhitePieceClick(standardGrid, 6, 0);
+        BoardView boardViewMock = EasyMock.createMock(BoardView.class);
+        boardViewMock.repaint();
+        EasyMock.expectLastCall().once();
+        EasyMock.replay(boardViewMock);
+
+        BoardController controller = controllerWithBoardView(boardMock, boardViewMock);
+        controller.handleSquareClick(selected);
+
+        EasyMock.verify(boardMock, boardViewMock);
+    }
 
 }

--- a/src/test/java/ui/BoardControllerTest.java
+++ b/src/test/java/ui/BoardControllerTest.java
@@ -1602,5 +1602,36 @@ class BoardControllerTest {
 
         EasyMock.verify(boardMock, boardViewMock);
     }
+    @Test
+    void ExecuteMove_OnLegalMove_RepaintsBoardViewTwice() {
+        Piece[][] standardGrid = newStandardStartingGrid();
+        Location selected = new Location(0, 6);
+        Location destination = new Location(0, 5);
+        Move move = new Move(selected, destination);
+        Board boardMock = EasyMock.createMock(Board.class);
+        final MainView mainViewMock = EasyMock.createMock(MainView.class);
+        final GameStatsView statsMock = EasyMock.createMock(GameStatsView.class);
+        EasyMock.expect(boardMock.getCurrentGameState()).andReturn(GameState.WHITE_TURN).times(4);
+        EasyMock.expect(boardMock.getPieceAt(6, 0)).andReturn(standardGrid[6][0]);
+        EasyMock.expect(boardMock.getPieceAt(5, 0)).andReturn(standardGrid[5][0]);
+        EasyMock.expect(boardMock.getLegalMoves(selected)).andReturn(List.of(move));
+        boardMock.makeMove(move);
+        EasyMock.expectLastCall().once();
+        EasyMock.expect(mainViewMock.getGameStatsView()).andReturn(statsMock);
+        statsMock.updateCurrentPlayerLabel(TEST_PLAYER_ONE);
+        EasyMock.expectLastCall().once();
+        EasyMock.replay(boardMock, mainViewMock, statsMock);
+        BoardView boardViewMock = EasyMock.createMock(BoardView.class);
+        boardViewMock.repaint();
+        EasyMock.expectLastCall().times(2);
+        EasyMock.replay(boardViewMock);
+
+        BoardController controller = controllerWithBoardView(boardMock, boardViewMock);
+        controller.setMainView(mainViewMock);
+        controller.handleSquareClick(selected);
+        controller.handleSquareClick(destination);
+
+        EasyMock.verify(boardMock, mainViewMock, statsMock, boardViewMock);
+    }
 
 }

--- a/src/test/java/ui/BoardControllerTest.java
+++ b/src/test/java/ui/BoardControllerTest.java
@@ -1678,5 +1678,22 @@ class BoardControllerTest {
         assertEquals(expected, actual);
         EasyMock.verify(boardMock, boardViewMock);
     }
+    @Test
+    void HandleSquareClick_WhenGameOver_IgnoresClick() {
+        Piece[][] standardGrid = newStandardStartingGrid();
+        Board boardMock = EasyMock.createMock(Board.class);
+        EasyMock.expect(boardMock.getCurrentGameState()).andReturn(GameState.WHITE_WIN);
+        EasyMock.replay(boardMock);
+        BoardView boardViewMock = EasyMock.createMock(BoardView.class);
+        EasyMock.replay(boardViewMock);
+
+        BoardController controller = controllerWithBoardView(boardMock, boardViewMock);
+        controller.handleSquareClick(new Location(0, 6));
+
+        boolean expected = false;
+        boolean actual = controller.hasSelection();
+        assertEquals(expected, actual);
+        EasyMock.verify(boardMock, boardViewMock);
+    }
 
 }

--- a/src/test/java/ui/BoardControllerTest.java
+++ b/src/test/java/ui/BoardControllerTest.java
@@ -69,17 +69,6 @@ class BoardControllerTest {
     }
 
     @Test
-    void GetMainView_BeforeShow_ReturnsNull() {
-        Board boardMock = replayEmptyBoard();
-        BoardController controller = newController(boardMock);
-
-        MainView expected = null;
-        MainView actual = controller.getMainView();
-        assertEquals(expected, actual);
-        EasyMock.verify(boardMock);
-    }
-
-    @Test
     void GetMainView_AfterSetMainView_ReturnsInjectedView() {
         Board boardMock = replayEmptyBoard();
         MainView mainViewMock = EasyMock.createMock(MainView.class);

--- a/src/test/java/ui/BoardControllerTest.java
+++ b/src/test/java/ui/BoardControllerTest.java
@@ -1661,5 +1661,22 @@ class BoardControllerTest {
         assertEquals(expected, actual);
         EasyMock.verify(boardMock, boardViewMock);
     }
+    @Test
+    void HandleSquareClick_OnMaxInBoundsSquare_AcceptsClick() {
+        Piece[][] standardGrid = newStandardStartingGrid();
+        Board boardMock = boardForWhitePieceClick(standardGrid, 7, 7);
+        BoardView boardViewMock = EasyMock.createMock(BoardView.class);
+        boardViewMock.repaint();
+        EasyMock.expectLastCall().once();
+        EasyMock.replay(boardViewMock);
+
+        BoardController controller = controllerWithBoardView(boardMock, boardViewMock);
+        controller.handleSquareClick(new Location(7, 7));
+
+        boolean expected = true;
+        boolean actual = controller.hasSelection();
+        assertEquals(expected, actual);
+        EasyMock.verify(boardMock, boardViewMock);
+    }
 
 }

--- a/src/test/java/ui/BoardControllerTest.java
+++ b/src/test/java/ui/BoardControllerTest.java
@@ -1647,5 +1647,19 @@ class BoardControllerTest {
         assertEquals(expected, actual);
         EasyMock.verify(boardMock, boardViewMock);
     }
+    @Test
+    void HandleSquareClick_OnRankEight_IgnoresClick() {
+        Board boardMock = replayEmptyBoard();
+        BoardView boardViewMock = EasyMock.createMock(BoardView.class);
+        EasyMock.replay(boardViewMock);
+
+        BoardController controller = controllerWithBoardView(boardMock, boardViewMock);
+        controller.handleSquareClick(new Location(0, 8));
+
+        boolean expected = false;
+        boolean actual = controller.hasSelection();
+        assertEquals(expected, actual);
+        EasyMock.verify(boardMock, boardViewMock);
+    }
 
 }

--- a/src/test/java/ui/BoardControllerTest.java
+++ b/src/test/java/ui/BoardControllerTest.java
@@ -1562,5 +1562,24 @@ class BoardControllerTest {
 
         EasyMock.verify(boardMock, boardViewMock);
     }
+    @Test
+    void HandleSquareClick_WithSelection_OnOwnPiece_RepaintsBoardViewTwice() {
+        Piece[][] standardGrid = newStandardStartingGrid();
+        Board boardMock = EasyMock.createMock(Board.class);
+        EasyMock.expect(boardMock.getCurrentGameState()).andReturn(GameState.WHITE_TURN).times(2);
+        EasyMock.expect(boardMock.getPieceAt(6, 0)).andReturn(standardGrid[6][0]);
+        EasyMock.expect(boardMock.getPieceAt(7, 1)).andReturn(standardGrid[7][1]);
+        EasyMock.replay(boardMock);
+        BoardView boardViewMock = EasyMock.createMock(BoardView.class);
+        boardViewMock.repaint();
+        EasyMock.expectLastCall().times(2);
+        EasyMock.replay(boardViewMock);
+
+        BoardController controller = controllerWithBoardView(boardMock, boardViewMock);
+        controller.handleSquareClick(new Location(0, 6));
+        controller.handleSquareClick(new Location(1, 7));
+
+        EasyMock.verify(boardMock, boardViewMock);
+    }
 
 }


### PR DESCRIPTION
## Description

Adds BVA and unit tests for `BoardController` to close PIT line/mutation gaps. No production code changes — test-only coverage improvements using EasyMock strict `verify` on `BoardView.repaint()` and headless-gated Swing tests where needed.

## Type of Change

- [ ] Feature (new functionality)
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactor
- [x] Test addition/update

## Related Work

Related to `docs/bva/BoardController.md` (BC-TC74–BC-TC87)

## Changes Made

- [x] Updated BVA with BC-TC74–BC-TC87 for coverage and surviving mutants
- [x] Added 14 new tests in `BoardControllerTest` (83 tests total for this class)
- [x] Added test helpers: `newController`, `controllerWithBoardView`, `anyEndGameViewVisible`, `@AfterEach` window cleanup
- [x] Fixed SpotBugs warnings (`RV_RETURN_VALUE_IGNORED`, dead store) in new tests

## BVA & Testing

- BVA documented in: `docs/bva/BoardController.md`
- Test cases implemented: **BC-TC74–BC-TC87** (14 new TCs; all marked ✅)
- Coverage results (`BoardController`):
  - **Line:** 92% (98/107)
  - **Mutation:** 90% (52/58)
  - **Test strength:** 96% (52/54)
- All tests passing: [x] `./gradlew check pitest`

### New test cases

| TC | Test method | Focus |
|----|-------------|-------|
| BC-TC74 | `GetMainView_BeforeShow_ReturnsNull` | Getter before `show()` |
| BC-TC86 | `GetMainView_AfterSetMainView_ReturnsInjectedView` | Getter after injection |
| BC-TC75 | `GetBoardView_AfterSetBoardView_ReturnsInjectedView` | BoardView getter |
| BC-TC76 | `GetLegalMovesForSelection_NoSelection_ReturnsMutableEmptyList` | `ArrayList` vs `Collections.emptyList` mutant |
| BC-TC77 | `HandleSquareClick_OnWhitePiece_RepaintsBoardView` | `repaint()` on source click |
| BC-TC78 | `HandleSquareClick_WithSelection_OnOwnPiece_RepaintsBoardViewTwice` | `repaint()` on reselect |
| BC-TC79 | `HandleSquareClick_WithSelection_OnIllegalDestination_RepaintsBoardViewTwice` | `repaint()` on illegal dest |
| BC-TC80 | `ExecuteMove_OnLegalMove_RepaintsBoardViewTwice` | `repaint()` on legal move |
| BC-TC81 | `HandleSquareClick_OnFileEight_IgnoresClick` | `isInBounds` file boundary |
| BC-TC87 | `HandleSquareClick_OnRankEight_IgnoresClick` | `isInBounds` rank boundary |
| BC-TC82 | `HandleSquareClick_OnMaxInBoundsSquare_AcceptsClick` | Max in-bounds square |
| BC-TC83 | `HandleSquareClick_WhenGameOver_IgnoresClick` | No clicks after game over |
| BC-TC84 | `ExecuteMove_AfterMoveResultsInGameOver_EndGameViewIsVisible` | End-game UI (headed) |
| BC-TC85 | `Show_WhenCalled_MainViewBecomesVisible` | `show()` (headed) |

### Remaining mutants (expected, headless / Swing)

- `show()` → `setVisible` / `updateCurrentPlayerLabel` — NO_COVERAGE (headless skip)
- `promptForPromotionPiece` default path — NO_COVERAGE (real `PromotionView`)
- `showEndGame` / `EndGameController.show` — NO_COVERAGE or PIT quirk with void calls
- 1× `isInBounds` boundary — likely equivalent mutant

## Design Alignment

- [x] Changes align with `docs/design/chess-full-design.puml`
- [x] No breaking changes to existing methods
- [x] New methods follow the established patterns (N/A — no new production methods)

## Implementation Notes

- Repaint mutants survived previously because `controllerFor()` stubbed `boardView.repaint()` with `anyTimes()`. New tests use `controllerWithBoardView()` with strict `times(n)` expectations.
- `GetLegalMovesForSelection_NoSelection_ReturnsMutableEmptyList` mutates the returned list to kill the `Collections.emptyList` replacement mutant.
- Headless-gated tests (`assumeTrue` + `@SuppressFBWarnings`) follow the same pattern as `WelcomeViewTest` / `PromotionViewTest`.
- 16 commits: 1 BVA + 14 per-test + 1 SpotBugs fix.

## Checklist

- [x] BVA analysis is documented
- [x] TDD workflow followed (tests before code)
- [x] Code compiles and all tests pass
- [x] No new compiler warnings
- [ ] Documentation updated (if applicable) — BVA only
- [x] Commit messages are clear and follow TDD workflow