### PR TITLE
[CHORE] Remove duplicate easyMock dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,7 +45,6 @@ dependencies {
     testImplementation(platform("org.junit:junit-bom:5.10.0"))
     testImplementation("org.easymock:easymock:5.6.0")
     testImplementation("org.junit.jupiter:junit-jupiter")
-    testImplementation("org.easymock:easymock:5.4.0")
     testImplementation(platform("io.cucumber:cucumber-bom:7.20.1"))
     testImplementation("io.cucumber:cucumber-java")
     testImplementation("io.cucumber:cucumber-junit-platform-engine")


### PR DESCRIPTION
Easymock imported twice, resolved to higher version. Delete old version.